### PR TITLE
fix(control-plane): count finished jobs by finished_at timestamp

### DIFF
--- a/src/control_plane/utils.rs
+++ b/src/control_plane/utils.rs
@@ -126,9 +126,9 @@ impl ControlPlane {
         context.insert("blocked_jobs_count", &blocked_count);
         context.insert("scheduled_jobs_count", &scheduled_count);
 
-        // Calculate finished jobs count (total jobs minus active executions)
+        // Count finished jobs by finished_at to match the /finished-jobs page
         let finished_count =
-            total_jobs as i64 - scheduled_count - in_progress_count - failed_count - blocked_count;
+            query_builder::jobs::count_finished(db, table_config, None, None).await? as i64;
         context.insert("finished_jobs_count", &finished_count);
 
         Ok(())


### PR DESCRIPTION
## Summary
- The nav badge's `finished_jobs_count` was computed as `total - scheduled - in_progress - failed - blocked`, which silently counted ready executions (queued but not yet started) as finished, inflating the badge.
- Switch to `query_builder::jobs::count_finished(...)` so the badge counts rows with `finished_at IS NOT NULL`, matching the total shown on the `/finished-jobs` page.

## Test plan
- [ ] `cargo clippy --all-targets --all-features` passes
- [ ] Manually verify: enqueue several jobs, let some finish, keep some ready/in-progress — the Finished jobs badge in the nav should match the count on `/finished-jobs`