### PR TITLE
fix(control-plane): navigate top frame for POST actions under Turbo Drive

### DIFF
--- a/src/control_plane/templates/blocked-jobs.html
+++ b/src/control_plane/templates/blocked-jobs.html
@@ -46,7 +46,7 @@
   {% set filter_qs = "" %}
   {% if filter_args %}{% set filter_qs = "?" ~ filter_args %}{% endif %}
 
-  <form action="{{ base_path }}/blocked-jobs/all/unblock{{ filter_qs }}" method="post">
+  <form action="{{ base_path }}/blocked-jobs/all/unblock{{ filter_qs }}" method="post" data-turbo-frame="_top">
     <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-gray-900 text-gray-50 hover:bg-gray-900/90 h-8 px-4 py-1.5">
       {% if filter_class_name or filter_queue_name %}Unblock filtered{% else %}Unblock all{% endif %}
     </button>
@@ -96,12 +96,12 @@
             <div class="text-sm text-gray-900">{{ job.waiting_time }}</div>
           </td>
           <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-            <form action="{{ base_path }}/blocked-jobs/{{ job.id }}/unblock" method="post" class="inline">
+            <form action="{{ base_path }}/blocked-jobs/{{ job.id }}/unblock" method="post" class="inline" data-turbo-frame="_top">
               <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-3 py-1 mr-2">
                 Unblock
               </button>
             </form>
-            <form action="{{ base_path }}/blocked-jobs/{{ job.id }}/cancel" method="post" class="inline">
+            <form action="{{ base_path }}/blocked-jobs/{{ job.id }}/cancel" method="post" class="inline" data-turbo-frame="_top">
               <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-3 py-1">
                 Cancel
               </button>

--- a/src/control_plane/templates/failed-jobs.html
+++ b/src/control_plane/templates/failed-jobs.html
@@ -46,13 +46,13 @@
     {% set filter_qs = "" %}
     {% if filter_args %}{% set filter_qs = "?" ~ filter_args %}{% endif %}
 
-    <form action="{{ base_path }}/failed-jobs/all/delete{{ filter_qs }}" method="post" data-turbo-confirm="{% if filter_class_name or filter_queue_name %}Discard all filtered failed jobs?{% else %}Discard all failed jobs?{% endif %}">
+    <form action="{{ base_path }}/failed-jobs/all/delete{{ filter_qs }}" method="post" data-turbo-frame="_top" data-turbo-confirm="{% if filter_class_name or filter_queue_name %}Discard all filtered failed jobs?{% else %}Discard all failed jobs?{% endif %}">
       <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-gray-900 text-gray-50 hover:bg-gray-900/90 h-8 px-4 py-1.5 mr-2">
         {% if filter_class_name or filter_queue_name %}Discard filtered{% else %}Discard all{% endif %}
       </button>
     </form>
 
-    <form action="{{ base_path }}/failed-jobs/all/retry{{ filter_qs }}" method="post">
+    <form action="{{ base_path }}/failed-jobs/all/retry{{ filter_qs }}" method="post" data-turbo-frame="_top">
       <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-gray-900 text-gray-50 hover:bg-gray-900/90 h-8 px-4 py-1.5">
         {% if filter_class_name or filter_queue_name %}Retry filtered{% else %}Retry all{% endif %}
       </button>
@@ -96,12 +96,12 @@
             <div class="text-xs text-gray-400"><span data-controller="localtime" data-localtime-datetime-value="{{ job.failed_at }}">{{ job.failed_at }}</span></div>
           </td>
           <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-            <form action="{{ base_path }}/failed-jobs/{{ job.id }}/delete" method="post" class="inline">
+            <form action="{{ base_path }}/failed-jobs/{{ job.id }}/delete" method="post" class="inline" data-turbo-frame="_top">
               <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-3 py-1 mr-2">
                 Discard
               </button>
             </form>
-            <form action="{{ base_path }}/failed-jobs/{{ job.id }}/retry" method="post" class="inline">
+            <form action="{{ base_path }}/failed-jobs/{{ job.id }}/retry" method="post" class="inline" data-turbo-frame="_top">
               <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-3 py-1">
                 Retry
               </button>

--- a/src/control_plane/templates/job-details.html
+++ b/src/control_plane/templates/job-details.html
@@ -31,24 +31,24 @@
     </div>
     <div class="flex mt-4 md:mt-0 space-x-3">
       {% if job.status == 'failed' %}
-        <form action="{{ base_path }}/failed-jobs/{{ job.id }}/delete" method="post">
+        <form action="{{ base_path }}/failed-jobs/{{ job.id }}/delete" method="post" data-turbo-frame="_top">
           <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-4 py-1.5">
             Discard
           </button>
         </form>
-        <form action="{{ base_path }}/failed-jobs/{{ job.id }}/retry" method="post">
+        <form action="{{ base_path }}/failed-jobs/{{ job.id }}/retry" method="post" data-turbo-frame="_top">
           <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-gray-900 text-gray-50 hover:bg-gray-900/90 h-8 px-4 py-1.5">
             Retry
           </button>
         </form>
       {% elif job.status == 'scheduled' %}
-        <form action="{{ base_path }}/scheduled-jobs/{{ job.execution_id }}/cancel" method="post">
+        <form action="{{ base_path }}/scheduled-jobs/{{ job.execution_id }}/cancel" method="post" data-turbo-frame="_top">
           <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-4 py-1.5">
             Cancel
           </button>
         </form>
       {% elif job.status == 'blocked' %}
-        <form action="{{ base_path }}/blocked-jobs/{{ job.execution_id }}/unblock" method="post">
+        <form action="{{ base_path }}/blocked-jobs/{{ job.execution_id }}/unblock" method="post" data-turbo-frame="_top">
           <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-gray-900 text-gray-50 hover:bg-gray-900/90 h-8 px-4 py-1.5">
             Unblock
           </button>

--- a/src/control_plane/templates/queue-details.html
+++ b/src/control_plane/templates/queue-details.html
@@ -12,13 +12,13 @@
     </div>
     <div class="flex gap-2">
       {% if queue_status == 'active' %}
-        <form action="{{ base_path }}/queues/{{ queue_name }}/pause" method="post">
+        <form action="{{ base_path }}/queues/{{ queue_name }}/pause" method="post" data-turbo-frame="_top">
           <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-gray-900 text-gray-50 hover:bg-gray-900/90 h-9 px-4 py-2">
             Pause Queue
           </button>
         </form>
       {% else %}
-        <form action="{{ base_path }}/queues/{{ queue_name }}/resume" method="post">
+        <form action="{{ base_path }}/queues/{{ queue_name }}/resume" method="post" data-turbo-frame="_top">
           <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-gray-900 text-gray-50 hover:bg-gray-900/90 h-9 px-4 py-2">
             Resume Queue
           </button>
@@ -86,7 +86,7 @@
               </td>
               <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                 {% if job.status == 'failed' %}
-                  <form action="{{ base_path }}/failed-jobs/{{ job.id }}/retry" method="post" class="inline">
+                  <form action="{{ base_path }}/failed-jobs/{{ job.id }}/retry" method="post" class="inline" data-turbo-frame="_top">
                     <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-3 py-1">Retry</button>
                   </form>
                 {% endif %}

--- a/src/control_plane/templates/queues.html
+++ b/src/control_plane/templates/queues.html
@@ -133,12 +133,10 @@ async function toggleQueueStatus(button) {
     const basePath = document.querySelector('meta[name="base-path"]')?.content || '';
     const response = await fetch(`${basePath}/queues/${queueName}/${action}`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      redirect: 'manual',
     });
 
-    if (!response.ok) {
+    if (!response.ok && response.type !== 'opaqueredirect') {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
 

--- a/src/control_plane/templates/recurring-jobs.html
+++ b/src/control_plane/templates/recurring-jobs.html
@@ -60,7 +60,7 @@
             </div>
           </td>
           <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-            <form action="{{ base_path }}/recurring-jobs/{{ task.id }}/run" method="post" class="inline">
+            <form action="{{ base_path }}/recurring-jobs/{{ task.id }}/run" method="post" class="inline" data-turbo-frame="_top">
               <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-3 py-1">
                 Run Now
               </button>

--- a/src/control_plane/templates/scheduled-jobs.html
+++ b/src/control_plane/templates/scheduled-jobs.html
@@ -84,7 +84,7 @@
             <div class="text-sm text-gray-900"><span data-controller="localtime" data-localtime-datetime-value="{{ job.created_at }}">{{ job.created_at }}</span></div>
           </td>
           <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-            <form action="{{ base_path }}/scheduled-jobs/{{ job.id }}/cancel" method="post" class="inline">
+            <form action="{{ base_path }}/scheduled-jobs/{{ job.id }}/cancel" method="post" class="inline" data-turbo-frame="_top">
               <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-3 py-1">
                 Cancel
               </button>


### PR DESCRIPTION
## Summary

- Add `data-turbo-frame="_top"` to every POST `<form>` in the control-plane templates so Turbo Drive navigates the whole page after a 303 redirect instead of trying to morph an unrelated frame
- Update the `toggleQueueStatus` fetch in `queues.html` to use `redirect: 'manual'` and accept `opaqueredirect` responses, so the JS flow tolerates the same 303 without throwing

Touches: blocked-jobs, failed-jobs, job-details, queue-details, queues, recurring-jobs, scheduled-jobs.

## Test plan

- [ ] Open the control plane in a browser and exercise Pause/Resume on queues
- [ ] From the failed-jobs list, click Retry / Discard / bulk Retry / bulk Discard and confirm the page updates correctly
- [ ] From blocked-jobs, trigger Unblock / Cancel (single + all) and verify the redirect lands on the expected page
- [ ] From scheduled-jobs and recurring-jobs, trigger Cancel and Run Now respectively and confirm navigation