### PR TITLE
perf(scheduler): use INSERT ... RETURNING * to skip post-insert SELECT

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -311,7 +311,7 @@ where
     // Run the actual DB enqueue; on any error, close the around_enqueue generator
     let concurrency_key_str = concurrency_constraint.as_ref().map(|c| c.key.as_str());
     let db_result: Result<(crate::entities::quebec_jobs::Model, bool), DbErr> = async {
-        let job_id = query_builder::jobs::insert(
+        let job = query_builder::jobs::insert_returning(
             db,
             &ctx.table_config,
             queue_name,
@@ -323,10 +323,6 @@ where
             concurrency_key_str,
         )
         .await?;
-
-        let job = query_builder::jobs::find_by_id(db, &ctx.table_config, job_id)
-            .await?
-            .ok_or_else(|| DbErr::Custom("Failed to find inserted job".to_string()))?;
 
         let claimed = query_builder::recurring_executions::try_insert(
             db,


### PR DESCRIPTION
## Summary

Cut one round-trip per scheduler tick by replacing `jobs::insert + jobs::find_by_id` in `src/scheduler.rs::enqueue_job` with the already-existing `jobs::insert_returning` helper, which runs `INSERT … RETURNING *` on Postgres/SQLite and falls back to `INSERT + last_insert_id + SELECT` on MySQL (no regression on that backend). Saves **1–3 ms per tick** on PostgreSQL, end-to-end `scheduled_at → Job started` delay drops from 24–55 ms to 16–22 ms in the measured workload.

## Methodology

Temporary `Instant::now()` probes were added to three layers — worker claim path, Rust→Python bridge, scheduler enqueue tick — and removed after analysis. Per-stage breakdown (PostgreSQL on macOS, baseline):

| Stage | Time | Note |
|---|---|---|
| Worker `claim_jobs` (full tx) | 2–7 ms | BEGIN + select + ready FOR UPDATE + claimed INSERT + ready DELETE + COMMIT |
| **Worker total claim path** | **3–15 ms** | Not the dominant cost |
| Rust→Python bridge total | <200 µs | Negligible |
| Scheduler `jobs::insert` | 2–5 ms | INSERT roundtrip |
| Scheduler `jobs::find_by_id` | 1–3 ms | **Redundant SELECT after the INSERT** |
| Scheduler `recurring_executions::try_insert` | 2–4 ms | INSERT…ON CONFLICT |
| Scheduler `ready_executions::insert` | 2–4 ms | INSERT |
| Scheduler outer-tx overhead (BEGIN+COMMIT) | 3–8 ms | WAL fsync on COMMIT (physical floor) |
| **Scheduler `enqueue_us` total** | **11–30 ms** | Dominant contributor to user-visible delay |

The `INSERT` followed by `SELECT WHERE id = ?` to rehydrate the row is pure waste — both PostgreSQL and SQLite can return the inserted row directly via `INSERT … RETURNING *`, and `query_builder::jobs::insert_returning` already implements this.

## Results

Steady-state delay (`Job_started_at − scheduled_at`) on the same workload:

| Configuration | Steady-state delay | `enqueue_us` (steady) |
|---|---|---|
| Baseline | 24–55 ms | 11–30 ms |
| **+ `INSERT … RETURNING *` (this PR)** | **16–22 ms** | **8–18 ms** |
| + `synchronous_commit = off` (operator-side) | 13–14 ms | 5–12 ms |

The first 1–2 ticks after process start still show 26–30 ms cold-path latency — Postgres is JIT-planning prepared statements; not eliminated by either optimization.

## Out of scope

- **No CTE merging** — would diverge from Solid Queue's table-by-table flow Quebec mirrors
- **No batched scheduler enqueue** — would change `recurring_executions` ON-CONFLICT semantics
- **No worker-side change** — claim hot path (3–15 ms) isn't the dominant cost on this workload
- **`synchronous_commit = off`** is documented as an operator-side option, not enabled by Quebec itself

## Test plan

- [x] `cargo check` / `cargo clippy --all-targets --all-features` / `cargo fmt --all -- --check`
- [x] `uv run --with maturin maturin develop`
- [x] `QUEBEC_SKIP_IMPORT_HOOK=1 uv run pytest --ignore=tests/step_defs` — full suite passes
- [x] Manual: scheduled job timing measured on PostgreSQL before/after; numbers above