### PR TITLE
fix(control-plane): redirect cancel-scheduled-job and align error responses

### DIFF
--- a/src/control_plane/handlers/scheduled_jobs.rs
+++ b/src/control_plane/handlers/scheduled_jobs.rs
@@ -1,7 +1,7 @@
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
-    response::{Html, IntoResponse},
+    response::{Html, IntoResponse, Redirect, Response},
 };
 use sea_orm::{ConnectionTrait, DbErr, Statement, TransactionTrait, Value};
 use std::sync::Arc;
@@ -244,14 +244,12 @@ impl ControlPlane {
     pub async fn cancel_scheduled_job(
         State(state): State<Arc<ControlPlane>>,
         Path(id): Path<i64>,
-    ) -> impl IntoResponse {
+    ) -> Response {
         let db = match state.ctx.get_db().await {
             Ok(db) => db,
-            Err(_) => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "/scheduled-jobs".to_string(),
-                )
+            Err(e) => {
+                error!("Failed to obtain db for scheduled job {} cancel: {}", id, e);
+                return Self::error_response();
             }
         };
         let db = db.as_ref();
@@ -290,13 +288,10 @@ impl ControlPlane {
             .await;
 
         match txn_result {
-            Ok(_) => (StatusCode::SEE_OTHER, "/scheduled-jobs".to_string()),
+            Ok(_) => Redirect::to("/scheduled-jobs").into_response(),
             Err(e) => {
                 error!("Failed to cancel scheduled job {}: {}", id, e);
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "/scheduled-jobs".to_string(),
-                )
+                Self::error_response()
             }
         }
     }


### PR DESCRIPTION
## Summary

- `cancel_scheduled_job` previously returned tuples like `(StatusCode::SEE_OTHER, "/scheduled-jobs")`, which axum serializes as status + text body (no `Location` header) — the browser stayed on the POST target instead of navigating back.
- Use `Redirect::to("/scheduled-jobs")` so the happy-path response carries a proper `Location` header.
- Switch both error branches to `Self::error_response()` to match sibling mutation handlers in `blocked_jobs.rs` / `failed_jobs.rs` (generic 500, no raw DB error text echoed to the browser).
- Return type updated to `Response` since we now mix `Redirect` and the shared error helper.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --lib` (only pre-existing warnings unrelated to this change)
- [ ] Manual: trigger cancel on the scheduled-jobs page and confirm the browser returns to `/scheduled-jobs` with the row removed
- [ ] Manual: force a DB error on cancel and confirm the response is a plain 500 without internal error text