### PR TITLE
feat(worker): make LISTEN/NOTIFY toggleable

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -280,6 +280,10 @@ pub struct AppContext {
     pub connect_options: ConnectOptions,     // For creating new connections
     pub name: String, // Application name for NOTIFY channel (default: "quebec")
     pub use_skip_locked: bool,
+    /// Enable PostgreSQL LISTEN/NOTIFY for low-latency job pickup.
+    /// Disable when running through transaction-pooling proxies (RDS Proxy,
+    /// PgBouncer transaction mode) that don't keep session state across queries.
+    pub use_listen_notify: bool,
     pub process_heartbeat_interval: Duration,
     pub process_alive_threshold: Duration,
     pub shutdown_timeout: Duration,
@@ -426,6 +430,9 @@ impl AppContext {
             if let Some(v) = get_bool("use_skip_locked") {
                 ctx.use_skip_locked = v;
             }
+            if let Some(v) = get_bool("use_listen_notify") {
+                ctx.use_listen_notify = v;
+            }
             if let Some(v) = get_duration("process_heartbeat_interval") {
                 ctx.process_heartbeat_interval = v;
             }
@@ -545,6 +552,7 @@ impl AppContext {
             connect_options,
             name: std::env::var("QUEBEC_NAME").unwrap_or_else(|_| "quebec".to_string()),
             use_skip_locked: true,
+            use_listen_notify: true,
             process_heartbeat_interval: Duration::from_secs(60),
             process_alive_threshold: Duration::from_secs(300),
             shutdown_timeout: Duration::from_secs(5),

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -2691,6 +2691,10 @@ impl Worker {
             info!("Non-PostgreSQL database detected, using polling only");
             return None;
         }
+        if !self.ctx.use_listen_notify {
+            info!("LISTEN/NOTIFY disabled by config, using polling only");
+            return None;
+        }
 
         info!("PostgreSQL detected, enabling LISTEN/NOTIFY for immediate job processing");
         let notify_manager = NotifyManager::new(self.ctx.clone());


### PR DESCRIPTION
## Summary
- Add `use_listen_notify` config option (default `true`) so users can disable PostgreSQL LISTEN/NOTIFY at startup.
- When disabled, workers fall back to polling only — required when running through transaction-pooling proxies (RDS Proxy, PgBouncer transaction mode) that don't keep session state across queries.
- Configurable via `Quebec(..., use_listen_notify=False)` kwarg or `QUEBEC_USE_LISTEN_NOTIFY=0` env var.

Default keeps current behavior (LISTEN auto-enabled on PostgreSQL), so this is a non-breaking change. When disabling, remember to lower `worker_polling_interval` to avoid the default 30s polling latency on PG.

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy --all-targets --all-features` — no new warnings
- [ ] Manual: run worker against PG with `QUEBEC_USE_LISTEN_NOTIFY=0`, verify log says "LISTEN/NOTIFY disabled by config" and jobs are still picked up via polling
- [ ] Manual: confirm default path (`use_listen_notify` unset) still logs "LISTEN started on '..._jobs' channel"