### PR TITLE
feat(api): return list of ActiveJob from perform_all_later

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -57,7 +57,7 @@ impl Quebec {
 
     pub async fn perform_all_later(
         &self,
-        jobs: Vec<PreparedJob>,
+        jobs: Arc<Vec<PreparedJob>>,
     ) -> Result<Vec<quebec_jobs::Model>> {
         if jobs.is_empty() {
             return Ok(vec![]);
@@ -71,6 +71,7 @@ impl Quebec {
                 let table_config = ctx.table_config.clone();
                 let duration = chrono::Duration::from_std(ctx.default_concurrency_control_period)
                     .unwrap_or_else(|_| chrono::Duration::seconds(60));
+                let jobs = Arc::clone(&jobs);
                 Box::pin(async move { enqueue_all_jobs(txn, &table_config, &jobs, duration).await })
             })
             .await

--- a/src/types.rs
+++ b/src/types.rs
@@ -1379,8 +1379,13 @@ impl PyQuebec {
     /// Each descriptor has: job_class, args, kwargs, options.
     /// All class attribute extraction, JSON serialization and concurrency
     /// resolution happens here (GIL held), then DB operations run with
-    /// GIL released.  Returns the number of enqueued jobs.
-    fn perform_all_later(&self, py: Python<'_>, descriptors: &Bound<'_, PyList>) -> PyResult<u64> {
+    /// GIL released.  Returns the enqueued ActiveJob objects (with `id`
+    /// populated), in the same order as the input descriptors.
+    fn perform_all_later(
+        &self,
+        py: Python<'_>,
+        descriptors: &Bound<'_, PyList>,
+    ) -> PyResult<Vec<ActiveJob>> {
         let start_time = Instant::now();
 
         // Phase 1 (GIL held): extract everything from Python JobDescriptor objects
@@ -1541,16 +1546,47 @@ impl PyQuebec {
 
         // Phase 2 (GIL released): perform database operations
         let quebec = self.quebec.clone();
-        let count = py
-            .detach(|| self.block_on(async move { quebec.perform_all_later(prepared).await }))
-            .map(|models| models.len() as u64)
+        let prepared = Arc::new(prepared);
+        let prepared_for_db = Arc::clone(&prepared);
+        let models = py
+            .detach(|| {
+                self.block_on(async move { quebec.perform_all_later(prepared_for_db).await })
+            })
             .map_err(|e| {
                 error!("perform_all_later error: {:?}", e);
                 pyo3::exceptions::PyRuntimeError::new_err(format!("Error: {:?}", e))
             })?;
 
-        debug!("Bulk enqueued {} jobs in {:?}", count, start_time.elapsed());
-        Ok(count)
+        let now = chrono::Utc::now().naive_utc();
+        let prepared = Arc::try_unwrap(prepared).unwrap_or_else(|arc| (*arc).clone());
+        let active_jobs: Vec<ActiveJob> = prepared
+            .into_iter()
+            .zip(models.iter())
+            .map(|(p, model)| ActiveJob {
+                logger: ActiveLogger::new(),
+                id: Some(model.id),
+                queue_name: p.queue_name,
+                class_name: p.class_name,
+                arguments: p.arguments,
+                priority: p.priority,
+                executions: 0,
+                active_job_id: p.active_job_id,
+                scheduled_at: p.scheduled_at.unwrap_or(now),
+                finished_at: None,
+                concurrency_key: p.concurrency_key,
+                concurrency_limit: p.concurrency_limit,
+                concurrency_on_conflict: p.concurrency_on_conflict,
+                created_at: Some(model.created_at),
+                updated_at: Some(model.updated_at),
+            })
+            .collect();
+
+        debug!(
+            "Bulk enqueued {} jobs in {:?}",
+            active_jobs.len(),
+            start_time.elapsed()
+        );
+        Ok(active_jobs)
     }
 
     fn __repr__(&self) -> PyResult<String> {

--- a/tests/test_bulk_enqueue_hooks.py
+++ b/tests/test_bulk_enqueue_hooks.py
@@ -31,7 +31,8 @@ def test_perform_all_later_does_not_trigger_enqueue_hooks(
     jobs = [TrackedBulkJob.build(i) for i in range(5)]
     inserted = qc.perform_all_later(jobs)
 
-    assert inserted == 5
+    assert len(inserted) == 5
+    assert all(job.id is not None for job in inserted)
     assert TrackedBulkJob.before_calls == 0
     assert TrackedBulkJob.after_calls == 0
     assert db_assert.count_jobs() == 5

--- a/tests/test_enqueue.py
+++ b/tests/test_enqueue.py
@@ -201,7 +201,14 @@ def test_perform_all_later_enqueues_multiple_descriptors(
         )
     ).fetchall()
 
-    assert inserted == 3
+    assert len(inserted) == 3
+    assert all(job.id is not None for job in inserted)
+    assert [job.id for job in inserted] == [
+        row.id
+        for row in session.execute(
+            text(f"SELECT id FROM {prefix}_jobs ORDER BY id")
+        ).fetchall()
+    ]
     assert len(rows) == 3
     assert rows[0].queue_name == "bulk-default"
     assert rows[0].priority == 0
@@ -216,3 +223,63 @@ def test_perform_all_later_enqueues_multiple_descriptors(
     assert db_assert.count_jobs() == 3
     assert db_assert.count_ready_executions() == 2
     assert db_assert.count_scheduled_executions() == 1
+
+
+def test_perform_all_later_returns_active_jobs_in_input_order(
+    qc_with_sqlalchemy,
+) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+    qc.register_job(BulkJob)
+
+    descriptors = [BulkJob.build(i) for i in range(5)]
+    inserted = qc.perform_all_later(descriptors)
+
+    assert len(inserted) == 5
+    assert all(isinstance(job, quebec.ActiveJob) for job in inserted)
+
+    ids = [job.id for job in inserted]
+    assert ids == sorted(ids)
+    assert len(set(ids)) == 5
+
+    for job in inserted:
+        assert job.queue_name == "bulk-default"
+        assert job.priority == 0
+        assert job.active_job_id
+
+    active_job_ids = [job.active_job_id for job in inserted]
+    assert len(set(active_job_ids)) == 5
+
+
+def test_perform_all_later_populates_overrides_on_returned_jobs(
+    qc_with_sqlalchemy,
+) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+    qc.register_job(BulkJob)
+
+    inserted = qc.perform_all_later(
+        [
+            BulkJob.build(1),
+            BulkJob.set(queue="critical", priority=9).build(2),
+            BulkJob.set(wait=timedelta(minutes=5)).build(3),
+        ]
+    )
+
+    assert inserted[0].queue_name == "bulk-default"
+    assert inserted[0].priority == 0
+
+    assert inserted[1].queue_name == "critical"
+    assert inserted[1].priority == 9
+
+    assert inserted[2].queue_name == "bulk-default"
+    # scheduled_at should reflect the wait offset (~5 minutes from now)
+    delta = inserted[2].scheduled_at - inserted[0].scheduled_at
+    assert delta >= timedelta(minutes=4, seconds=30)
+
+
+def test_perform_all_later_returns_empty_list_for_empty_input(
+    qc_with_sqlalchemy,
+) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+    qc.register_job(BulkJob)
+
+    assert qc.perform_all_later([]) == []


### PR DESCRIPTION
## Summary

- Change `qc.perform_all_later(descriptors)` return type from `int` (count) to `list[ActiveJob]`, aligning with `perform_later` which already returns an `ActiveJob`. Each returned job has `id`, `active_job_id`, `queue_name`, `priority`, `scheduled_at` populated and is in the same order as the input descriptors.
- Pass `Arc<Vec<PreparedJob>>` into `core::Quebec::perform_all_later` so the DB future shares the prepared payload with the post-call ActiveJob builder via a refcount bump, instead of deep-cloning N strings per job.
- Match Solid Queue's `enqueue_all` shape: callers needing a count use `len(result)`; callers needing per-job state get the full `ActiveJob` objects directly. Concurrency-`on_conflict: discard` rows still produce an `ActiveJob` in the list (matches current insert behavior — refining this is a follow-up).

## Test plan

- [x] `cargo check` / `cargo clippy --all-targets --all-features` / `cargo fmt --all -- --check`
- [x] `uv run --with maturin maturin develop`
- [x] `QUEBEC_SKIP_IMPORT_HOOK=1 uv run pytest --ignore=tests/step_defs` — 76 passed (full suite)
- [x] New cases:
  - `test_perform_all_later_returns_active_jobs_in_input_order` — list type, monotonic unique ids, ordered alignment
  - `test_perform_all_later_populates_overrides_on_returned_jobs` — `queue` / `priority` / `wait` propagate to returned `ActiveJob`
  - `test_perform_all_later_returns_empty_list_for_empty_input`