### PR TITLE
feat(python): make qc optional in perform_later shorthand

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ class FakeJob(quebec.BaseClass):
 
 
 if __name__ == "__main__":
-    # Enqueue a job
-    FakeJob.perform_later(qc, 123, foo='bar')
+    # Enqueue a job (qc is inferred from @qc.register_job)
+    FakeJob.perform_later(123, foo='bar')
 
     # Start Quebec (handles signal, spawns workers, runs main loop)
     qc.run(
@@ -142,6 +142,20 @@ arguments (varargs) — no need to wrap a single package in a list.
   fail to import in some environments. The top-level package is always
   imported strictly.
 
+### Multiple Quebec Instances
+
+Quebec is designed for one instance per process. Registering a job class
+(via `@qc.register_job`, `qc.register_job_class`, or `qc.discover_jobs`)
+binds it to that Quebec instance, so `MyJob.perform_later(...)` shorthand
+routes to the binding. If a process holds more than one Quebec instance
+and registers the same job class to each, the most recent registration
+wins — pass the target instance explicitly to disambiguate:
+
+```python
+MyJob.perform_later(qc2, arg1)                  # route to qc2
+MyJob.set(queue='critical').perform_later(qc2, arg1)
+```
+
 ### `qc.run()` Options
 
 | Parameter | Type | Default | Description |
@@ -159,13 +173,13 @@ If you need a one-off override, `Quebec(..., worker_threads=3)` is also supporte
 from datetime import timedelta
 
 # Run after 1 hour
-FakeJob.set(wait=3600).perform_later(qc, arg1)
+FakeJob.set(wait=3600).perform_later(arg1)
 
 # Run at specific time
-FakeJob.set(wait_until=tomorrow_9am).perform_later(qc, arg1)
+FakeJob.set(wait_until=tomorrow_9am).perform_later(arg1)
 
 # Override queue and priority
-FakeJob.set(queue='critical', priority=1).perform_later(qc, arg1)
+FakeJob.set(queue='critical', priority=1).perform_later(arg1)
 ```
 
 ### Automatic Retries

--- a/python/quebec/__init__.py
+++ b/python/quebec/__init__.py
@@ -191,17 +191,20 @@ class JobBuilder:
         """Create a JobDescriptor with configured options (for bulk enqueue)."""
         return JobDescriptor(self.job_class, args, kwargs, dict(self.options))
 
-    def perform_later(self, qc=None, *args, **kwargs) -> "ActiveJob":
+    def perform_later(self, *args, **kwargs) -> "ActiveJob":
         """Enqueue the job with configured options.
 
-        ``qc`` may be passed explicitly (legacy) or omitted when the job
-        class has been registered with a Quebec instance (all three
-        registration paths bind ``cls.quebec``). If the first positional
-        argument is not a ``Quebec`` instance it is treated as job data.
+        The Quebec instance may be passed explicitly as the first
+        positional argument (legacy form) or omitted entirely when the
+        job class has been registered with a Quebec instance. A leading
+        argument is only consumed as the Quebec instance when it is
+        actually a ``Quebec`` object; any other value (including
+        ``None``) is treated as job payload data.
         """
-        if qc is not None and not isinstance(qc, Quebec):
-            args = (qc, *args)
-            qc = None
+        qc = None
+        if args and isinstance(args[0], Quebec):
+            qc = args[0]
+            args = args[1:]
 
         scheduled_at = self._calculate_scheduled_at()
 
@@ -216,7 +219,15 @@ class JobBuilder:
             kwargs["_priority"] = self.options["priority"]
 
         if qc is None:
-            return self.job_class.perform_later(*args, **kwargs)
+            qc = getattr(self.job_class, "quebec", None)
+            if qc is None:
+                name = self.job_class.__qualname__
+                raise TypeError(
+                    f"{name} is not registered with a Quebec instance. Use "
+                    f"@qc.register_job, qc.register_job_class({name}), or "
+                    f"qc.discover_jobs(...) — or pass the Quebec instance as "
+                    f"the first argument to perform_later."
+                )
         return self.job_class.perform_later(qc, *args, **kwargs)
 
 

--- a/python/quebec/__init__.py
+++ b/python/quebec/__init__.py
@@ -191,8 +191,18 @@ class JobBuilder:
         """Create a JobDescriptor with configured options (for bulk enqueue)."""
         return JobDescriptor(self.job_class, args, kwargs, dict(self.options))
 
-    def perform_later(self, qc: "Quebec", *args, **kwargs) -> "ActiveJob":
-        """Enqueue the job with configured options."""
+    def perform_later(self, qc=None, *args, **kwargs) -> "ActiveJob":
+        """Enqueue the job with configured options.
+
+        ``qc`` may be passed explicitly (legacy) or omitted when the job
+        class has been registered with a Quebec instance (all three
+        registration paths bind ``cls.quebec``). If the first positional
+        argument is not a ``Quebec`` instance it is treated as job data.
+        """
+        if qc is not None and not isinstance(qc, Quebec):
+            args = (qc, *args)
+            qc = None
+
         scheduled_at = self._calculate_scheduled_at()
 
         # Pass internal options via kwargs (will be filtered out before serialization)
@@ -205,7 +215,8 @@ class JobBuilder:
         if "priority" in self.options:
             kwargs["_priority"] = self.options["priority"]
 
-        # Call the original perform_later
+        if qc is None:
+            return self.job_class.perform_later(*args, **kwargs)
         return self.job_class.perform_later(qc, *args, **kwargs)
 
 

--- a/python/quebec/__init__.py
+++ b/python/quebec/__init__.py
@@ -154,8 +154,14 @@ class JobBuilder:
     """Builder for configuring job options before enqueueing.
 
     This allows chaining configuration like:
-        MyJob.set(wait=3600).perform_later(qc, arg1, arg2)
-        MyJob.set(queue='high', priority=10).perform_later(qc, arg1)
+        MyJob.set(wait=3600).perform_later(arg1, arg2)
+        MyJob.set(queue='high', priority=10).perform_later(arg1)
+
+    The Quebec instance is inferred from the class binding set by
+    ``@qc.register_job`` / ``qc.register_job_class`` / ``qc.discover_jobs``.
+    If the same job class is registered to more than one Quebec instance,
+    the most recent registration wins; pass the target instance explicitly
+    as the first positional argument to ``perform_later`` to disambiguate.
     """
 
     def __init__(self, job_class: Type, **options):
@@ -271,9 +277,9 @@ class BaseClass(ActiveJob, metaclass=NoNewOverrideMeta):
             JobBuilder instance for chaining with perform_later
 
         Example:
-            MyJob.set(wait=3600).perform_later(qc, arg1)  # Run in 1 hour
-            MyJob.set(wait_until=tomorrow).perform_later(qc, arg1)
-            MyJob.set(queue='critical', priority=1).perform_later(qc, arg1)
+            MyJob.set(wait=3600).perform_later(arg1)  # Run in 1 hour
+            MyJob.set(wait_until=tomorrow).perform_later(arg1)
+            MyJob.set(queue='critical', priority=1).perform_later(arg1)
         """
         options = {}
         if wait is not None:

--- a/quickstart.py
+++ b/quickstart.py
@@ -29,7 +29,7 @@ class FakeJob(quebec.BaseClass):
 
 
 if __name__ == "__main__":
-    FakeJob.perform_later(qc, 3466, foo='bar')
+    FakeJob.perform_later(3466, foo='bar')
 
     qc.run(
         create_tables=not db_path.exists(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -965,7 +965,20 @@ impl PyQuebec {
     }
 
     fn register_job_class(&self, py: Python, job_class: Py<PyAny>) -> PyResult<()> {
-        // Register with worker (this will store in AppContext.runnables)
+        if !job_class.bind(py).is_instance_of::<PyType>() {
+            return Err(PyTypeError::new_err(
+                "Expected a class, but got an instance",
+            ));
+        }
+
+        let instance = job_class.bind(py).call0()?;
+        if !instance.is_instance_of::<ActiveJob>() {
+            return Err(PyTypeError::new_err(
+                "Job class must be a subclass of ActiveJob",
+            ));
+        }
+
+        job_class.setattr(py, "quebec", self.clone().into_pyobject(py)?)?;
         self.worker.register_job_class(py, job_class)?;
         Ok(())
     }
@@ -1468,26 +1481,8 @@ impl PyQuebec {
 
     // implment a decorator to register job class
     fn register_job(&self, py: Python, job_class: Py<PyAny>) -> PyResult<Py<PyAny>> {
-        // Check if the passed object is a class
-        if !job_class.bind(py).is_instance_of::<PyType>() {
-            return Err(PyTypeError::new_err(
-                "Expected a class, but got an instance",
-            ));
-        }
-
-        let binding = job_class.clone();
-        let bound = binding.bind(py);
-
-        let instance = bound.call0()?;
-        if !instance.is_instance_of::<ActiveJob>() {
-            return Err(pyo3::exceptions::PyTypeError::new_err(
-                "Job class must be a subclass of ActiveJob",
-            ));
-        }
-
-        let _ = job_class.setattr(py, "quebec", self.clone().into_pyobject(py)?);
         let dup = job_class.clone();
-        let _ = self.worker.register_job_class(py, job_class);
+        self.register_job_class(py, job_class)?;
         Ok(dup)
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -2081,34 +2081,43 @@ impl ActiveJob {
     /// via ``@qc.register_job``, ``qc.register_job_class`` or
     /// ``qc.discover_jobs`` — all three paths bind the instance onto
     /// ``cls.quebec``, so ``MyJob.perform_later(arg1, arg2)`` works.
+    ///
+    /// A leading argument is only consumed as the Quebec instance when it
+    /// is actually a ``Quebec`` object; any other value (including
+    /// ``None``) is treated as job payload data.
     #[classmethod]
-    #[pyo3(signature = (quebec=None, *args, **kwargs))]
+    #[pyo3(signature = (*args, **kwargs))]
     fn perform_later<'py>(
         cls: &Bound<'py, PyType>,
         py: Python<'py>,
-        quebec: Option<Bound<'py, PyAny>>,
         args: &Bound<'py, PyTuple>,
         kwargs: Option<&Bound<'py, PyDict>>,
     ) -> PyResult<ActiveJob> {
-        match quebec {
-            Some(first) if first.is_instance_of::<PyQuebec>() => {
+        if let Ok(first) = args.get_item(0) {
+            if first.is_instance_of::<PyQuebec>() {
                 let qc = first.extract::<PyQuebec>()?;
-                qc.perform_later(py, cls, args, kwargs)
-            }
-            Some(first) => {
-                let mut items: Vec<Bound<'py, PyAny>> = Vec::with_capacity(args.len() + 1);
-                items.push(first);
-                for item in args.iter() {
-                    items.push(item);
-                }
-                let combined = PyTuple::new(py, items)?;
-                let qc = cls.getattr("quebec")?.extract::<PyQuebec>()?;
-                qc.perform_later(py, cls, &combined, kwargs)
-            }
-            None => {
-                let qc = cls.getattr("quebec")?.extract::<PyQuebec>()?;
-                qc.perform_later(py, cls, args, kwargs)
+                let rest = args.get_slice(1, args.len());
+                return qc.perform_later(py, cls, &rest, kwargs);
             }
         }
+        let qc = resolve_quebec_from_cls(cls)?;
+        qc.perform_later(py, cls, args, kwargs)
     }
+}
+
+fn resolve_quebec_from_cls(cls: &Bound<'_, PyType>) -> PyResult<PyQuebec> {
+    let name_err = || {
+        let name = cls
+            .qualname()
+            .map(|s| s.to_string())
+            .unwrap_or_else(|_| "job class".to_string());
+        PyTypeError::new_err(format!(
+            "{name} is not registered with a Quebec instance. Use \
+             @qc.register_job, qc.register_job_class({name}), or \
+             qc.discover_jobs(...) — or pass the Quebec instance as the \
+             first argument to perform_later."
+        ))
+    };
+    let attr = cls.getattr("quebec").map_err(|_| name_err())?;
+    attr.extract::<PyQuebec>().map_err(|_| name_err())
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -2074,27 +2074,41 @@ impl ActiveJob {
         Ok(self.logger.clone())
     }
 
+    /// Enqueue the job.
+    ///
+    /// The Quebec instance may be passed explicitly as the first argument
+    /// (legacy style) or omitted entirely when the class has been registered
+    /// via ``@qc.register_job``, ``qc.register_job_class`` or
+    /// ``qc.discover_jobs`` — all three paths bind the instance onto
+    /// ``cls.quebec``, so ``MyJob.perform_later(arg1, arg2)`` works.
     #[classmethod]
-    #[pyo3(signature = ( quebec, *args, **kwargs))]
-    fn perform_later(
-        cls: &Bound<'_, PyType>,
-        py: Python<'_>,
-        quebec: &PyQuebec,
-        args: &Bound<'_, PyTuple>,
-        kwargs: Option<&Bound<'_, PyDict>>,
+    #[pyo3(signature = (quebec=None, *args, **kwargs))]
+    fn perform_later<'py>(
+        cls: &Bound<'py, PyType>,
+        py: Python<'py>,
+        quebec: Option<Bound<'py, PyAny>>,
+        args: &Bound<'py, PyTuple>,
+        kwargs: Option<&Bound<'py, PyDict>>,
     ) -> PyResult<ActiveJob> {
-        quebec.perform_later(py, cls, args, kwargs)
-    }
-
-    #[classmethod]
-    #[pyo3(signature = (*args, **kwargs))]
-    fn perform_later1(
-        cls: &Bound<'_, PyType>,
-        py: Python<'_>,
-        args: &Bound<'_, PyTuple>,
-        kwargs: Option<&Bound<'_, PyDict>>,
-    ) -> PyResult<ActiveJob> {
-        let quebec = cls.getattr("quebec")?.extract::<PyQuebec>()?;
-        quebec.perform_later(py, cls, args, kwargs)
+        match quebec {
+            Some(first) if first.is_instance_of::<PyQuebec>() => {
+                let qc = first.extract::<PyQuebec>()?;
+                qc.perform_later(py, cls, args, kwargs)
+            }
+            Some(first) => {
+                let mut items: Vec<Bound<'py, PyAny>> = Vec::with_capacity(args.len() + 1);
+                items.push(first);
+                for item in args.iter() {
+                    items.push(item);
+                }
+                let combined = PyTuple::new(py, items)?;
+                let qc = cls.getattr("quebec")?.extract::<PyQuebec>()?;
+                qc.perform_later(py, cls, &combined, kwargs)
+            }
+            None => {
+                let qc = cls.getattr("quebec")?.extract::<PyQuebec>()?;
+                qc.perform_later(py, cls, args, kwargs)
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Job classes now bind the Quebec instance onto `cls.quebec` via all three registration paths (`@qc.register_job`, `qc.register_job_class`, `qc.discover_jobs`), so `MyJob.perform_later(...)` and `MyJob.set(...).perform_later(...)` work without passing `qc` every time.
- Legacy explicit form `MyJob.perform_later(qc, ...)` still works — the first positional arg is only consumed as the Quebec instance when it actually is one. `None` and other values are preserved as job payload (fixes a signature-level drop that the old `quebec=None` default introduced).
- Unregistered classes raise a friendly `TypeError` listing the three registration paths and the explicit-qc fallback, instead of a bare `AttributeError`.
- README / quickstart / docstrings updated to the shorthand form, with a new "Multiple Quebec Instances" section documenting the single-instance-by-design contract (last-registration-wins when the same class is bound to multiple Quebec instances; disambiguate by passing `qc` explicitly).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features`
- [x] `cargo check --all-targets --all-features`
- [ ] `maturin develop` and confirm shorthand enqueue works under all three registration paths
- [ ] Confirm `MyJob.perform_later(None)` enqueues `[null]` (not `[]`)
- [ ] Confirm unregistered-class call raises the new `TypeError` message
- [ ] Legacy `MyJob.perform_later(qc, arg)` still enqueues correctly