### PR TITLE
feat(logger): expose add_quebec_context structlog processor

### DIFF
--- a/python/quebec/context.py
+++ b/python/quebec/context.py
@@ -1,0 +1,22 @@
+"""Per-job context shared between the worker, logger, and structlog integration.
+
+Kept in its own module so that ``quebec.logger`` and ``quebec.structlog`` can
+both depend on it without importing each other.
+"""
+
+import contextvars
+from dataclasses import dataclass
+
+__all__ = ["JobContext", "job_context_var"]
+
+
+@dataclass(frozen=True)
+class JobContext:
+    jid: str | None = None
+    queue: str | None = None
+    target: str | None = None
+
+
+job_context_var: contextvars.ContextVar[JobContext] = contextvars.ContextVar(
+    "job_context", default=JobContext()
+)

--- a/python/quebec/logger.py
+++ b/python/quebec/logger.py
@@ -1,20 +1,11 @@
 import logging
-import contextvars
-from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Optional
 
+from .context import JobContext, job_context_var
+from .structlog import add_quebec_context
 
-@dataclass(frozen=True)
-class JobContext:
-    jid: str | None = None
-    queue: str | None = None
-    target: str | None = None
-
-
-job_context_var: contextvars.ContextVar[JobContext] = contextvars.ContextVar(
-    "job_context", default=JobContext()
-)
+__all__ = ["JobContext", "job_context_var"]
 
 
 class ContextFilter(logging.Filter):
@@ -54,16 +45,6 @@ def setup_logging(level: int = logging.INFO, *, replace_root: bool = True) -> No
     handler.setFormatter(QuebecFormatter())
     handler.addFilter(ContextFilter())
     root.addHandler(handler)
-
-
-def _add_job_context(logger, method_name, event_dict):
-    """Processor to add job context (jid, target) from contextvars."""
-    ctx = job_context_var.get()
-    if ctx.jid:
-        event_dict["jid"] = ctx.jid
-    if "target" not in event_dict and ctx.target:
-        event_dict["target"] = ctx.target
-    return event_dict
 
 
 def _rename_event_to_message(logger, method_name, event_dict):
@@ -188,7 +169,7 @@ def setup_structlog(level: int = logging.INFO, *, format: str | None = None) -> 
 
     shared_processors = [
         structlog.contextvars.merge_contextvars,
-        _add_job_context,
+        add_quebec_context,
         structlog.processors.add_log_level,
         structlog.processors.CallsiteParameterAdder(
             [

--- a/python/quebec/structlog.py
+++ b/python/quebec/structlog.py
@@ -1,0 +1,40 @@
+"""Structlog integration for quebec.
+
+Plug ``add_quebec_context`` into your own structlog configuration so the
+per-job context set by the quebec worker shows up in your logs.
+
+Example:
+
+    import structlog
+    import quebec.structlog
+
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            quebec.structlog.add_quebec_context,
+            structlog.stdlib.add_log_level,
+            structlog.processors.JSONRenderer(),
+        ],
+    )
+"""
+
+from .context import job_context_var
+
+__all__ = ["add_quebec_context"]
+
+
+def add_quebec_context(logger, method_name, event_dict):
+    """Add quebec's JobContext fields (jid, queue, target) to the event dict.
+
+    Reads from the contextvar set by the quebec worker around each job
+    execution. Outside a worker the contextvar is empty, so this is a no-op.
+    Existing keys in ``event_dict`` are never overwritten.
+    """
+    ctx = job_context_var.get()
+    if "jid" not in event_dict and ctx.jid:
+        event_dict["jid"] = ctx.jid
+    if "queue" not in event_dict and ctx.queue:
+        event_dict["queue"] = ctx.queue
+    if "target" not in event_dict and ctx.target:
+        event_dict["target"] = ctx.target
+    return event_dict


### PR DESCRIPTION
## Summary
- Add `quebec.structlog.add_quebec_context` — a standalone structlog processor users can plug into their own `structlog.configure(...)` to pull quebec's per-job context (`jid`, `queue`, `target`) into their logs, without adopting quebec's `setup_structlog` formatter.
- Extract `JobContext` + `job_context_var` into a neutral `quebec.context` module so `logger.py` and `structlog.py` both depend on it without circular imports.
- `setup_structlog` now uses the exported processor; `JobContext` / `job_context_var` are re-exported from `quebec.logger` for backward compat.

## Usage
```python
import structlog
import quebec.structlog

structlog.configure(
    processors=[
        structlog.contextvars.merge_contextvars,
        quebec.structlog.add_quebec_context,
        structlog.stdlib.add_log_level,
        structlog.processors.JSONRenderer(),
    ],
)
```

## Test plan
- [ ] `ruff check python/` and `ruff format --check python/` pass
- [ ] Existing `setup_structlog` still emits `jid` / `queue` / `target` inside a worker-executed job
- [ ] Manually call `add_quebec_context` in a user-configured structlog pipeline and verify fields are merged when a `JobContext` is set, and it's a no-op outside a worker