### PR TITLE
feat: add Quebec.discover_jobs() for package-based auto-registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,40 @@ curl -O https://raw.githubusercontent.com/ratazzi/quebec/refs/heads/master/quick
 uv run quickstart.py
 ```
 
+### Auto-Discovering Jobs
+
+If your jobs are organized in a package (e.g. `app.jobs.*`), call
+`Quebec.discover_jobs()` instead of decorating each class with
+`@qc.register_job` or calling `qc.register_job_class(...)` one by one:
+
+```python
+# app/jobs/cleanup.py
+class CleanupJob(quebec.BaseClass):
+    def perform(self, *args, **kwargs): ...
+
+# main.py
+qc = quebec.Quebec(dsn)
+qc.discover_jobs("app.jobs", "worker.tasks")   # recursively scans each
+qc.run()
+```
+
+`discover_jobs` takes one or more dotted package paths as positional
+arguments (varargs) — no need to wrap a single package in a list.
+
+`discover_jobs(*packages, recursive=True, on_error="raise")`:
+
+- Registers every `BaseClass` subclass whose `__module__` falls under one of
+  the given packages. Classes imported from elsewhere (e.g. `from
+  some.lib import JobMixin`) are ignored.
+- Raises `ValueError` if two discovered classes share the same
+  `__qualname__`, since Quebec's worker registry is keyed by qualname and
+  the later registration would otherwise silently replace the earlier one.
+- `on_error="raise"` (default) propagates submodule `ImportError`. Pass
+  `on_error="warn"` to emit a `RuntimeWarning` and keep scanning —
+  useful when a package contains optional-integration modules that may
+  fail to import in some environments. The top-level package is always
+  imported strictly.
+
 ### `qc.run()` Options
 
 | Parameter | Type | Default | Description |

--- a/python/quebec/__init__.py
+++ b/python/quebec/__init__.py
@@ -554,8 +554,134 @@ def _quebec_asgi_app(self):
     return ControlPlaneASGI(self)
 
 
+def _quebec_discover_jobs(
+    self,
+    *packages: str,
+    recursive: bool = True,
+    on_error: str = "raise",
+) -> List[Type]:
+    """Import the given packages and register every ``BaseClass`` subclass found.
+
+    This is a thin wrapper around ``importlib`` + ``pkgutil`` that replaces the
+    hand-rolled job-discovery loops most projects end up writing (scan a
+    ``jobs`` package, ``issubclass(..., BaseClass)``, call ``register_job``).
+
+    A class is only registered once, even if it is re-exported from multiple
+    modules. Classes whose ``__module__`` does not fall under one of the given
+    packages are ignored, so ``from some.lib import JobMixin`` will not leak
+    unrelated classes into the worker registry.
+
+    The worker registry is currently keyed by each class's ``__qualname__``, so
+    two jobs sharing a qualified name (e.g. ``foo.jobs.CleanupJob`` and
+    ``bar.jobs.CleanupJob``) would silently clobber each other. ``discover_jobs``
+    raises ``ValueError`` on such collisions rather than letting them through.
+
+    Args:
+        *packages: Dotted package paths to scan (e.g. ``"app.services.jobs"``).
+        recursive: When ``True`` (default), walk nested subpackages as well.
+        on_error: How to handle import failures in submodules. ``"raise"``
+            (default) re-raises the first ``ImportError``; ``"warn"`` emits a
+            ``RuntimeWarning`` and continues with the remaining modules. The
+            top-level package is always imported strictly — if the root fails
+            to import, there is nothing to discover.
+
+    Returns:
+        The list of ``BaseClass`` subclasses that were registered, in discovery
+        order.
+
+    Raises:
+        ValueError: If no packages are given, if ``on_error`` is not one of the
+            supported values, or if two discovered classes collide on
+            ``__qualname__``.
+        ImportError: Propagated from submodule imports when ``on_error="raise"``.
+
+    Example:
+        qc = quebec.Quebec(dsn)
+        qc.discover_jobs("app.services.jobs")
+        qc.run()
+    """
+    import importlib
+    import pkgutil
+    import warnings
+
+    if not packages:
+        raise ValueError("discover_jobs() requires at least one package name")
+    if on_error not in ("raise", "warn"):
+        raise ValueError(
+            f"discover_jobs() on_error must be 'raise' or 'warn', got {on_error!r}"
+        )
+
+    registered: List[Type] = []
+    seen: set = set()
+    by_qualname: dict = {}
+
+    def _scan_module(module) -> None:
+        for obj in module.__dict__.values():
+            if not isinstance(obj, type):
+                continue
+            if not issubclass(obj, BaseClass) or obj is BaseClass:
+                continue
+            if obj in seen:
+                continue
+            if not any(
+                obj.__module__ == pkg or obj.__module__.startswith(pkg + ".")
+                for pkg in packages
+            ):
+                continue
+            existing = by_qualname.get(obj.__qualname__)
+            if existing is not None and existing is not obj:
+                raise ValueError(
+                    f"discover_jobs() found two classes sharing qualname "
+                    f"{obj.__qualname__!r}: {existing.__module__}.{existing.__qualname__} "
+                    f"and {obj.__module__}.{obj.__qualname__}. Quebec's worker "
+                    "registry is keyed by qualname, so the later registration "
+                    "would silently replace the earlier one. Rename one of the "
+                    "classes or skip this package."
+                )
+            seen.add(obj)
+            by_qualname[obj.__qualname__] = obj
+            self.register_job(obj)
+            registered.append(obj)
+
+    def _safe_import(module_name: str):
+        try:
+            return importlib.import_module(module_name)
+        except ImportError as exc:
+            if on_error == "raise":
+                raise
+            warnings.warn(
+                f"discover_jobs: skipping {module_name!r} (import failed: {exc})",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            return None
+
+    for pkg_name in packages:
+        # Top-level package must import cleanly — we cannot walk a missing package.
+        package = importlib.import_module(pkg_name)
+        _scan_module(package)
+
+        pkg_path = getattr(package, "__path__", None)
+        if pkg_path is None:
+            # Plain module, not a package — nothing else to walk.
+            continue
+
+        walker = pkgutil.walk_packages if recursive else pkgutil.iter_modules
+        for info in walker(pkg_path, prefix=f"{pkg_name}."):
+            module_name = info.name
+            if any(part.startswith("_") for part in module_name.split(".")):
+                continue
+            submodule = _safe_import(module_name)
+            if submodule is None:
+                continue
+            _scan_module(submodule)
+
+    return registered
+
+
 # Attach methods to Quebec class
 Quebec.start = _quebec_start
 Quebec.wait = _quebec_wait
 Quebec.run = _quebec_run
 Quebec.asgi_app = _quebec_asgi_app
+Quebec.discover_jobs = _quebec_discover_jobs

--- a/python/quebec/__main__.py
+++ b/python/quebec/__main__.py
@@ -5,6 +5,10 @@ Usage:
     python -m quebec app.jobs
     python -m quebec app.jobs app.other_jobs
 
+Each positional argument is a dotted package path; the runner recursively
+scans it via ``Quebec.discover_jobs`` and registers every ``BaseClass``
+subclass whose ``__module__`` falls under that package.
+
 All configuration via environment variables:
 
     QUEBEC_DATABASE_URL or DATABASE_URL  — database connection string (required)
@@ -14,37 +18,24 @@ All configuration via environment variables:
     QUEBEC_SPAWN            — comma-separated components: worker,dispatcher,scheduler
     QUEBEC_LOG_LEVEL        — log level (default: INFO)
     QUEBEC_LOG_FORMAT       — structlog format: console, json, logfmt (default: console)
+    QUEBEC_DISCOVER_ON_ERROR — how discover_jobs handles submodule ImportError:
+                              "raise" (default) or "warn"
 
     Other QUEBEC_* env vars (pool, polling, etc.) are handled by the Rust core.
 """
 
-import importlib
-import inspect
 import logging
 import os
 import sys
 
-from quebec import BaseClass, Quebec
+from quebec import Quebec
 from quebec.logger import setup_structlog, get_structlog
-
-
-def discover_job_classes(module):
-    """Find all BaseClass subclasses defined in a module."""
-    return [
-        obj
-        for _name, obj in inspect.getmembers(module, inspect.isclass)
-        if issubclass(obj, BaseClass) and obj is not BaseClass
-    ]
-
-
-def parse_bool(value):
-    return value.lower() in ("true", "1", "yes")
 
 
 def main():
     modules = sys.argv[1:]
     if not modules:
-        print(__doc__.strip(), file=sys.stderr)
+        print((__doc__ or "").strip(), file=sys.stderr)
         sys.exit(1)
 
     # Logging
@@ -66,30 +57,24 @@ def main():
     # Create Quebec instance (QUEBEC_* env vars are read by Rust core)
     qc = Quebec(database_url)
 
-    # Discover and register job classes
-    total = 0
-    for module_path in modules:
-        try:
-            mod = importlib.import_module(module_path)
-        except ImportError as e:
-            logger.error(f"Cannot import module '{module_path}': {e}")
-            sys.exit(1)
+    on_error = os.environ.get("QUEBEC_DISCOVER_ON_ERROR", "raise")
+    try:
+        registered = qc.discover_jobs(*modules, on_error=on_error)
+    except ImportError as e:
+        logger.error(f"Cannot import module: {e}")
+        sys.exit(1)
+    except ValueError as e:
+        logger.error(str(e))
+        sys.exit(1)
 
-        classes = discover_job_classes(mod)
-        if not classes:
-            logger.warning(f"No BaseClass subclasses found in '{module_path}'")
-            continue
-
-        for cls in classes:
-            qc.register_job(cls)
-            logger.info(f"Registered {cls.__name__} from {module_path}")
-            total += 1
-
-    if total == 0:
+    if not registered:
         logger.error("No job classes found in any of the specified modules")
         sys.exit(1)
 
-    logger.info(f"Discovered {total} job class(es), starting Quebec")
+    for cls in registered:
+        logger.info(f"Registered {cls.__qualname__} from {cls.__module__}")
+
+    logger.info(f"Discovered {len(registered)} job class(es), starting Quebec")
 
     # Run options
     create_tables_env = os.environ.get("QUEBEC_CREATE_TABLES")


### PR DESCRIPTION
## Summary

Adds `Quebec.discover_jobs(*packages, recursive=True, on_error="raise")`, which walks the given packages and auto-registers every `BaseClass` subclass it finds. Replaces the hand-rolled `importlib` + `pkgutil` loop most projects end up writing (`for mod in walk_packages(...)`, `issubclass(..., BaseClass)`, `register_job(cls)`).

### Behavior

- **Module scoping.** Classes whose `__module__` does not fall under one of the given packages are ignored, so `from some.lib import JobMixin` will not leak unrelated classes into the worker registry.
- **Deduplication.** A class re-exported from multiple modules is only registered once (identity-based).
- **Qualname collision guard.** Quebec's worker registry is keyed by `__qualname__` (see `src/worker.rs` and `src/types.rs`). If discovery finds two different classes sharing a qualname (e.g. `foo.jobs.CleanupJob` and `bar.jobs.CleanupJob`), `discover_jobs` raises `ValueError` instead of letting the later registration silently overwrite the earlier one. This guard is specific to the batch discovery path; manual `register_job` calls are unchanged.
- **Import-error policy.** `on_error="raise"` (default) propagates any submodule `ImportError` so you see the real failure immediately. Pass `on_error="warn"` to emit a `RuntimeWarning` and skip the offending submodule — useful when a package contains optional-integration modules that may fail to import in some environments. The top-level package is always imported strictly; if the root can't load, there's nothing to discover.
- **Private modules.** Modules whose path contains a leading-underscore component are skipped.

### Usage

```python
qc = quebec.Quebec(dsn)
qc.discover_jobs("app.services.jobs")
qc.run()

# Tolerate optional-integration submodules that may fail to import:
qc.discover_jobs("app.services.jobs", on_error="warn")
```

## Test plan

- [ ] Smoke-tested four scenarios locally in `/tmp/qb_test/`:
  - qualname collision across two packages → `ValueError` raised
  - submodule `ImportError` with `on_error="raise"` → error propagates
  - submodule `ImportError` with `on_error="warn"` → `RuntimeWarning`, scan continues
  - invalid `on_error` value → `ValueError` at param validation
- [ ] Verified `py_compile python/quebec/__init__.py` succeeds.
- [ ] No direct automated coverage added for `discover_jobs` yet — follow-up.