### PR TITLE
feat(postgres): TLS config kwargs + reject sslmode=allow

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,47 @@ class ReportJob(quebec.BaseClass):
 
 The actual concurrency key is `"ClassName/key"` (e.g. `"ReportJob/123"`), so different job classes never conflict. When the limit is reached, new jobs are blocked until a slot becomes available. The `concurrency_duration` acts as a safety TTL — the semaphore is released automatically if a worker crashes.
 
+### TLS Configuration (PostgreSQL)
+
+Quebec links `sqlx` against `rustls` + `webpki-roots`. Public CAs (AWS RDS,
+Neon, Google Cloud SQL, Supabase, etc.) are trusted out of the box — no OS
+trust store is consulted.
+
+Pass libpq-style SSL options as `Quebec(...)` kwargs, as DSN query params, or
+via `QUEBEC_SSL*` environment variables:
+
+```python
+qc = quebec.Quebec(
+    "postgresql://user:pass@host:5432/db",
+    sslmode="verify-full",             # or QUEBEC_SSLMODE
+    sslrootcert="/etc/ssl/certs/ca.pem",  # internal CAs only
+)
+```
+
+Priority is **kwargs > env > DSN query**. Passing any `ssl*` kwarg/env against
+a non-postgres URL raises `ValueError`.
+
+| `sslmode`     | Transport              | Certificate verification | Hostname verification |
+|---------------|------------------------|--------------------------|-----------------------|
+| `disable`     | plaintext              | —                        | —                     |
+| `prefer`      | TLS if offered, else plaintext | —                | —                     |
+| `require`     | TLS (fails if unsupported) | — (accepts any cert)  | —                     |
+| `verify-ca`   | TLS                    | CA-signed                | —                     |
+| `verify-full` | TLS                    | CA-signed                | hostname matches CN/SAN |
+
+For public CAs, `verify-full` works zero-config. Use `sslrootcert` for
+internal/self-signed CAs. `sslcert` + `sslkey` enable client certificate
+(mTLS) auth.
+
+> `sslmode=allow` is **rejected** with a `ValueError`. Upstream `sqlx-postgres`
+> 0.8 treats `allow` identically to `disable` (plaintext, marked `FIXME` in
+> the driver); to avoid a silent downgrade, Quebec refuses it. Use `prefer`
+> for opportunistic TLS, or `require`/`verify-*` to enforce it.
+
+> Note: some managed Postgres services (e.g. Neon) terminate TLS at a proxy
+> layer. In those cases `pg_stat_ssl.ssl` may report `false` because the
+> backend sees plaintext from the proxy — not the client.
+
 ## Lifecycle Hooks
 
 Quebec provides several lifecycle hooks that you can use to execute code at different stages of the application lifecycle:

--- a/src/database_url.rs
+++ b/src/database_url.rs
@@ -76,6 +76,62 @@ impl DatabaseUrl {
         matches!(self.kind, DatabaseKind::Mysql)
     }
 
+    /// Upsert libpq-style SSL query parameters into the DSN.
+    ///
+    /// Each provided value replaces an existing query param of the same name
+    /// *and any accepted alias*; `None` leaves the existing value (if any)
+    /// untouched. Param order is preserved for non-SSL pairs. sqlx-postgres
+    /// accepts both canonical (`sslmode`, `sslrootcert`, `sslcert`, `sslkey`)
+    /// and aliased (`ssl-mode`, `ssl-root-cert`, `ssl-ca`, `ssl-cert`,
+    /// `ssl-key`) spellings — all are scrubbed when the matching override is
+    /// supplied so the caller's value is the only effective one.
+    pub fn with_ssl_params(
+        &self,
+        sslmode: Option<&str>,
+        sslrootcert: Option<&str>,
+        sslcert: Option<&str>,
+        sslkey: Option<&str>,
+    ) -> Result<Self> {
+        let overrides: &[(&str, Option<&str>)] = &[
+            ("sslmode", sslmode),
+            ("sslrootcert", sslrootcert),
+            ("sslcert", sslcert),
+            ("sslkey", sslkey),
+        ];
+        if overrides.iter().all(|(_, v)| v.is_none()) {
+            return Ok(self.clone());
+        }
+
+        let existing: Vec<(String, String)> = self
+            .parsed
+            .query_pairs()
+            .filter(|(k, _)| {
+                !overrides.iter().any(|(name, val)| {
+                    val.is_some() && ssl_param_aliases(name).iter().any(|a| *a == k.as_ref())
+                })
+            })
+            .map(|(k, v)| (k.into_owned(), v.into_owned()))
+            .collect();
+
+        let mut u = self.parsed.clone();
+        {
+            let mut qp = u.query_pairs_mut();
+            qp.clear();
+            for (k, v) in &existing {
+                qp.append_pair(k, v);
+            }
+            for (name, val) in overrides {
+                if let Some(v) = val {
+                    qp.append_pair(name, v);
+                }
+            }
+        }
+        if u.query().is_some_and(|q| q.is_empty()) {
+            u.set_query(None);
+        }
+        Self::parse(u.as_str())
+    }
+
     /// Password redacted, query/fragment stripped.
     pub fn masked(&self) -> String {
         let mut u = self.parsed.clone();
@@ -99,6 +155,18 @@ impl std::str::FromStr for DatabaseUrl {
 
     fn from_str(s: &str) -> Result<Self> {
         Self::parse(s)
+    }
+}
+
+/// Aliases sqlx-postgres accepts for a given canonical libpq SSL query param.
+/// See `sqlx-postgres` `options/parse.rs` `parse_from_url`.
+pub fn ssl_param_aliases(canonical: &str) -> &'static [&'static str] {
+    match canonical {
+        "sslmode" => &["sslmode", "ssl-mode"],
+        "sslrootcert" => &["sslrootcert", "ssl-root-cert", "ssl-ca"],
+        "sslcert" => &["sslcert", "ssl-cert"],
+        "sslkey" => &["sslkey", "ssl-key"],
+        _ => &[],
     }
 }
 
@@ -220,5 +288,87 @@ mod tests {
         let url = DatabaseUrl::parse("postgres://alice:secret@h:5432/db?sslmode=require").unwrap();
         assert_eq!(url.masked(), "postgres://alice:***@h:5432/db");
         assert_eq!(url.to_string(), "postgres://alice:***@h:5432/db");
+    }
+
+    #[test]
+    fn ssl_params_all_none_returns_clone() {
+        let url = DatabaseUrl::parse("postgres://h/db?application_name=x").unwrap();
+        let out = url.with_ssl_params(None, None, None, None).unwrap();
+        assert_eq!(out.as_connect_str(), "postgres://h/db?application_name=x");
+    }
+
+    #[test]
+    fn ssl_params_inserts_into_empty_query() {
+        let url = DatabaseUrl::parse("postgres://h/db").unwrap();
+        let out = url
+            .with_ssl_params(Some("require"), None, None, None)
+            .unwrap();
+        assert_eq!(out.as_connect_str(), "postgres://h/db?sslmode=require");
+    }
+
+    #[test]
+    fn ssl_params_override_existing_sslmode() {
+        let url = DatabaseUrl::parse("postgres://h/db?sslmode=disable&application_name=x").unwrap();
+        let out = url
+            .with_ssl_params(Some("require"), None, None, None)
+            .unwrap();
+        // Existing non-ssl params preserved; sslmode replaced.
+        assert!(out.as_connect_str().contains("application_name=x"));
+        assert!(out.as_connect_str().contains("sslmode=require"));
+        assert!(!out.as_connect_str().contains("sslmode=disable"));
+    }
+
+    #[test]
+    fn ssl_params_leaves_existing_when_override_is_none() {
+        let url = DatabaseUrl::parse("postgres://h/db?sslmode=require").unwrap();
+        let out = url
+            .with_ssl_params(None, Some("/etc/ca.pem"), None, None)
+            .unwrap();
+        assert!(out.as_connect_str().contains("sslmode=require"));
+        assert!(out.as_connect_str().contains("sslrootcert=%2Fetc%2Fca.pem"));
+    }
+
+    #[test]
+    fn ssl_params_override_strips_sqlx_aliases() {
+        // sqlx accepts `ssl-mode` as alias; overriding `sslmode` should also
+        // strip the alias form so the caller's value is the only effective one.
+        let url = DatabaseUrl::parse("postgres://h/db?ssl-mode=allow").unwrap();
+        let out = url
+            .with_ssl_params(Some("require"), None, None, None)
+            .unwrap();
+        assert!(out.as_connect_str().contains("sslmode=require"));
+        assert!(!out.as_connect_str().contains("ssl-mode"));
+        assert!(!out.as_connect_str().contains("allow"));
+    }
+
+    #[test]
+    fn ssl_params_override_strips_sqlx_rootcert_aliases() {
+        // sqlx accepts `ssl-ca` and `ssl-root-cert` as aliases of sslrootcert.
+        let url =
+            DatabaseUrl::parse("postgres://h/db?ssl-ca=/old/ca.pem&ssl-root-cert=/older/ca.pem")
+                .unwrap();
+        let out = url
+            .with_ssl_params(None, Some("/new/ca.pem"), None, None)
+            .unwrap();
+        assert!(out.as_connect_str().contains("sslrootcert=%2Fnew%2Fca.pem"));
+        assert!(!out.as_connect_str().contains("ssl-ca"));
+        assert!(!out.as_connect_str().contains("ssl-root-cert"));
+    }
+
+    #[test]
+    fn ssl_params_percent_encodes_paths() {
+        let url = DatabaseUrl::parse("postgres://h/db").unwrap();
+        let out = url
+            .with_ssl_params(
+                Some("verify-full"),
+                Some("/path/with space/ca.pem"),
+                None,
+                None,
+            )
+            .unwrap();
+        assert!(out.as_connect_str().contains("sslmode=verify-full"));
+        assert!(out
+            .as_connect_str()
+            .contains("sslrootcert=%2Fpath%2Fwith+space%2Fca.pem"));
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -51,6 +51,32 @@ where
     default
 }
 
+/// Like `extract_kwarg_or_env` but returns `None` when neither kwargs nor env
+/// supplies a value. Use for optional config where an absent value must be
+/// distinguished from a typed default.
+fn extract_kwarg_or_env_opt<T>(
+    kwargs: Option<&Bound<'_, PyDict>>,
+    key: &str,
+    env_key: &str,
+) -> Option<T>
+where
+    T: for<'a, 'py> FromPyObject<'a, 'py> + FromStr,
+{
+    if let Some(py_val) = kwargs.and_then(|kw| kw.get_item(key).ok().flatten()) {
+        match py_val.extract::<T>() {
+            Ok(val) => return Some(val),
+            Err(_) => warn!("Config '{}': type mismatch, falling back to env", key),
+        }
+    }
+    if let Ok(raw) = std::env::var(env_key) {
+        match raw.parse::<T>() {
+            Ok(parsed) => return Some(parsed),
+            Err(_) => warn!("Env '{}': failed to parse '{}', ignoring", env_key, raw),
+        }
+    }
+    None
+}
+
 use crate::control_plane::{ControlPlane, ControlPlaneExt};
 
 use crate::context::*;
@@ -266,6 +292,56 @@ impl PyQuebec {
         let dsn = crate::database_url::DatabaseUrl::parse(&url).map_err(|e| {
             PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Invalid database URL: {}", e))
         })?;
+
+        let sslmode: Option<String> = extract_kwarg_or_env_opt(kwargs, "sslmode", "QUEBEC_SSLMODE");
+        let sslrootcert: Option<String> =
+            extract_kwarg_or_env_opt(kwargs, "sslrootcert", "QUEBEC_SSLROOTCERT");
+        let sslcert: Option<String> = extract_kwarg_or_env_opt(kwargs, "sslcert", "QUEBEC_SSLCERT");
+        let sslkey: Option<String> = extract_kwarg_or_env_opt(kwargs, "sslkey", "QUEBEC_SSLKEY");
+        let dsn = if sslmode.is_some()
+            || sslrootcert.is_some()
+            || sslcert.is_some()
+            || sslkey.is_some()
+        {
+            if !dsn.is_postgres() {
+                return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                    "SSL parameters (sslmode/sslrootcert/sslcert/sslkey) require a postgres:// URL",
+                ));
+            }
+            dsn.with_ssl_params(
+                sslmode.as_deref(),
+                sslrootcert.as_deref(),
+                sslcert.as_deref(),
+                sslkey.as_deref(),
+            )
+            .map_err(|e| {
+                PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                    "Failed to apply SSL params: {}",
+                    e
+                ))
+            })?
+        } else {
+            dsn
+        };
+
+        // sqlx-postgres 0.8 treats `sslmode=allow` identically to `disable`
+        // (plaintext, marked FIXME upstream). Reject it from any source
+        // (kwargs, env, or DSN query string) so callers don't silently get
+        // cleartext while expecting opportunistic TLS. sqlx also accepts
+        // `ssl-mode` as an alias of `sslmode`, so both spellings are scanned.
+        if dsn.is_postgres() {
+            let aliases = crate::database_url::ssl_param_aliases("sslmode");
+            let offender = dsn
+                .url()
+                .query_pairs()
+                .find(|(k, v)| aliases.contains(&k.as_ref()) && v.eq_ignore_ascii_case("allow"));
+            if offender.is_some() {
+                return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
+                    "sslmode=allow is not supported: sqlx-postgres treats it as disable (plaintext). Use 'prefer' for opportunistic TLS or 'require'/'verify-*' to enforce it.",
+                ));
+            }
+        }
+
         info!("PyQuebec<{}>", dsn);
 
         let rt = Arc::new(


### PR DESCRIPTION
## Summary

- Add `sslmode` / `sslrootcert` / `sslcert` / `sslkey` as `Quebec(...)` kwargs and `QUEBEC_SSL*` env mirrors (priority: kwargs > env > DSN query)
- Reject `sslmode=allow` from any source (kwargs/env/DSN). sqlx-postgres 0.8 treats `Allow` identically to `Disable` (plaintext, FIXME upstream); accepting it would silently downgrade callers who expect opportunistic TLS
- Alias-aware: detection and upsert both cover every spelling sqlx-postgres accepts (`ssl-mode`, `ssl-ca` / `ssl-root-cert`, `ssl-cert`, `ssl-key`)
- README section documents the full taxonomy, rustls + webpki-roots default, and the Neon-style proxy caveat for `pg_stat_ssl`

## Why

Quebec links sqlx with `runtime-tokio-rustls`, so public CAs (AWS RDS / Neon / Cloud SQL / Supabase) work zero-config — but there was no ergonomic way to flip `sslmode` or point at an internal CA without hand-editing the DSN. This adds the standard libpq-style knobs while guarding against the silent-plaintext footgun in sqlx's current `Allow` handling.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features`
- [x] `cargo test --no-default-features --lib database_url` (13 tests, all pass; includes new alias-strip coverage)
- [x] Manual smoke:
  - `Quebec("postgresql://u:p@h/db", sslmode="allow")` → `ValueError`
  - `Quebec("postgresql://u:p@h/db?sslmode=allow")` → `ValueError`
  - `Quebec("postgresql://u:p@h/db?ssl-mode=allow")` → `ValueError` (alias)
  - `Quebec(..., sslmode="require")` against non-TLS server → `ConnectionError`, not panic
  - Non-postgres URL with any `ssl*` kwarg → `ValueError`
- [ ] No automated coverage yet for the full kwargs/env/DSN interaction at the Python boundary (tracked as residual gap)