### PR TITLE
fix(signal): skip SIGQUIT registration when unavailable (Windows)

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -1430,20 +1430,18 @@ impl PyQuebec {
             .getattr("partial")?
             .call((handler_func,), Some(&kwargs))?;
 
-        signal.call_method1(
-            "signal",
-            (signal.getattr("SIGINT")?, wrapped_handler.clone()),
-        )?;
-        signal.call_method1(
-            "signal",
-            (signal.getattr("SIGTERM")?, wrapped_handler.clone()),
-        )?;
-        signal.call_method1(
-            "signal",
-            (signal.getattr("SIGQUIT")?, wrapped_handler.clone()),
-        )?;
+        let mut registered: Vec<&str> = Vec::with_capacity(3);
+        for name in ["SIGINT", "SIGTERM", "SIGQUIT"] {
+            if !signal.hasattr(name)? {
+                // SIGQUIT (and in theory others) is missing on Windows; skip
+                // rather than aborting startup.
+                continue;
+            }
+            signal.call_method1("signal", (signal.getattr(name)?, wrapped_handler.clone()))?;
+            registered.push(name);
+        }
 
-        info!("Signal handlers registered for SIGINT and SIGTERM and SIGQUIT");
+        info!("Signal handlers registered: {}", registered.join(", "));
         Ok(wrapped_handler.into_pyobject(py)?.into())
     }
 


### PR DESCRIPTION
## Summary

`Quebec.run()` aborted at signal-handler setup on Windows because Python's stdlib `signal` module does not define `SIGQUIT` there — `signal.getattr("SIGQUIT")?` in `src/types.rs` raised `AttributeError` before any worker could start. Callers had to monkey-patch `signal.SIGQUIT = signal.SIGTERM` before `import quebec`, which is an unreasonable thing to ask of users.

## Change

- Probe `signal.hasattr(name)` at runtime for each of `SIGINT`, `SIGTERM`, `SIGQUIT`, and register only the ones the interpreter actually exposes.
- Log which signals were wired up, rather than hard-coding the three names in the info line.

Kept this as a runtime probe rather than a `#[cfg(target_os = "windows")]` split, since Python-level signal availability is a property of the running interpreter (PyPy, MSYS, embedded Pythons can differ independently of the underlying OS).

## Test plan

- [ ] `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features`, `cargo check --all-targets` all clean locally.
- [ ] Linux/macOS behavior unchanged (all three signals still registered).
- [ ] On Windows, `Quebec.run()` proceeds past signal setup with only `SIGINT, SIGTERM` registered.