### PR TITLE
refactor: unify DSN normalization and masking in DatabaseUrl type

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -11,7 +11,8 @@ use std::time::Duration;
 use tokio::runtime::Handle;
 use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
-use url::Url;
+
+use crate::database_url::DatabaseUrl;
 
 use tracing::{debug, error, trace, warn};
 
@@ -274,7 +275,7 @@ impl DiscardStrategy {
 #[derive(Debug)]
 pub struct AppContext {
     pub cwd: std::path::PathBuf,
-    pub dsn: Url,
+    pub dsn: DatabaseUrl,
     pub db: Option<Arc<DatabaseConnection>>, // Use shared connection for SQLite
     pub connect_options: ConnectOptions,     // For creating new connections
     pub name: String, // Application name for NOTIFY channel (default: "quebec")
@@ -327,7 +328,7 @@ pub(crate) fn parse_duration_f64_env(s: &str) -> Option<Duration> {
 impl AppContext {
     #[cfg(feature = "python")]
     pub fn new(
-        dsn: Url,
+        dsn: DatabaseUrl,
         db: Option<Arc<DatabaseConnection>>,
         connect_options: ConnectOptions,
         options: Option<HashMap<String, Py<PyAny>>>,
@@ -523,7 +524,7 @@ impl AppContext {
 
     #[cfg(not(feature = "python"))]
     pub fn new(
-        dsn: Url,
+        dsn: DatabaseUrl,
         db: Option<Arc<DatabaseConnection>>,
         connect_options: ConnectOptions,
     ) -> Self {
@@ -533,7 +534,7 @@ impl AppContext {
     }
 
     fn new_inner(
-        dsn: Url,
+        dsn: DatabaseUrl,
         db: Option<Arc<DatabaseConnection>>,
         connect_options: ConnectOptions,
     ) -> Self {
@@ -614,7 +615,7 @@ impl AppContext {
 
     /// Check if the database is PostgreSQL
     pub fn is_postgres(&self) -> bool {
-        self.dsn.scheme().starts_with("postgres")
+        self.dsn.is_postgres()
     }
 
     /// Get a runnable by class name

--- a/src/control_plane/utils.rs
+++ b/src/control_plane/utils.rs
@@ -322,30 +322,11 @@ impl ControlPlane {
             .await
             .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
-        let dsn = self.ctx.dsn.to_string();
-        let (db_type, connection_info) = if let Ok(mut parsed) = Url::parse(&dsn) {
-            let db_type = match parsed.scheme() {
-                s if s.starts_with("postgres") => "PostgreSQL",
-                s if s.starts_with("mysql") => "MySQL",
-                s if s.starts_with("sqlite") => "SQLite",
-                _ => "Unknown",
-            };
-            if parsed.password().is_some() {
-                let _ = parsed.set_password(Some("***"));
-            }
-            parsed.set_query(None);
-            parsed.set_fragment(None);
-            let display = parsed.to_string();
-            (db_type, display)
-        } else {
-            ("Unknown", "<invalid url>".to_string())
-        };
-
         let db_info = serde_json::json!({
-            "database_type": db_type,
+            "database_type": self.ctx.dsn.kind().as_str(),
             "connection_type": "Pool",
             "status": "Connected",
-            "dsn": connection_info
+            "dsn": self.ctx.dsn.masked(),
         });
         context.insert("db_info", &db_info);
         context.insert("version", env!("CARGO_PKG_VERSION"));

--- a/src/database_url.rs
+++ b/src/database_url.rs
@@ -1,0 +1,224 @@
+use std::fmt;
+
+use url::Url;
+
+use crate::error::{QuebecError, Result};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DatabaseKind {
+    Postgres,
+    Mysql,
+    Sqlite,
+    Unknown,
+}
+
+impl DatabaseKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            DatabaseKind::Postgres => "PostgreSQL",
+            DatabaseKind::Mysql => "MySQL",
+            DatabaseKind::Sqlite => "SQLite",
+            DatabaseKind::Unknown => "Unknown",
+        }
+    }
+}
+
+/// Database connection URL with SQLAlchemy-compatible normalization.
+///
+/// `Display` yields a masked form (password redacted, query/fragment stripped)
+/// safe to log or show in the control plane.
+#[derive(Debug, Clone)]
+pub struct DatabaseUrl {
+    raw: String,
+    parsed: Url,
+    kind: DatabaseKind,
+}
+
+impl DatabaseUrl {
+    pub fn parse(input: &str) -> Result<Self> {
+        let normalized = normalize(input);
+        let parsed = Url::parse(&normalized)?;
+        let kind = match parsed.scheme() {
+            s if s.starts_with("postgres") => DatabaseKind::Postgres,
+            s if s.starts_with("mysql") => DatabaseKind::Mysql,
+            s if s.starts_with("sqlite") => DatabaseKind::Sqlite,
+            _ => DatabaseKind::Unknown,
+        };
+        Ok(Self {
+            raw: normalized,
+            parsed,
+            kind,
+        })
+    }
+
+    /// Connection string in the form sqlx / SeaORM accept.
+    pub fn as_connect_str(&self) -> &str {
+        &self.raw
+    }
+
+    pub fn url(&self) -> &Url {
+        &self.parsed
+    }
+
+    pub fn kind(&self) -> DatabaseKind {
+        self.kind
+    }
+
+    pub fn is_postgres(&self) -> bool {
+        matches!(self.kind, DatabaseKind::Postgres)
+    }
+
+    pub fn is_sqlite(&self) -> bool {
+        matches!(self.kind, DatabaseKind::Sqlite)
+    }
+
+    pub fn is_mysql(&self) -> bool {
+        matches!(self.kind, DatabaseKind::Mysql)
+    }
+
+    /// Password redacted, query/fragment stripped.
+    pub fn masked(&self) -> String {
+        let mut u = self.parsed.clone();
+        if u.password().is_some() {
+            let _ = u.set_password(Some("***"));
+        }
+        u.set_query(None);
+        u.set_fragment(None);
+        u.to_string()
+    }
+}
+
+impl fmt::Display for DatabaseUrl {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.masked())
+    }
+}
+
+impl std::str::FromStr for DatabaseUrl {
+    type Err = QuebecError;
+
+    fn from_str(s: &str) -> Result<Self> {
+        Self::parse(s)
+    }
+}
+
+fn normalize(input: &str) -> String {
+    let stripped = strip_driver_suffix(input);
+    normalize_sqlite(&stripped)
+}
+
+/// `postgresql+psycopg://...` → `postgresql://...`
+fn strip_driver_suffix(url: &str) -> String {
+    let Some(scheme_end) = url.find("://") else {
+        return url.to_string();
+    };
+    let scheme = &url[..scheme_end];
+    let Some(plus) = scheme.find('+') else {
+        return url.to_string();
+    };
+    format!("{}{}", &scheme[..plus], &url[scheme_end..])
+}
+
+/// Handle unambiguous SQLAlchemy sqlite quirks:
+///   - `sqlite:///:memory:`   → `sqlite::memory:`
+///   - `sqlite:////abs/path`  → `sqlite:///abs/path`
+/// The 3-slash `sqlite:///relative.db` form is ambiguous (SQLAlchemy: relative,
+/// sqlx: absolute) and is left untouched — sqlx semantics win.
+fn normalize_sqlite(url: &str) -> String {
+    let Some(rest) = url.strip_prefix("sqlite://") else {
+        return url.to_string();
+    };
+    if rest == "/:memory:" {
+        return "sqlite::memory:".to_string();
+    }
+    if let Some(abs) = rest.strip_prefix("//") {
+        return format!("sqlite:///{}", abs);
+    }
+    url.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_sqlalchemy_driver_suffix() {
+        assert_eq!(
+            DatabaseUrl::parse("postgresql+psycopg://u:p@h/db")
+                .unwrap()
+                .as_connect_str(),
+            "postgresql://u:p@h/db"
+        );
+        assert_eq!(
+            DatabaseUrl::parse("postgresql+asyncpg://h/db")
+                .unwrap()
+                .as_connect_str(),
+            "postgresql://h/db"
+        );
+        assert_eq!(
+            DatabaseUrl::parse("mysql+pymysql://u@h/db")
+                .unwrap()
+                .as_connect_str(),
+            "mysql://u@h/db"
+        );
+        assert_eq!(
+            DatabaseUrl::parse("sqlite+aiosqlite:///tmp/x.db")
+                .unwrap()
+                .as_connect_str(),
+            "sqlite:///tmp/x.db"
+        );
+    }
+
+    #[test]
+    fn normalizes_sqlite_memory() {
+        assert_eq!(
+            DatabaseUrl::parse("sqlite:///:memory:")
+                .unwrap()
+                .as_connect_str(),
+            "sqlite::memory:"
+        );
+    }
+
+    #[test]
+    fn normalizes_sqlite_four_slash_abs() {
+        assert_eq!(
+            DatabaseUrl::parse("sqlite:////var/lib/q.db")
+                .unwrap()
+                .as_connect_str(),
+            "sqlite:///var/lib/q.db"
+        );
+    }
+
+    #[test]
+    fn leaves_non_sqlalchemy_urls_alone() {
+        assert_eq!(
+            DatabaseUrl::parse("postgres://u:p@h/db")
+                .unwrap()
+                .as_connect_str(),
+            "postgres://u:p@h/db"
+        );
+        assert_eq!(
+            DatabaseUrl::parse("sqlite:///var/x.db")
+                .unwrap()
+                .as_connect_str(),
+            "sqlite:///var/x.db"
+        );
+    }
+
+    #[test]
+    fn detects_kind() {
+        assert!(DatabaseUrl::parse("postgres://h/d").unwrap().is_postgres());
+        assert!(DatabaseUrl::parse("postgresql://h/d")
+            .unwrap()
+            .is_postgres());
+        assert!(DatabaseUrl::parse("mysql://h/d").unwrap().is_mysql());
+        assert!(DatabaseUrl::parse("sqlite::memory:").unwrap().is_sqlite());
+    }
+
+    #[test]
+    fn masked_strips_password_and_query() {
+        let url = DatabaseUrl::parse("postgres://alice:secret@h:5432/db?sslmode=require").unwrap();
+        assert_eq!(url.masked(), "postgres://alice:***@h:5432/db");
+        assert_eq!(url.to_string(), "postgres://alice:***@h:5432/db");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod continuation;
 mod control_plane;
 #[cfg(feature = "python")]
 mod core;
+pub mod database_url;
 mod dispatcher;
 pub mod entities;
 mod error;

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -37,7 +37,7 @@ impl NotifyManager {
 
         let (tx, rx) = mpsc::channel::<String>(200);
         let channel = self.channel_name.clone();
-        let dsn = self.ctx.dsn.to_string();
+        let dsn = self.ctx.dsn.as_connect_str().to_string();
         let graceful_shutdown = self.ctx.graceful_shutdown.clone();
 
         // Spawn a background task to handle LISTEN using sqlx
@@ -200,10 +200,10 @@ impl NotifyManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use url::Url;
+    use crate::database_url::DatabaseUrl;
 
     /// Helper to create AppContext for tests (handles cfg-gated signature)
-    fn make_ctx(dsn: Url) -> Arc<AppContext> {
+    fn make_ctx(dsn: DatabaseUrl) -> Arc<AppContext> {
         #[cfg(feature = "python")]
         {
             Arc::new(AppContext::new(
@@ -225,7 +225,8 @@ mod tests {
 
     #[test]
     fn test_channel_name_generation() {
-        let dsn = Url::parse("postgres://user:pass@localhost/test").expect("Valid test URL");
+        let dsn =
+            DatabaseUrl::parse("postgres://user:pass@localhost/test").expect("Valid test URL");
         let ctx = make_ctx(dsn);
         let manager = NotifyManager::new(ctx);
         assert_eq!(manager.get_channel_name(), "quebec_jobs");
@@ -233,12 +234,12 @@ mod tests {
 
     #[test]
     fn test_is_postgres_detection() {
-        let postgres_dsn =
-            Url::parse("postgres://user:pass@localhost/test").expect("Valid postgres test URL");
+        let postgres_dsn = DatabaseUrl::parse("postgres://user:pass@localhost/test")
+            .expect("Valid postgres test URL");
         let postgres_ctx = make_ctx(postgres_dsn);
         assert!(postgres_ctx.is_postgres());
 
-        let sqlite_dsn = Url::parse("sqlite://test.db").expect("Valid sqlite test URL");
+        let sqlite_dsn = DatabaseUrl::parse("sqlite://test.db").expect("Valid sqlite test URL");
         let sqlite_ctx = make_ctx(sqlite_dsn);
         assert!(!sqlite_ctx.is_postgres());
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -16,8 +16,6 @@ use std::time::Instant;
 use tokio::task::JoinHandle;
 use tokio::time::Duration;
 
-use url::Url;
-
 /// Extract a value from kwargs, falling back to an environment variable, then to a default.
 /// Priority: kwargs > env var > default
 fn extract_kwarg_or_env<T>(
@@ -265,16 +263,10 @@ impl PyQuebec {
     #[pyo3(signature = (url, **kwargs))]
     #[new]
     fn new(url: String, kwargs: Option<&Bound<'_, PyDict>>) -> PyResult<Self> {
-        let redacted = Url::parse(&url)
-            .ok()
-            .map(|mut u| {
-                if u.password().is_some() {
-                    let _ = u.set_password(Some("***"));
-                }
-                u.to_string()
-            })
-            .unwrap_or_else(|| "<invalid url>".to_string());
-        info!("PyQuebec<{}>", redacted);
+        let dsn = crate::database_url::DatabaseUrl::parse(&url).map_err(|e| {
+            PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Invalid database URL: {}", e))
+        })?;
+        info!("PyQuebec<{}>", dsn);
 
         let rt = Arc::new(
             tokio::runtime::Builder::new_multi_thread()
@@ -289,11 +281,8 @@ impl PyQuebec {
                 })?,
         );
 
-        let dsn = Url::parse(&url).map_err(|e| {
-            PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Invalid database URL: {}", e))
-        })?;
-        let mut opt: ConnectOptions = ConnectOptions::new(url.to_string());
-        let is_sqlite = url.contains("sqlite");
+        let mut opt: ConnectOptions = ConnectOptions::new(dsn.as_connect_str().to_string());
+        let is_sqlite = dsn.is_sqlite();
         let min_conns: u32 = extract_kwarg_or_env(
             kwargs,
             "db_min_connections",


### PR DESCRIPTION
## Summary

- Introduce `src/database_url.rs` with a `DatabaseUrl` type that unifies DSN handling: parsing, normalization (strip SQLAlchemy `+driver` suffix, collapse sqlite `/:memory:`), and masked `Display` (hides password, strips query/fragment)
- `AppContext::dsn` switches from `url::Url` to `DatabaseUrl`; `types.rs`, `notify.rs`, and `control_plane/utils.rs` now use `as_connect_str()` / `masked()` / `kind()`
- Remove `src/utils.rs::normalize_dsn()` as well as the unused `src/bin/quebec-worker.rs` and `.cargo/config.toml`
- Six unit tests cover SQLAlchemy-style URLs and masked output

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features`
- [x] `cargo check --all-targets`
- [x] `cargo check --no-default-features`
- [ ] Boot the control plane once each against PostgreSQL / SQLite / MySQL DSNs and confirm the displayed `dsn` is masked
- [ ] SQLAlchemy sqlite relative-path ambiguity (`sqlite+aiosqlite:///rel.db`) is not handled yet; follow up separately