### PR TITLE
feat: fork-based multi-process supervisor (Solid Queue parity)

### DIFF
--- a/python/quebec/__init__.py
+++ b/python/quebec/__init__.py
@@ -5,6 +5,7 @@ from .quebec import Quebec, ActiveJob, JobInterrupted, InvalidStepError
 from .quebec import Continuable as _RustContinuable
 from .quebec import StepContext, StepContextManager
 import logging
+import os
 import time
 import queue
 import threading
@@ -490,19 +491,24 @@ def _quebec_run(
         control_plane: Control plane listen address, e.g. '127.0.0.1:5006'.
         spawn: List of components to spawn. Options: 'worker', 'dispatcher', 'scheduler'.
                None means spawn all components. Ignored when ``processes`` is set.
-        processes: If set (or if the loaded queue.yml declares multiple
-                   worker/dispatcher processes), run in fork-based supervisor
-                   mode. Accepts a dict like ``{"worker": 2, "dispatcher": 1,
-                   "scheduler": 1}``.
+        processes: If set, run in fork-based supervisor mode. Accepts a dict
+                   like ``{"worker": 2, "dispatcher": 1, "scheduler": 1}``.
+                   When unset, the call stays in single-process threaded mode
+                   for backward compatibility, even if ``queue.yml`` declares
+                   ``processes: >1``. Set ``QUEBEC_SUPERVISOR=1`` to opt in to
+                   auto-deriving the plan from ``queue.yml``.
 
     Example:
-        qc.run()  # Start all components and block
+        qc.run()  # Start all components and block (single-process mode)
         qc.run(create_tables=True)  # Create tables and start all
         qc.run(spawn=['worker'])  # Only start worker
         qc.run(processes={"worker": 4, "dispatcher": 1})  # Supervisor mode
     """
     plan = processes
-    if plan is None:
+    # Auto-deriving the plan from queue.yml is opt-in (QUEBEC_SUPERVISOR=1) so
+    # that an existing deployment with `processes: >1` does not silently switch
+    # from the single-process threaded runtime to fork-based supervision.
+    if plan is None and os.environ.get("QUEBEC_SUPERVISOR") == "1":
         try:
             plan = self.supervisor_plan_from_config()
         except Exception:

--- a/python/quebec/__init__.py
+++ b/python/quebec/__init__.py
@@ -447,6 +447,17 @@ def _quebec_wait(self):
 
     try:
         while not state["shutdown_event"].is_set():
+            # Detect supervisor death in fork-based mode: if Rust flagged us
+            # orphaned, unblock this wait loop so run() returns and the child
+            # can exit. `is_orphaned()` stays False unless `watch_parent_pid`
+            # was called, so the non-supervisor case is unaffected.
+            if self.is_orphaned():
+                logger.warning(
+                    "Supervisor went away (ppid changed), shutting down child"
+                )
+                state["shutdown_event"].set()
+                self.graceful_shutdown()
+                break
             time.sleep(0.5)
     except KeyboardInterrupt:
         logger.debug("KeyboardInterrupt, shutting down...")

--- a/python/quebec/__init__.py
+++ b/python/quebec/__init__.py
@@ -476,7 +476,6 @@ def _quebec_run(
     create_tables: bool = False,
     control_plane: Optional[str] = None,
     spawn: Optional[List[str]] = None,
-    processes: Optional[dict] = None,
 ):
     """Blocking run. Starts all components and waits until shutdown.
 
@@ -485,30 +484,36 @@ def _quebec_run(
     (workers.threads). The worker_threads constructor parameter can be used
     as an explicit override.
 
+    Fork-based supervisor mode is enabled by setting ``QUEBEC_SUPERVISOR=1``
+    in the environment. The plan is then derived from ``queue.yml`` —
+    ``workers[].processes`` and ``dispatchers[].processes`` decide how many
+    children to fork, and each child picks its config from the yml entry
+    matching its slot index. This matches Solid Queue's model.
+
+    For low-level use (tests, embedded services without a yml), construct
+    ``quebec.supervisor.Supervisor`` directly instead.
+
     Args:
         create_tables: Whether to create database tables (default False).
                        Set to True only if the current user has DDL permissions.
         control_plane: Control plane listen address, e.g. '127.0.0.1:5006'.
         spawn: List of components to spawn. Options: 'worker', 'dispatcher', 'scheduler'.
-               None means spawn all components. Ignored when ``processes`` is set.
-        processes: If set, run in fork-based supervisor mode. Accepts a dict
-                   like ``{"worker": 2, "dispatcher": 1, "scheduler": 1}``.
-                   When unset, the call stays in single-process threaded mode
-                   for backward compatibility, even if ``queue.yml`` declares
-                   ``processes: >1``. Set ``QUEBEC_SUPERVISOR=1`` to opt in to
-                   auto-deriving the plan from ``queue.yml``.
+               None means spawn all components. Ignored in supervisor mode.
 
     Example:
-        qc.run()  # Start all components and block (single-process mode)
-        qc.run(create_tables=True)  # Create tables and start all
-        qc.run(spawn=['worker'])  # Only start worker
-        qc.run(processes={"worker": 4, "dispatcher": 1})  # Supervisor mode
+        qc.run()  # Single-process mode (default)
+        qc.run(create_tables=True)
+        qc.run(spawn=['worker'])
+
+        # Fork-based supervisor:
+        #   queue.yml: workers.processes / dispatchers.processes
+        #   shell:    QUEBEC_SUPERVISOR=1 python -m quebec your.jobs
     """
-    plan = processes
-    # Auto-deriving the plan from queue.yml is opt-in (QUEBEC_SUPERVISOR=1) so
-    # that an existing deployment with `processes: >1` does not silently switch
-    # from the single-process threaded runtime to fork-based supervision.
-    if plan is None and os.environ.get("QUEBEC_SUPERVISOR") == "1":
+    plan = None
+    # Fork-based supervision is opt-in via QUEBEC_SUPERVISOR=1, so that an
+    # existing deployment with `processes: >1` in queue.yml does not silently
+    # switch from the single-process threaded runtime to fork mode on upgrade.
+    if os.environ.get("QUEBEC_SUPERVISOR") == "1":
         try:
             plan = self.supervisor_plan_from_config()
         except Exception:

--- a/python/quebec/__init__.py
+++ b/python/quebec/__init__.py
@@ -464,6 +464,7 @@ def _quebec_run(
     create_tables: bool = False,
     control_plane: Optional[str] = None,
     spawn: Optional[List[str]] = None,
+    processes: Optional[dict] = None,
 ):
     """Blocking run. Starts all components and waits until shutdown.
 
@@ -477,14 +478,34 @@ def _quebec_run(
                        Set to True only if the current user has DDL permissions.
         control_plane: Control plane listen address, e.g. '127.0.0.1:5006'.
         spawn: List of components to spawn. Options: 'worker', 'dispatcher', 'scheduler'.
-               None means spawn all components.
+               None means spawn all components. Ignored when ``processes`` is set.
+        processes: If set (or if the loaded queue.yml declares multiple
+                   worker/dispatcher processes), run in fork-based supervisor
+                   mode. Accepts a dict like ``{"worker": 2, "dispatcher": 1,
+                   "scheduler": 1}``.
 
     Example:
         qc.run()  # Start all components and block
         qc.run(create_tables=True)  # Create tables and start all
         qc.run(spawn=['worker'])  # Only start worker
-        qc.run(spawn=['worker', 'dispatcher'], control_plane='127.0.0.1:5006')
+        qc.run(processes={"worker": 4, "dispatcher": 1})  # Supervisor mode
     """
+    plan = processes
+    if plan is None:
+        try:
+            plan = self.supervisor_plan_from_config()
+        except Exception:
+            plan = None
+
+    if plan:
+        from .supervisor import Supervisor
+
+        if create_tables:
+            self.create_tables()
+        sup = Supervisor(self, plan, control_plane=control_plane)
+        sup.start()
+        return
+
     self.start(
         create_tables=create_tables,
         control_plane=control_plane,

--- a/python/quebec/supervisor.py
+++ b/python/quebec/supervisor.py
@@ -201,6 +201,8 @@ class Supervisor:
                 os.close(self._wakeup_w)
 
                 self.qc.reset_after_fork()
+                # Record ppid so role loops self-terminate if supervisor dies.
+                self.qc.watch_parent_pid()
 
                 if role == ROLE_WORKER:
                     try:

--- a/python/quebec/supervisor.py
+++ b/python/quebec/supervisor.py
@@ -66,7 +66,7 @@ class Supervisor:
         plan: Plan,
         *,
         control_plane: Optional[str] = None,
-        shutdown_timeout: float = 30.0,
+        shutdown_timeout: Optional[float] = None,
         crash_loop_window: float = 10.0,
         crash_loop_max: int = 3,
         heartbeat_interval: float = 60.0,
@@ -88,7 +88,10 @@ class Supervisor:
         self.qc = qc
         self.plan = normalized
         self.control_plane = control_plane
-        self.shutdown_timeout = shutdown_timeout
+        # Match Solid Queue's default (`SolidQueue.shutdown_timeout = 5`).
+        self.shutdown_timeout = (
+            shutdown_timeout if shutdown_timeout is not None else 5.0
+        )
         self.crash_loop_window = crash_loop_window
         self.crash_loop_max = crash_loop_max
         self.heartbeat_interval = heartbeat_interval

--- a/python/quebec/supervisor.py
+++ b/python/quebec/supervisor.py
@@ -98,6 +98,7 @@ class Supervisor:
         self._children: Dict[int, _ChildInfo] = {}
         self._slots: Dict[Tuple[str, int], _SlotState] = {}
         self._stopping = False
+        self._immediate = False
         self._hostname = socket.gethostname()
         self._wakeup_r, self._wakeup_w = os.pipe()
         os.set_blocking(self._wakeup_r, False)
@@ -160,13 +161,25 @@ class Supervisor:
     # -- internals --------------------------------------------------------
 
     def _install_signal_handlers(self) -> None:
-        def handler(signum, _frame):
+        def graceful(signum, _frame):
             logger.info("Supervisor received signal %d", signum)
             self._stopping = True
             self._wake()
 
-        for sig in (signal.SIGTERM, signal.SIGINT, signal.SIGQUIT):
-            signal.signal(sig, handler)
+        # SIGQUIT skips the graceful-wait window and SIGKILLs children at once.
+        # Mirrors Solid Queue's terminate_immediately path for the QUIT signal.
+        def immediate(signum, _frame):
+            logger.warning(
+                "Supervisor received signal %d, terminating children immediately",
+                signum,
+            )
+            self._stopping = True
+            self._immediate = True
+            self._wake()
+
+        signal.signal(signal.SIGTERM, graceful)
+        signal.signal(signal.SIGINT, graceful)
+        signal.signal(signal.SIGQUIT, immediate)
 
     def _wake(self) -> None:
         try:
@@ -372,14 +385,21 @@ class Supervisor:
         if not pids:
             return
 
-        logger.info("Supervisor sending SIGTERM to %d child(ren)", len(pids))
+        if self._immediate:
+            # SIGQUIT path: skip the SIGTERM wait entirely.
+            sig_first, sig_name = signal.SIGKILL, "SIGKILL"
+            deadline = time.monotonic()
+        else:
+            sig_first, sig_name = signal.SIGTERM, "SIGTERM"
+            deadline = time.monotonic() + self.shutdown_timeout
+
+        logger.info("Supervisor sending %s to %d child(ren)", sig_name, len(pids))
         for pid in pids:
             try:
-                os.kill(pid, signal.SIGTERM)
+                os.kill(pid, sig_first)
             except ProcessLookupError:
                 self._children.pop(pid, None)
 
-        deadline = time.monotonic() + self.shutdown_timeout
         while self._children and time.monotonic() < deadline:
             pid = self._reap_one(block=False)
             if pid == 0:

--- a/python/quebec/supervisor.py
+++ b/python/quebec/supervisor.py
@@ -115,16 +115,19 @@ class Supervisor:
         )
         self._install_signal_handlers()
 
-        if self.control_plane:
-            try:
-                self.qc.start_control_plane(self.control_plane)
-            except Exception:
-                logger.exception("Failed to start control plane")
-
         try:
             for role, count in self.plan.items():
                 for index in range(count):
                     self._fork_child(role, index)
+
+            # Start the control plane only after all children are forked so
+            # the listening socket/runtime task stays parent-only. Children
+            # would otherwise inherit the TcpListener fd.
+            if self.control_plane:
+                try:
+                    self.qc.start_control_plane(self.control_plane)
+                except Exception:
+                    logger.exception("Failed to start control plane")
 
             self._start_heartbeat()
             self._supervise()

--- a/python/quebec/supervisor.py
+++ b/python/quebec/supervisor.py
@@ -388,28 +388,25 @@ class Supervisor:
         if not pids:
             return
 
+        # Solid Queue mirror:
+        #   * SIGTERM phase (graceful) -> wait shutdown_timeout
+        #   * SIGQUIT phase (terminate_immediately) -> children call exit(0)
+        #     via the supervised SIGQUIT handler in src/types.rs
+        #   * SIGKILL is a final safety net for processes wedged in C code that
+        #     never reach the SIGQUIT handler (Solid Queue stops at SIGQUIT and
+        #     leaves wedged children to init).
         if self._immediate:
-            # SIGQUIT path: skip the SIGTERM wait entirely.
-            sig_first, sig_name = signal.SIGKILL, "SIGKILL"
-            deadline = time.monotonic()
+            self._kill_children(pids, signal.SIGQUIT, "SIGQUIT")
         else:
-            sig_first, sig_name = signal.SIGTERM, "SIGTERM"
-            deadline = time.monotonic() + self.shutdown_timeout
+            self._kill_children(pids, signal.SIGTERM, "SIGTERM")
+            self._reap_until(deadline=time.monotonic() + self.shutdown_timeout)
+            if self._children:
+                self._kill_children(
+                    list(self._children.keys()), signal.SIGQUIT, "SIGQUIT"
+                )
 
-        logger.info("Supervisor sending %s to %d child(ren)", sig_name, len(pids))
-        for pid in pids:
-            try:
-                os.kill(pid, sig_first)
-            except ProcessLookupError:
-                self._children.pop(pid, None)
-
-        while self._children and time.monotonic() < deadline:
-            pid = self._reap_one(block=False)
-            if pid == 0:
-                time.sleep(0.1)
-                continue
-            info = self._children.pop(pid, None)
-            self._fail_claimed_for_pid(pid, info)
+        # Short window for SIGQUIT handlers to run before final SIGKILL.
+        self._reap_until(deadline=time.monotonic() + 1.0)
 
         remaining = list(self._children.keys())
         for pid in remaining:
@@ -423,5 +420,22 @@ class Supervisor:
             pid = self._reap_one(block=True)
             if pid == 0:
                 break
+            info = self._children.pop(pid, None)
+            self._fail_claimed_for_pid(pid, info)
+
+    def _kill_children(self, pids: List[int], sig: int, sig_name: str) -> None:
+        logger.info("Supervisor sending %s to %d child(ren)", sig_name, len(pids))
+        for pid in pids:
+            try:
+                os.kill(pid, sig)
+            except ProcessLookupError:
+                self._children.pop(pid, None)
+
+    def _reap_until(self, *, deadline: float) -> None:
+        while self._children and time.monotonic() < deadline:
+            pid = self._reap_one(block=False)
+            if pid == 0:
+                time.sleep(0.1)
+                continue
             info = self._children.pop(pid, None)
             self._fail_claimed_for_pid(pid, info)

--- a/python/quebec/supervisor.py
+++ b/python/quebec/supervisor.py
@@ -1,0 +1,369 @@
+"""Fork-based multi-process supervisor for Quebec.
+
+Mirrors the Solid Queue supervisor model: a parent process forks one child per
+role-instance (worker / dispatcher / scheduler), monitors them via waitpid,
+restarts crashes, and on shutdown sends SIGTERM then SIGKILL after a timeout.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import select
+import signal
+import socket
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple, Union
+
+logger = logging.getLogger(__name__)
+
+ROLE_WORKER = "worker"
+ROLE_DISPATCHER = "dispatcher"
+ROLE_SCHEDULER = "scheduler"
+VALID_ROLES = {ROLE_WORKER, ROLE_DISPATCHER, ROLE_SCHEDULER}
+
+Plan = Dict[str, Union[int, List]]
+
+
+@dataclass
+class _ChildInfo:
+    role: str
+    index: int
+    pid: int
+
+
+@dataclass
+class _SlotState:
+    """Restart history for a (role, index) slot."""
+
+    spawn_times: List[float] = field(default_factory=list)
+    disabled: bool = False
+
+
+class Supervisor:
+    """Fork-based supervisor.
+
+    Args:
+        qc: The Quebec instance whose config/registries the children inherit.
+        plan: Mapping of role -> child count. Example:
+            ``{"worker": 2, "dispatcher": 1, "scheduler": 1}``.
+            The role keys must be one of ``worker``, ``dispatcher``, ``scheduler``.
+        control_plane: If set, the HTTP listen address (e.g. ``"127.0.0.1:5006"``).
+            The control plane runs only in the supervisor process.
+        shutdown_timeout: Seconds to wait for children to exit after SIGTERM
+            before escalating to SIGKILL.
+        crash_loop_window / crash_loop_max: A slot that crashes more than
+            ``crash_loop_max`` times in ``crash_loop_window`` seconds is
+            considered unhealthy; auto-restart is disabled for that slot.
+        heartbeat_interval: Seconds between supervisor heartbeats to the DB.
+    """
+
+    def __init__(
+        self,
+        qc,
+        plan: Plan,
+        *,
+        control_plane: Optional[str] = None,
+        shutdown_timeout: float = 30.0,
+        crash_loop_window: float = 10.0,
+        crash_loop_max: int = 3,
+        heartbeat_interval: float = 60.0,
+    ):
+        normalized: Dict[str, int] = {}
+        for role, spec in plan.items():
+            if role not in VALID_ROLES:
+                raise ValueError(
+                    f"unknown role {role!r}; must be one of {sorted(VALID_ROLES)}"
+                )
+            count = spec if isinstance(spec, int) else len(spec)
+            if count <= 0:
+                continue
+            normalized[role] = count
+        if not normalized:
+            raise ValueError("plan must spawn at least one child process")
+
+        self.qc = qc
+        self.plan = normalized
+        self.control_plane = control_plane
+        self.shutdown_timeout = shutdown_timeout
+        self.crash_loop_window = crash_loop_window
+        self.crash_loop_max = crash_loop_max
+        self.heartbeat_interval = heartbeat_interval
+
+        self._process_id: Optional[int] = None
+        self._children: Dict[int, _ChildInfo] = {}
+        self._slots: Dict[Tuple[str, int], _SlotState] = {}
+        self._stopping = False
+        self._hostname = socket.gethostname()
+        self._wakeup_r, self._wakeup_w = os.pipe()
+        os.set_blocking(self._wakeup_r, False)
+        os.set_blocking(self._wakeup_w, False)
+        self._heartbeat_thread: Optional[threading.Thread] = None
+        self._heartbeat_stop = threading.Event()
+
+    # -- public -----------------------------------------------------------
+
+    def start(self) -> None:
+        """Blocking entrypoint: register, fork children, supervise, cleanup."""
+        self._process_id = self.qc.register_supervisor()
+        logger.info(
+            "Supervisor registered (process_id=%d, pid=%d)",
+            self._process_id,
+            os.getpid(),
+        )
+        self._install_signal_handlers()
+
+        if self.control_plane:
+            try:
+                self.qc.start_control_plane(self.control_plane)
+            except Exception:
+                logger.exception("Failed to start control plane")
+
+        try:
+            for role, count in self.plan.items():
+                for index in range(count):
+                    self._fork_child(role, index)
+
+            self._start_heartbeat()
+            self._supervise()
+        finally:
+            try:
+                self._terminate_gracefully()
+            finally:
+                self._heartbeat_stop.set()
+                if self._heartbeat_thread is not None:
+                    self._heartbeat_thread.join(timeout=2.0)
+                if self._process_id is not None:
+                    try:
+                        self.qc.deregister_process(self._process_id)
+                    except Exception:
+                        logger.exception("Failed to deregister supervisor row")
+
+    def stop(self) -> None:
+        """Request a graceful shutdown from another thread."""
+        self._stopping = True
+        self._wake()
+
+    # -- internals --------------------------------------------------------
+
+    def _install_signal_handlers(self) -> None:
+        def handler(signum, _frame):
+            logger.info("Supervisor received signal %d", signum)
+            self._stopping = True
+            self._wake()
+
+        for sig in (signal.SIGTERM, signal.SIGINT, signal.SIGQUIT):
+            signal.signal(sig, handler)
+
+    def _wake(self) -> None:
+        try:
+            os.write(self._wakeup_w, b"x")
+        except BlockingIOError:
+            pass
+        except OSError:
+            pass
+
+    def _start_heartbeat(self) -> None:
+        def loop():
+            while not self._heartbeat_stop.wait(self.heartbeat_interval):
+                try:
+                    self.qc.heartbeat_process(self._process_id)
+                except Exception as e:
+                    logger.warning("Supervisor heartbeat failed: %s", e)
+
+        self._heartbeat_thread = threading.Thread(
+            target=loop, name="quebec-supervisor-heartbeat", daemon=True
+        )
+        self._heartbeat_thread.start()
+
+    def _fork_child(self, role: str, index: int) -> None:
+        slot = self._slots.setdefault((role, index), _SlotState())
+        if slot.disabled:
+            logger.warning("Slot (%s, %d) disabled; skipping restart", role, index)
+            return
+
+        now = time.monotonic()
+        slot.spawn_times = [
+            t for t in slot.spawn_times if now - t <= self.crash_loop_window
+        ]
+        slot.spawn_times.append(now)
+
+        pid = os.fork()
+        if pid == 0:
+            # --- child ---
+            try:
+                signal.signal(signal.SIGTERM, signal.SIG_DFL)
+                signal.signal(signal.SIGINT, signal.SIG_DFL)
+                signal.signal(signal.SIGQUIT, signal.SIG_DFL)
+                os.close(self._wakeup_r)
+                os.close(self._wakeup_w)
+
+                self.qc.reset_after_fork()
+
+                if role == ROLE_WORKER:
+                    try:
+                        self.qc.apply_worker_config(index)
+                    except IndexError:
+                        pass  # No config file / single worker case
+                    except Exception:
+                        logger.exception(
+                            "apply_worker_config(%d) failed in child", index
+                        )
+                    self.qc.run(spawn=["worker"], create_tables=False)
+                elif role == ROLE_DISPATCHER:
+                    try:
+                        self.qc.apply_dispatcher_config(index)
+                    except IndexError:
+                        pass
+                    except Exception:
+                        logger.exception(
+                            "apply_dispatcher_config(%d) failed in child", index
+                        )
+                    self.qc.run(spawn=["dispatcher"], create_tables=False)
+                elif role == ROLE_SCHEDULER:
+                    self.qc.run(spawn=["scheduler"], create_tables=False)
+                else:
+                    raise ValueError(f"unknown role {role!r}")
+                os._exit(0)
+            except SystemExit as e:
+                code = e.code if isinstance(e.code, int) else 0
+                os._exit(code)
+            except BaseException:
+                logger.exception("Child (%s, %d) crashed", role, index)
+                os._exit(1)
+        else:
+            # --- parent ---
+            logger.info("Forked %s[%d] as pid=%d", role, index, pid)
+            self._children[pid] = _ChildInfo(role=role, index=index, pid=pid)
+
+    def _supervise(self) -> None:
+        while not self._stopping:
+            pid = self._reap_one(block=False)
+            if pid == 0:
+                self._interruptible_sleep(1.0)
+                continue
+            self._handle_exit(pid)
+
+    def _reap_one(self, *, block: bool) -> int:
+        """Return a reaped child pid, or 0 if none (when non-blocking)."""
+        flags = 0 if block else os.WNOHANG
+        try:
+            pid, _status = os.waitpid(-1, flags)
+            return pid
+        except ChildProcessError:
+            return 0
+
+    def _fail_claimed_for_pid(self, pid: int, info: Optional[_ChildInfo]) -> None:
+        """Best-effort: mark any claimed jobs owned by a dead child as failed.
+
+        Safe to call on cleanly exited children — a worker that completed its
+        own `on_stop` will have already released its claims and deleted its
+        process row, so this becomes a no-op. Essential on the SIGKILL path
+        where the child never got to run its cleanup.
+        """
+        try:
+            failed = self.qc.supervisor_fail_claimed_by_pid(pid, self._hostname)
+            if failed:
+                if info is not None:
+                    logger.info(
+                        "Marked %d claimed job(s) failed for %s[%d] pid=%d",
+                        failed,
+                        info.role,
+                        info.index,
+                        pid,
+                    )
+                else:
+                    logger.info(
+                        "Marked %d claimed job(s) failed for pid=%d", failed, pid
+                    )
+        except Exception:
+            if info is not None:
+                logger.exception(
+                    "Failed to mark claimed jobs for %s[%d] pid=%d",
+                    info.role,
+                    info.index,
+                    pid,
+                )
+            else:
+                logger.exception("Failed to mark claimed jobs for pid=%d", pid)
+
+    def _handle_exit(self, pid: int) -> None:
+        info = self._children.pop(pid, None)
+        if info is None:
+            logger.warning("Reaped unknown pid=%d", pid)
+            return
+        logger.warning(
+            "Child %s[%d] (pid=%d) exited unexpectedly", info.role, info.index, pid
+        )
+
+        self._fail_claimed_for_pid(pid, info)
+
+        if self._stopping:
+            return
+
+        slot = self._slots.get((info.role, info.index))
+        if slot is not None:
+            now = time.monotonic()
+            recent = [t for t in slot.spawn_times if now - t <= self.crash_loop_window]
+            if len(recent) >= self.crash_loop_max:
+                slot.disabled = True
+                logger.error(
+                    "Slot (%s, %d) crashed %d times in %.0fs; disabling auto-restart",
+                    info.role,
+                    info.index,
+                    len(recent),
+                    self.crash_loop_window,
+                )
+                return
+
+        self._fork_child(info.role, info.index)
+
+    def _interruptible_sleep(self, seconds: float) -> None:
+        try:
+            r, _, _ = select.select([self._wakeup_r], [], [], seconds)
+            if r:
+                try:
+                    while True:
+                        os.read(self._wakeup_r, 4096)
+                except BlockingIOError:
+                    pass
+        except InterruptedError:
+            pass
+
+    def _terminate_gracefully(self) -> None:
+        pids = list(self._children.keys())
+        if not pids:
+            return
+
+        logger.info("Supervisor sending SIGTERM to %d child(ren)", len(pids))
+        for pid in pids:
+            try:
+                os.kill(pid, signal.SIGTERM)
+            except ProcessLookupError:
+                self._children.pop(pid, None)
+
+        deadline = time.monotonic() + self.shutdown_timeout
+        while self._children and time.monotonic() < deadline:
+            pid = self._reap_one(block=False)
+            if pid == 0:
+                time.sleep(0.1)
+                continue
+            info = self._children.pop(pid, None)
+            self._fail_claimed_for_pid(pid, info)
+
+        remaining = list(self._children.keys())
+        for pid in remaining:
+            logger.warning("Shutdown timeout; SIGKILLing pid=%d", pid)
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
+        while self._children:
+            pid = self._reap_one(block=True)
+            if pid == 0:
+                break
+            info = self._children.pop(pid, None)
+            self._fail_claimed_for_pid(pid, info)

--- a/python/quebec/supervisor.py
+++ b/python/quebec/supervisor.py
@@ -70,6 +70,7 @@ class Supervisor:
         crash_loop_window: float = 10.0,
         crash_loop_max: int = 3,
         heartbeat_interval: float = 60.0,
+        maintenance_interval: float = 300.0,
     ):
         normalized: Dict[str, int] = {}
         for role, spec in plan.items():
@@ -91,6 +92,7 @@ class Supervisor:
         self.crash_loop_window = crash_loop_window
         self.crash_loop_max = crash_loop_max
         self.heartbeat_interval = heartbeat_interval
+        self.maintenance_interval = maintenance_interval
 
         self._process_id: Optional[int] = None
         self._children: Dict[int, _ChildInfo] = {}
@@ -102,6 +104,8 @@ class Supervisor:
         os.set_blocking(self._wakeup_w, False)
         self._heartbeat_thread: Optional[threading.Thread] = None
         self._heartbeat_stop = threading.Event()
+        self._maintenance_thread: Optional[threading.Thread] = None
+        self._maintenance_stop = threading.Event()
 
     # -- public -----------------------------------------------------------
 
@@ -130,14 +134,18 @@ class Supervisor:
                     logger.exception("Failed to start control plane")
 
             self._start_heartbeat()
+            self._start_maintenance()
             self._supervise()
         finally:
             try:
                 self._terminate_gracefully()
             finally:
                 self._heartbeat_stop.set()
+                self._maintenance_stop.set()
                 if self._heartbeat_thread is not None:
                     self._heartbeat_thread.join(timeout=2.0)
+                if self._maintenance_thread is not None:
+                    self._maintenance_thread.join(timeout=2.0)
                 if self._process_id is not None:
                     try:
                         self.qc.deregister_process(self._process_id)
@@ -180,6 +188,28 @@ class Supervisor:
             target=loop, name="quebec-supervisor-heartbeat", daemon=True
         )
         self._heartbeat_thread.start()
+
+    def _start_maintenance(self) -> None:
+        def loop():
+            while not self._maintenance_stop.wait(self.maintenance_interval):
+                try:
+                    pruned, orphaned = self.qc.supervisor_run_maintenance(
+                        self._process_id
+                    )
+                    if pruned or orphaned:
+                        logger.info(
+                            "Supervisor maintenance: pruned %d process(es), "
+                            "failed %d orphaned claim(s)",
+                            pruned,
+                            orphaned,
+                        )
+                except Exception as e:
+                    logger.warning("Supervisor maintenance failed: %s", e)
+
+        self._maintenance_thread = threading.Thread(
+            target=loop, name="quebec-supervisor-maintenance", daemon=True
+        )
+        self._maintenance_thread.start()
 
     def _fork_child(self, role: str, index: int) -> None:
         slot = self._slots.setdefault((role, index), _SlotState())

--- a/python/quebec/supervisor.py
+++ b/python/quebec/supervisor.py
@@ -205,22 +205,30 @@ class Supervisor:
         )
         self._heartbeat_thread.start()
 
+    def _run_maintenance_once(self) -> None:
+        try:
+            pruned, orphaned = self.qc.supervisor_run_maintenance(self._process_id)
+            if pruned or orphaned:
+                logger.info(
+                    "Supervisor maintenance: pruned %d process(es), "
+                    "failed %d orphaned claim(s)",
+                    pruned,
+                    orphaned,
+                )
+        except Exception as e:
+            logger.warning("Supervisor maintenance failed: %s", e)
+
     def _start_maintenance(self) -> None:
+        # Solid Queue runs `fail_orphaned_executions` once at boot and starts
+        # the prune timer with `run_now: true`. Mirror that by sweeping
+        # immediately before the periodic loop so a fresh supervisor cleans up
+        # stale state from the previous instance instead of waiting one full
+        # interval.
+        self._run_maintenance_once()
+
         def loop():
             while not self._maintenance_stop.wait(self.maintenance_interval):
-                try:
-                    pruned, orphaned = self.qc.supervisor_run_maintenance(
-                        self._process_id
-                    )
-                    if pruned or orphaned:
-                        logger.info(
-                            "Supervisor maintenance: pruned %d process(es), "
-                            "failed %d orphaned claim(s)",
-                            pruned,
-                            orphaned,
-                        )
-                except Exception as e:
-                    logger.warning("Supervisor maintenance failed: %s", e)
+                self._run_maintenance_once()
 
         self._maintenance_thread = threading.Thread(
             target=loop, name="quebec-supervisor-maintenance", daemon=True

--- a/src/config.rs
+++ b/src/config.rs
@@ -223,6 +223,9 @@ pub struct DispatcherConfig {
 
     /// Whether to perform concurrency maintenance
     pub concurrency_maintenance: Option<bool>,
+
+    /// Number of processes to fork (supervisor mode)
+    pub processes: Option<u32>,
 }
 
 #[cfg(feature = "python")]
@@ -246,6 +249,11 @@ impl DispatcherConfig {
     #[getter]
     fn concurrency_maintenance(&self) -> Option<bool> {
         self.concurrency_maintenance
+    }
+
+    #[getter]
+    fn processes(&self) -> Option<u32> {
+        self.processes
     }
 
     fn __repr__(&self) -> String {

--- a/src/context.rs
+++ b/src/context.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "python")]
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use tokio::runtime::Handle;
@@ -305,6 +306,11 @@ pub struct AppContext {
     pub table_config: TableConfig, // Dynamic table name configuration
     /// Optional notifier for idle worker threads - when set, signals main loop to poll for new jobs
     pub idle_notify: Arc<RwLock<Option<Arc<Notify>>>>,
+    /// Supervisor PID recorded right after fork. When non-zero, the role loops
+    /// periodically compare `getppid()` against it and trigger graceful shutdown
+    /// if it no longer matches (i.e. the supervisor died and we got reparented
+    /// to init/launchd). Zero means "not supervised, do not check".
+    pub supervisor_pid: AtomicI32,
 }
 
 /// Parse env var string as bool: true/1/yes → true, false/0/no → false
@@ -569,7 +575,29 @@ impl AppContext {
             runtime_handle: None,
             table_config: TableConfig::default(),
             idle_notify: Arc::new(RwLock::new(None)),
+            supervisor_pid: AtomicI32::new(0),
         }
+    }
+
+    /// Record the current parent PID so role loops can detect supervisor death.
+    /// Intended to be called from a forked child right after `reset_after_fork`
+    /// (mirrors Solid Queue's `Supervised#supervised_by`). A zero PID disables
+    /// the check (e.g. a standalone library user has no supervisor to watch).
+    pub fn watch_parent_pid(&self) {
+        let ppid = unsafe { libc::getppid() };
+        self.supervisor_pid.store(ppid, Ordering::Relaxed);
+    }
+
+    /// Whether we were reparented since `watch_parent_pid` was called.
+    /// Returns false when `watch_parent_pid` has not been invoked (the common
+    /// single-process library case).
+    pub fn is_orphaned(&self) -> bool {
+        let stored = self.supervisor_pid.load(Ordering::Relaxed);
+        if stored == 0 {
+            return false;
+        }
+        let current = unsafe { libc::getppid() };
+        current != stored
     }
 
     pub fn set_runtime_handle(&mut self, handle: Handle) {
@@ -622,6 +650,8 @@ impl AppContext {
             runtime_handle: Some(runtime_handle),
             table_config: self.table_config.clone(),
             idle_notify: Arc::new(RwLock::new(None)),
+            // Fresh state; child must call `watch_parent_pid` after fork.
+            supervisor_pid: AtomicI32::new(0),
         }
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -580,6 +580,51 @@ impl AppContext {
         self.runtime_handle.clone()
     }
 
+    /// Produce a new `AppContext` suitable for a freshly forked child process.
+    ///
+    /// - Replaces the database connection and runtime handle with the caller-provided values.
+    /// - Creates fresh `CancellationToken`s (the parent's tokens may already be cancelled
+    ///   or associated with dropped tokio tasks).
+    /// - Clears the `idle_notify` slot (the old `Notify` is tied to the parent runtime).
+    /// - Preserves all configuration values and the shared registries
+    ///   (`runnables`, `concurrency_enabled`) so Python-side job class registrations
+    ///   keep working without re-registering in the child.
+    pub fn fork_clone(&self, db: Option<Arc<DatabaseConnection>>, runtime_handle: Handle) -> Self {
+        Self {
+            cwd: self.cwd.clone(),
+            dsn: self.dsn.clone(),
+            db,
+            connect_options: self.connect_options.clone(),
+            name: self.name.clone(),
+            use_skip_locked: self.use_skip_locked,
+            process_heartbeat_interval: self.process_heartbeat_interval,
+            process_alive_threshold: self.process_alive_threshold,
+            shutdown_timeout: self.shutdown_timeout,
+            silence_polling: self.silence_polling,
+            preserve_finished_jobs: self.preserve_finished_jobs,
+            clear_finished_jobs_after: self.clear_finished_jobs_after,
+            cleanup_batch_size: self.cleanup_batch_size,
+            cleanup_interval: self.cleanup_interval,
+            default_concurrency_control_period: self.default_concurrency_control_period,
+            dispatcher_polling_interval: self.dispatcher_polling_interval,
+            dispatcher_batch_size: self.dispatcher_batch_size,
+            dispatcher_concurrency_maintenance_interval: self
+                .dispatcher_concurrency_maintenance_interval,
+            worker_polling_interval: self.worker_polling_interval,
+            worker_threads: self.worker_threads,
+            control_plane_sse_interval: self.control_plane_sse_interval,
+            worker_queues: self.worker_queues.clone(),
+            graceful_shutdown: CancellationToken::new(),
+            force_quit: CancellationToken::new(),
+            #[cfg(feature = "python")]
+            runnables: self.runnables.clone(),
+            concurrency_enabled: self.concurrency_enabled.clone(),
+            runtime_handle: Some(runtime_handle),
+            table_config: self.table_config.clone(),
+            idle_notify: Arc::new(RwLock::new(None)),
+        }
+    }
+
     async fn get_db_inner(&self) -> Result<Arc<DatabaseConnection>, DbErr> {
         if let Some(db) = &self.db {
             return Ok(Arc::clone(db));

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -36,6 +36,12 @@ impl Dispatcher {
         let mut polling_interval = tokio::time::interval(self.ctx.dispatcher_polling_interval);
         let mut heartbeat_interval = tokio::time::interval(self.ctx.process_heartbeat_interval);
         // Orphan check: detect supervisor death via ppid change (Solid Queue parity).
+        // Only armed when running as a supervisor-managed child.
+        let supervised = self
+            .ctx
+            .supervisor_pid
+            .load(std::sync::atomic::Ordering::Relaxed)
+            != 0;
         let mut parent_check_interval = tokio::time::interval(std::time::Duration::from_secs(1));
         let batch_size = self.ctx.dispatcher_batch_size;
 
@@ -55,7 +61,7 @@ impl Dispatcher {
                     self.heartbeat(&heartbeat_db, &process).await?;
                 }
                 // Detect supervisor death: if our ppid changed we were reparented.
-                _ = parent_check_interval.tick() => {
+                _ = parent_check_interval.tick(), if supervised => {
                     if self.ctx.is_orphaned() {
                         warn!("Supervisor went away (ppid changed), initiating graceful shutdown");
                         self.ctx.graceful_shutdown.cancel();

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -35,6 +35,8 @@ impl Dispatcher {
     pub async fn run(&self) -> Result<(), anyhow::Error> {
         let mut polling_interval = tokio::time::interval(self.ctx.dispatcher_polling_interval);
         let mut heartbeat_interval = tokio::time::interval(self.ctx.process_heartbeat_interval);
+        // Orphan check: detect supervisor death via ppid change (Solid Queue parity).
+        let mut parent_check_interval = tokio::time::interval(std::time::Duration::from_secs(1));
         let batch_size = self.ctx.dispatcher_batch_size;
 
         let init_db = self.ctx.get_db().await?;
@@ -51,6 +53,13 @@ impl Dispatcher {
                         warn!("Failed to get DB for heartbeat: {}", e);
                     }) else { continue };
                     self.heartbeat(&heartbeat_db, &process).await?;
+                }
+                // Detect supervisor death: if our ppid changed we were reparented.
+                _ = parent_check_interval.tick() => {
+                    if self.ctx.is_orphaned() {
+                        warn!("Supervisor went away (ppid changed), initiating graceful shutdown");
+                        self.ctx.graceful_shutdown.cancel();
+                    }
                 }
                 _ = quit.cancelled() => {
                     info!("Stopped");

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -16,11 +16,20 @@ use tracing::{info, trace, warn};
 #[derive(Debug)]
 pub struct Dispatcher {
     pub ctx: Arc<AppContext>,
+    /// Process ID for this dispatcher (set after on_start)
+    process_id: Arc<tokio::sync::Mutex<Option<i64>>>,
 }
 
 impl Dispatcher {
     pub fn new(ctx: Arc<AppContext>) -> Self {
-        Self { ctx }
+        Self {
+            ctx,
+            process_id: Arc::new(tokio::sync::Mutex::new(None)),
+        }
+    }
+
+    pub fn process_id_handle(&self) -> Arc<tokio::sync::Mutex<Option<i64>>> {
+        self.process_id.clone()
     }
 
     pub async fn run(&self) -> Result<(), anyhow::Error> {
@@ -31,6 +40,7 @@ impl Dispatcher {
         let init_db = self.ctx.get_db().await?;
         let process = self.on_start(&init_db).await?;
         info!(">> Process started: {:?}", process);
+        *self.process_id.lock().await = Some(process.id);
 
         let quit = self.ctx.graceful_shutdown.clone();
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -10,9 +10,9 @@ use std::sync::Arc;
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 
-use tracing::info;
 #[cfg(feature = "python")]
 use tracing::trace;
+use tracing::{info, warn};
 
 #[cfg(feature = "python")]
 pub fn is_running_in_pyo3() -> bool {
@@ -157,7 +157,33 @@ pub trait ProcessTrait: Send + Sync {
         process: &quebec_processes::Model,
     ) -> Result<(), Error> {
         let ctx = self.ctx();
-        query_builder::processes::update_heartbeat(db, &ctx.table_config, process.id).await?;
+        let rows =
+            query_builder::processes::update_heartbeat(db, &ctx.table_config, process.id).await?;
+        // Row gone means the supervisor pruned us (stale heartbeat) or another
+        // operator deregistered us. Mirrors Solid Queue's Registrable#heartbeat
+        // rescue of RecordNotFound: stop polling and exit gracefully so we do
+        // not hold claimed jobs with no process row backing them.
+        // Only enabled for supervisor-managed children (supervisor_pid != 0)
+        // so standalone single-process Quebec keeps its old behavior of just
+        // logging when the row disappears.
+        if rows == 0 {
+            let supervised = ctx
+                .supervisor_pid
+                .load(std::sync::atomic::Ordering::Relaxed)
+                != 0;
+            if supervised {
+                warn!(
+                    "Process row {} (pid={}) no longer exists; initiating graceful shutdown",
+                    process.id, process.pid
+                );
+                ctx.graceful_shutdown.cancel();
+            } else {
+                warn!(
+                    "Process row {} (pid={}) no longer exists; continuing (standalone mode)",
+                    process.id, process.pid
+                );
+            }
+        }
         Ok(())
     }
 

--- a/src/proctitle_unix.rs
+++ b/src/proctitle_unix.rs
@@ -7,7 +7,7 @@ use std::os::raw::c_char;
 use std::sync::Once;
 
 #[cfg(target_os = "linux")]
-use std::{cmp::min, ffi::CStr, ptr, sync::Mutex};
+use std::{cmp::min, ptr, sync::Mutex};
 
 static INIT: Once = Once::new();
 #[cfg(target_os = "linux")]
@@ -68,7 +68,7 @@ unsafe fn init_state() -> Option<ProcTitleState> {
         argv_len = min(argv_len, env_start.saturating_sub(arg_start));
     }
 
-    if argv_len < 64 || argv_len > 1024 * 1024 {
+    if argv_len == 0 || argv_len > 1024 * 1024 {
         return None;
     }
 

--- a/src/query_builder.rs
+++ b/src/query_builder.rs
@@ -2694,6 +2694,27 @@ pub mod processes {
         execute_select_one(db, query).await
     }
 
+    /// Find a process by OS pid + hostname (hostname required to avoid cross-host pid collisions)
+    pub async fn find_by_pid<C>(
+        db: &C,
+        table_config: &TableConfig,
+        pid: i32,
+        hostname: &str,
+    ) -> Result<Option<quebec_processes::Model>, DbErr>
+    where
+        C: ConnectionTrait,
+    {
+        let table = Alias::new(&table_config.processes);
+        let query = Query::select()
+            .column(Asterisk)
+            .from(table)
+            .and_where(Expr::col(col("pid")).eq(pid))
+            .and_where(Expr::col(col("hostname")).eq(hostname))
+            .to_owned();
+
+        execute_select_one(db, query).await
+    }
+
     /// Delete a process by ID
     pub async fn delete_by_id<C>(db: &C, table_config: &TableConfig, id: i64) -> Result<u64, DbErr>
     where

--- a/src/query_builder.rs
+++ b/src/query_builder.rs
@@ -2838,18 +2838,58 @@ pub mod processes {
         execute_select(db, query).await
     }
 
-    /// Find prunable (stale) processes with heartbeat before threshold
-    /// These are processes that have stopped sending heartbeats
+    /// Find prunable (stale) processes with heartbeat before threshold.
+    /// These are processes that have stopped sending heartbeats. When
+    /// `use_skip_locked` is set the rows are taken with `FOR UPDATE SKIP
+    /// LOCKED` so concurrent supervisors (multi-host deployments) do not
+    /// double-prune the same row. Mirrors Solid Queue's
+    /// `Process.prunable.non_blocking_lock`.
     pub async fn find_prunable<C>(
         db: &C,
         table_config: &TableConfig,
         heartbeat_threshold: chrono::NaiveDateTime,
         exclude_id: Option<i64>,
+        use_skip_locked: bool,
     ) -> Result<Vec<quebec_processes::Model>, DbErr>
     where
         C: ConnectionTrait,
     {
-        let table = Alias::new(&table_config.processes);
+        let backend = db.get_database_backend();
+        let table_name = &table_config.processes;
+
+        if use_skip_locked && backend != DbBackend::Sqlite {
+            let (where_extra, params): (&str, Vec<sea_orm::Value>) = match exclude_id {
+                Some(id) => match backend {
+                    DbBackend::Postgres => (
+                        " AND \"id\" <> $2",
+                        vec![heartbeat_threshold.into(), id.into()],
+                    ),
+                    _ => (
+                        " AND `id` <> ?",
+                        vec![heartbeat_threshold.into(), id.into()],
+                    ),
+                },
+                None => ("", vec![heartbeat_threshold.into()]),
+            };
+
+            let sql = match backend {
+                DbBackend::Postgres => format!(
+                    r#"SELECT * FROM "{}" WHERE "last_heartbeat_at" < $1{} FOR UPDATE SKIP LOCKED"#,
+                    table_name, where_extra
+                ),
+                DbBackend::MySql => format!(
+                    r#"SELECT * FROM `{}` WHERE `last_heartbeat_at` < ?{} FOR UPDATE SKIP LOCKED"#,
+                    table_name, where_extra
+                ),
+                DbBackend::Sqlite => unreachable!(),
+            };
+            let stmt = Statement::from_sql_and_values(backend, sql, params);
+            return quebec_processes::Model::find_by_statement(stmt)
+                .all(db)
+                .await;
+        }
+
+        let table = Alias::new(table_name);
         let mut query = Query::select()
             .column(Asterisk)
             .from(table)

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -840,12 +840,21 @@ impl Scheduler {
         task_handles: Vec<tokio::task::JoinHandle<()>>,
     ) -> Result<(), anyhow::Error> {
         let graceful_shutdown = self.ctx.graceful_shutdown.clone();
+        // Orphan check: detect supervisor death via ppid change (Solid Queue parity).
+        let mut parent_check_interval = tokio::time::interval(std::time::Duration::from_secs(1));
 
         loop {
             tokio::select! {
                 _ = heartbeat_interval.tick() => {
                     self.heartbeat(db, process).await?;
                     trace!("Scheduler heartbeat");
+                }
+                // Detect supervisor death: if our ppid changed we were reparented.
+                _ = parent_check_interval.tick() => {
+                    if self.ctx.is_orphaned() {
+                        warn!("Supervisor went away (ppid changed), initiating graceful shutdown");
+                        self.ctx.graceful_shutdown.cancel();
+                    }
                 }
                 _ = graceful_shutdown.cancelled() => {
                     info!("Scheduler stopping - waiting for {} tasks to complete", task_handles.len());

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -527,7 +527,7 @@ impl Scheduler {
     /// 2. QUEBEC_RECURRING_SCHEDULE env var
     /// 3. recurring.yml (current directory)
     /// 4. config/recurring.yml (Solid Queue compatible)
-    fn find_schedule_path() -> Option<String> {
+    pub(crate) fn find_schedule_path() -> Option<String> {
         std::env::var("SOLID_QUEUE_RECURRING_SCHEDULE")
             .or_else(|_| std::env::var("QUEBEC_RECURRING_SCHEDULE"))
             .ok()
@@ -540,6 +540,13 @@ impl Scheduler {
                     None
                 }
             })
+    }
+
+    /// Whether a recurring schedule is configured (env var or YAML file).
+    /// Used by the supervisor plan builder to decide whether to fork a
+    /// dedicated scheduler child.
+    pub(crate) fn has_recurring_schedule() -> bool {
+        Self::find_schedule_path().is_some()
     }
 
     fn parse_schedule_file(

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -841,6 +841,12 @@ impl Scheduler {
     ) -> Result<(), anyhow::Error> {
         let graceful_shutdown = self.ctx.graceful_shutdown.clone();
         // Orphan check: detect supervisor death via ppid change (Solid Queue parity).
+        // Only armed when running as a supervisor-managed child.
+        let supervised = self
+            .ctx
+            .supervisor_pid
+            .load(std::sync::atomic::Ordering::Relaxed)
+            != 0;
         let mut parent_check_interval = tokio::time::interval(std::time::Duration::from_secs(1));
 
         loop {
@@ -850,7 +856,7 @@ impl Scheduler {
                     trace!("Scheduler heartbeat");
                 }
                 // Detect supervisor death: if our ppid changed we were reparented.
-                _ = parent_check_interval.tick() => {
+                _ = parent_check_interval.tick(), if supervised => {
                     if self.ctx.is_orphaned() {
                         warn!("Supervisor went away (ppid changed), initiating graceful shutdown");
                         self.ctx.graceful_shutdown.cancel();

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -505,6 +505,8 @@ where
 pub struct Scheduler {
     pub ctx: Arc<AppContext>,
     pub schedule: Vec<HashMap<String, ScheduledEntry>>,
+    /// Process ID for this scheduler (set after on_start)
+    process_id: Arc<tokio::sync::Mutex<Option<i64>>>,
 }
 
 impl Scheduler {
@@ -512,7 +514,12 @@ impl Scheduler {
         Self {
             ctx,
             schedule: Vec::new(),
+            process_id: Arc::new(tokio::sync::Mutex::new(None)),
         }
+    }
+
+    pub fn process_id_handle(&self) -> Arc<tokio::sync::Mutex<Option<i64>>> {
+        self.process_id.clone()
     }
 
     /// Find schedule file with priority:
@@ -881,6 +888,7 @@ impl Scheduler {
 
         let process = self.on_start(&db).await?;
         info!(">> Process started: {:?}", process);
+        *self.process_id.lock().await = Some(process.id);
 
         let scheduled =
             Self::sync_tasks_to_db(&*db, &self.ctx.table_config, schedule.unwrap()).await?;

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -1,17 +1,23 @@
-// TODO: Supervisor is a placeholder for future process-based architecture.
-// Currently Quebec uses a thread-based model. When migrating to multi-process
-// mode (like Solid Queue's fork-based supervision), this module will manage
-// child process lifecycles, health checks, and restarts.
+//! Supervisor: DB-layer operations for fork-based multi-process mode.
+//!
+//! Provides methods used by the Python-side Supervisor to:
+//!   - register itself in the `processes` table
+//!   - heartbeat
+//!   - mark claimed executions of crashed children as failed
+//!   - prune dead process rows
+
 #![allow(dead_code)]
 
 use crate::context::AppContext;
 use crate::process::{ProcessInfo, ProcessTrait};
+use crate::query_builder;
+use crate::worker::Worker;
 use anyhow::Result;
 use async_trait::async_trait;
-
+use sea_orm::{DatabaseConnection, DbErr, TransactionTrait};
 use std::sync::Arc;
 
-use tracing::info;
+use tracing::{info, warn};
 
 #[derive(Debug)]
 pub struct Supervisor {
@@ -23,19 +29,123 @@ impl Supervisor {
         Self { ctx }
     }
 
-    pub async fn run(&self) -> Result<(), anyhow::Error> {
-        let mut heartbeat_interval = tokio::time::interval(self.ctx.process_heartbeat_interval);
-
-        loop {
-            tokio::select! {
-              _ = heartbeat_interval.tick() => {}
-              _ = tokio::signal::ctrl_c() => {
-                info!("ctrl-c received");
-                return Ok(());
-              }
-            }
-        }
+    /// Register the supervisor process in the `processes` table.
+    /// Returns the new row id.
+    pub async fn register(&self) -> Result<i64> {
+        let db = self.ctx.get_db().await?;
+        let process = self.on_start(db.as_ref()).await?;
+        info!(
+            "Supervisor registered: id={} pid={} hostname={:?}",
+            process.id, process.pid, process.hostname
+        );
+        Ok(process.id)
     }
+
+    /// Update heartbeat for a process row.
+    pub async fn heartbeat_process(&self, process_id: i64) -> Result<()> {
+        let db = self.ctx.get_db().await?;
+        query_builder::processes::update_heartbeat(db.as_ref(), &self.ctx.table_config, process_id)
+            .await?;
+        Ok(())
+    }
+
+    /// Remove a process row.
+    pub async fn deregister_process(&self, process_id: i64) -> Result<()> {
+        let db = self.ctx.get_db().await?;
+        query_builder::processes::delete_by_id(db.as_ref(), &self.ctx.table_config, process_id)
+            .await?;
+        Ok(())
+    }
+
+    /// Find the process row id for a given (pid, hostname), or None if not found.
+    pub async fn lookup_process_id_by_pid(&self, pid: i32, hostname: &str) -> Result<Option<i64>> {
+        let db = self.ctx.get_db().await?;
+        let row = query_builder::processes::find_by_pid(
+            db.as_ref(),
+            &self.ctx.table_config,
+            pid,
+            hostname,
+        )
+        .await?;
+        Ok(row.map(|m| m.id))
+    }
+
+    /// Mark all claimed executions for the given process row as failed, then prune the row.
+    /// Returns number of claimed executions failed.
+    pub async fn fail_claimed_by_process_id(&self, process_id: i64) -> Result<u64> {
+        let db = self.ctx.get_db().await?;
+        fail_claimed_by_process_id_inner(&self.ctx, db.as_ref(), process_id).await
+    }
+
+    /// Convenience: look up by (pid, hostname) and fail. Returns 0 if no such row.
+    pub async fn fail_claimed_by_pid(&self, pid: i32, hostname: &str) -> Result<u64> {
+        let Some(process_id) = self.lookup_process_id_by_pid(pid, hostname).await? else {
+            return Ok(0);
+        };
+        self.fail_claimed_by_process_id(process_id).await
+    }
+}
+
+async fn fail_claimed_by_process_id_inner(
+    ctx: &Arc<AppContext>,
+    db: &DatabaseConnection,
+    process_id: i64,
+) -> Result<u64> {
+    let table_config = ctx.table_config.clone();
+    let process = query_builder::processes::find_by_id(db, &table_config, process_id).await?;
+    let (process_pid, process_hostname) = match &process {
+        Some(p) => (p.pid, p.hostname.clone()),
+        None => {
+            warn!(
+                "Supervisor: process row {} not found, nothing to fail",
+                process_id
+            );
+            return Ok(0);
+        }
+    };
+
+    let error_msg = format!(
+        "Child process {} (pid={}, host={:?}) crashed",
+        process_id, process_pid, process_hostname
+    );
+
+    let ctx = ctx.clone();
+    let tc = table_config.clone();
+    let deleted_count = db
+        .transaction::<_, u64, DbErr>(|txn| {
+            let ctx = ctx.clone();
+            let tc = tc.clone();
+            let error_msg = error_msg.clone();
+            Box::pin(async move {
+                let claimed =
+                    query_builder::claimed_executions::find_by_process_id(txn, &tc, process_id)
+                        .await?;
+                let deleted_count = claimed.len() as u64;
+
+                for execution in &claimed {
+                    Worker::fail_claimed_execution(
+                        &ctx,
+                        txn,
+                        &tc,
+                        execution.job_id,
+                        execution.id,
+                        &error_msg,
+                    )
+                    .await?;
+                }
+
+                query_builder::processes::prune(txn, &tc, process_id).await?;
+                Ok(deleted_count)
+            })
+        })
+        .await?;
+
+    warn!(
+        "Supervisor pruned crashed process {} (pid={}, host={:?}), failed {} claimed job(s)",
+        process_id, process_pid, process_hostname, deleted_count
+    );
+
+    Ok(deleted_count)
 }
 
 #[async_trait]

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -141,7 +141,7 @@ async fn fail_claimed_by_process_id_inner(
         .await?;
 
     warn!(
-        "Supervisor pruned crashed process {} (pid={}, host={:?}), failed {} claimed job(s)",
+        "Supervisor reaped process {} (pid={}, host={:?}), failed {} claimed job(s)",
         process_id, process_pid, process_hostname, deleted_count
     );
 

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -84,6 +84,79 @@ impl Supervisor {
         };
         self.fail_claimed_by_process_id(process_id).await
     }
+
+    /// Periodic maintenance run by the supervisor itself. Mirrors Solid Queue's
+    /// `Supervisor#launch_maintenance_task`: prune processes whose heartbeat has
+    /// gone stale (failing their claimed executions) and then sweep any leftover
+    /// orphaned claims whose process row is already gone.
+    ///
+    /// `exclude_process_id` is the supervisor's own row id, so it is not pruned.
+    /// Returns (pruned_processes, orphaned_claims_failed).
+    pub async fn run_maintenance(&self, exclude_process_id: Option<i64>) -> Result<(usize, usize)> {
+        let db = self.ctx.get_db().await?;
+        let table_config = self.ctx.table_config.clone();
+
+        let threshold = chrono::Utc::now().naive_utc()
+            - chrono::Duration::from_std(self.ctx.process_alive_threshold)?;
+        let stale = query_builder::processes::find_prunable(
+            db.as_ref(),
+            &table_config,
+            threshold,
+            exclude_process_id,
+        )
+        .await?;
+
+        let pruned = stale.len();
+        if pruned > 0 {
+            info!(
+                "Supervisor maintenance: pruning {} stale process(es) (no heartbeat since {})",
+                pruned, threshold
+            );
+        }
+        for p in stale {
+            if let Err(e) = fail_claimed_by_process_id_inner(&self.ctx, db.as_ref(), p.id).await {
+                warn!(
+                    "Supervisor maintenance: failed to prune process {}: {}",
+                    p.id, e
+                );
+            }
+        }
+
+        // Any claimed row whose process is already gone is orphaned; fail it so
+        // the job can be retried. Safety net for cases where process cleanup
+        // raced or skipped releasing claims.
+        let orphaned =
+            query_builder::claimed_executions::find_orphaned(db.as_ref(), &table_config).await?;
+        let orphaned_count = orphaned.len();
+        if orphaned_count > 0 {
+            info!(
+                "Supervisor maintenance: failing {} orphaned claimed execution(s)",
+                orphaned_count
+            );
+        }
+        for execution in orphaned {
+            let ctx = self.ctx.clone();
+            let tc = table_config.clone();
+            let job_id = execution.job_id;
+            let exec_id = execution.id;
+            db.transaction::<_, (), DbErr>(|txn| {
+                Box::pin(async move {
+                    Worker::fail_claimed_execution(
+                        &ctx,
+                        txn,
+                        &tc,
+                        job_id,
+                        exec_id,
+                        "Process crashed or was killed before job completion",
+                    )
+                    .await
+                })
+            })
+            .await?;
+        }
+
+        Ok((pruned, orphaned_count))
+    }
 }
 
 async fn fail_claimed_by_process_id_inner(

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -103,6 +103,7 @@ impl Supervisor {
             &table_config,
             threshold,
             exclude_process_id,
+            self.ctx.use_skip_locked,
         )
         .await?;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1283,6 +1283,13 @@ impl PyQuebec {
         if total_dispatchers > 0 {
             dict.set_item("dispatcher", total_dispatchers)?;
         }
+        // Once supervisor mode is active, move the scheduler into its own
+        // process too when a recurring schedule is configured. In the
+        // single-process fallback, spawn_all already covers the scheduler via
+        // a tokio task, so we skip it there to stay backward-compatible.
+        if crate::scheduler::Scheduler::has_recurring_schedule() {
+            dict.set_item("scheduler", 1u32)?;
+        }
         Ok(Some(dict.into()))
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1170,15 +1170,15 @@ impl PyQuebec {
         // The freshly built wrappers above do not yet carry the preserved
         // start/stop handler lists — rebuild_wrappers_with_ctx below would,
         // but it also drops its old Arcs. We want both: transfer handlers +
-        // avoid dropping old state. So we do the transfer manually.
-        let preserved_start: Vec<Py<PyAny>> = self
-            .worker
+        // avoid dropping old state. Pull handlers off `old_worker` (the Arc
+        // we just swapped out) rather than `self.worker` (now the empty
+        // replacement).
+        let preserved_start: Vec<Py<PyAny>> = old_worker
             .start_handlers
             .read()
             .map(|g| g.iter().map(|h| h.clone_ref(py)).collect())
             .unwrap_or_default();
-        let preserved_stop: Vec<Py<PyAny>> = self
-            .worker
+        let preserved_stop: Vec<Py<PyAny>> = old_worker
             .stop_handlers
             .read()
             .map(|g| g.iter().map(|h| h.clone_ref(py)).collect())

--- a/src/types.rs
+++ b/src/types.rs
@@ -1006,6 +1006,11 @@ impl PyQuebec {
     }
 
     fn spawn_job_claim_poller(&self) -> PyResult<()> {
+        // Set the process title on the main thread (where it actually takes
+        // effect) before handing the loop off to the tokio runtime.
+        self.ctx
+            .set_proc_title("worker", Some(&self.ctx.worker_threads.to_string()));
+
         let worker = self.worker.clone();
         let _ = self.rt.spawn(async move {
             let _ = worker.run_main_loop().await;
@@ -1015,6 +1020,8 @@ impl PyQuebec {
     }
 
     fn spawn_dispatcher(&self) -> PyResult<()> {
+        self.ctx.set_proc_title("dispatcher", None);
+
         let dispatcher = self.dispatcher.clone();
         let _ = self.rt.spawn(async move {
             let _ = dispatcher.run().await;
@@ -1024,6 +1031,8 @@ impl PyQuebec {
     }
 
     fn spawn_scheduler(&self) -> PyResult<()> {
+        self.ctx.set_proc_title("scheduler", None);
+
         let scheduler = self.scheduler.clone();
         let _ = self.rt.spawn(async move {
             let _ = scheduler.run().await;
@@ -1245,6 +1254,11 @@ impl PyQuebec {
     /// Supervisor: register this process as kind="Supervisor" in the `processes`
     /// table. Returns the new row id.
     fn register_supervisor(&self, py: Python<'_>) -> PyResult<i64> {
+        // Set the supervisor's process title on the main thread before
+        // releasing the GIL — this is the supervisor parent's only entry
+        // into Rust prior to forking its children.
+        self.ctx.set_proc_title("supervisor", None);
+
         let ctx = self.ctx.clone();
         py.detach(|| {
             self.rt.block_on(async move {
@@ -2159,11 +2173,9 @@ impl PyQuebec {
             }
         }
 
-        // Set process title on the main thread where it takes effect
-        self.ctx
-            .set_proc_title("worker", Some(&self.ctx.worker_threads.to_string()));
-
-        // Spawn all components
+        // Spawn all components. Each spawn_* sets the process title on the
+        // main thread; spawn_job_claim_poller runs last so the final title
+        // is "worker:<threads>" in single-process mode.
         self.spawn_dispatcher()?;
         self.spawn_scheduler()?;
         self.spawn_job_claim_poller()?;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1069,19 +1069,26 @@ impl PyQuebec {
     /// concurrency_enabled, table_config, and any worker start/stop handlers
     /// the user registered pre-fork.
     fn reset_after_fork(&mut self, py: Python<'_>) -> PyResult<()> {
-        // Cancel the old tokens so any inherited tasks stop trying to run.
-        self.ctx.graceful_shutdown.cancel();
-        self.ctx.force_quit.cancel();
+        // Do NOT call `cancel()` on the inherited tokens. In a forked child
+        // the parent's tokio I/O driver is dead (kqueue fds are per-process on
+        // Darwin/Linux) and any waker fired by a CancellationToken wake path
+        // will try to notify that driver and panic with
+        // `failed to wake I/O driver: Bad file descriptor`.
 
-        // Drop any inherited JoinHandles without awaiting (they belong to the
-        // parent's runtime, which we are about to discard).
-        {
+        // Drain inherited JoinHandles without awaiting. `JoinHandle::drop`
+        // detaches without waking the runtime, so this is safe.
+        let inherited_handles = {
             let mut guard = self
                 .handles
                 .lock()
                 .map_err(|_| pyo3::exceptions::PyRuntimeError::new_err("handles lock poisoned"))?;
-            guard.clear();
-        }
+            std::mem::take(&mut *guard)
+        };
+        // But do NOT drop the Vec contents here — leak them. The JoinHandles
+        // themselves reference the dead parent runtime; leaving them to be
+        // dropped at the end of this function would destructure through the
+        // runtime's task table and touch the dead driver.
+        std::mem::forget(inherited_handles);
 
         // Remove ourselves from the process-global instance map, if present.
         // Subsequent `get_instance(url)` in this child will build a fresh one
@@ -1128,8 +1135,56 @@ impl PyQuebec {
                 .fork_clone(Some(new_db.clone()), new_rt.handle().clone()),
         );
 
-        self.rt = new_rt;
-        self.rebuild_wrappers_with_ctx(py, new_ctx);
+        // Swap in the new runtime + ctx + wrappers, then LEAK the old ones.
+        // Dropping the old `Arc<Runtime>` would run tokio's shutdown path
+        // (wake worker threads that no longer exist, touch the dead I/O
+        // driver) and panic. Dropping the old `Arc<AppContext>` would
+        // eventually drop the inherited sqlx pool and Notify/CancellationToken
+        // fields, which can also wake on the dead runtime. Leaking a few
+        // Arcs once per child at fork time is cheap and the only safe option.
+        let old_rt = std::mem::replace(&mut self.rt, new_rt);
+        let old_ctx = std::mem::replace(&mut self.ctx, new_ctx.clone());
+        let old_quebec =
+            std::mem::replace(&mut self.quebec, Arc::new(Quebec::new(new_ctx.clone())));
+        let old_worker =
+            std::mem::replace(&mut self.worker, Arc::new(Worker::new(new_ctx.clone())));
+        let old_dispatcher = std::mem::replace(
+            &mut self.dispatcher,
+            Arc::new(Dispatcher::new(new_ctx.clone())),
+        );
+        let old_scheduler = std::mem::replace(
+            &mut self.scheduler,
+            Arc::new(Scheduler::new(new_ctx.clone())),
+        );
+        // The freshly built wrappers above do not yet carry the preserved
+        // start/stop handler lists — rebuild_wrappers_with_ctx below would,
+        // but it also drops its old Arcs. We want both: transfer handlers +
+        // avoid dropping old state. So we do the transfer manually.
+        let preserved_start: Vec<Py<PyAny>> = self
+            .worker
+            .start_handlers
+            .read()
+            .map(|g| g.iter().map(|h| h.clone_ref(py)).collect())
+            .unwrap_or_default();
+        let preserved_stop: Vec<Py<PyAny>> = self
+            .worker
+            .stop_handlers
+            .read()
+            .map(|g| g.iter().map(|h| h.clone_ref(py)).collect())
+            .unwrap_or_default();
+        if let Ok(mut guard) = self.worker.start_handlers.write() {
+            *guard = preserved_start;
+        }
+        if let Ok(mut guard) = self.worker.stop_handlers.write() {
+            *guard = preserved_stop;
+        }
+
+        std::mem::forget(old_rt);
+        std::mem::forget(old_ctx);
+        std::mem::forget(old_quebec);
+        std::mem::forget(old_worker);
+        std::mem::forget(old_dispatcher);
+        std::mem::forget(old_scheduler);
 
         // Child processes do not run the control plane; reset the slot.
         let cp = self.control_plane_router.clone();

--- a/src/types.rs
+++ b/src/types.rs
@@ -1256,6 +1256,30 @@ impl PyQuebec {
         })
     }
 
+    /// Supervisor maintenance: prune processes whose heartbeat has gone stale
+    /// and sweep any orphaned claimed executions. Mirrors Solid Queue's
+    /// `Supervisor#launch_maintenance_task`. `exclude_process_id` is the
+    /// supervisor's own row so it is not pruned. Returns
+    /// (pruned_processes, orphaned_claims_failed).
+    fn supervisor_run_maintenance(
+        &self,
+        py: Python<'_>,
+        exclude_process_id: Option<i64>,
+    ) -> PyResult<(usize, usize)> {
+        let ctx = self.ctx.clone();
+        py.detach(|| {
+            self.rt.block_on(async move {
+                let sup = crate::supervisor::Supervisor::new(ctx);
+                sup.run_maintenance(exclude_process_id).await.map_err(|e| {
+                    PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
+                        "supervisor_run_maintenance failed: {}",
+                        e
+                    ))
+                })
+            })
+        })
+    }
+
     /// Delete a process row (typically the supervisor's on shutdown).
     fn deregister_process(&self, py: Python<'_>, process_id: i64) -> PyResult<()> {
         let ctx = self.ctx.clone();

--- a/src/types.rs
+++ b/src/types.rs
@@ -173,7 +173,26 @@ fn signal_handler(
     _frame: Py<PyAny>,
     quebec: Py<PyAny>,
 ) -> PyResult<()> {
-    info!("Received signal {}, initiating graceful shutdown", signum);
+    // SIGQUIT is the "exit now" signal in the Solid Queue convention. Only
+    // supervisor-managed children skip cleanup — standalone Quebec processes
+    // (no supervisor watching) drain gracefully so they release claims and
+    // delete their process row instead of leaking them.
+    const SIGQUIT: i32 = 3;
+    if signum == SIGQUIT {
+        let supervised = quebec
+            .bind(py)
+            .cast::<PyQuebec>()
+            .ok()
+            .map(|q| q.borrow().ctx.supervisor_pid.load(Ordering::Relaxed) != 0)
+            .unwrap_or(false);
+        if supervised {
+            warn!("Received SIGQUIT, exiting immediately");
+            std::process::exit(0);
+        }
+        info!("Received SIGQUIT (standalone process), draining gracefully");
+    } else {
+        info!("Received signal {}, initiating graceful shutdown", signum);
+    }
 
     if let Err(e) = quebec.bind(py).call_method0("graceful_shutdown") {
         error!("Error calling graceful_shutdown: {:?}", e);

--- a/src/types.rs
+++ b/src/types.rs
@@ -88,6 +88,84 @@ use crate::worker::{Execution, Worker};
 
 use tracing::{debug, error, info, trace, warn};
 
+/// Map a supervisor slot index (0..total_processes) to the config entry that
+/// should drive that slot's configuration. Entries with `processes == 0` are
+/// skipped entirely to match the counting done in `supervisor_plan_from_config`.
+fn slot_to_entry<T>(slot: usize, entries: &[T], processes: impl Fn(&T) -> u32) -> Option<&T> {
+    let mut acc = 0usize;
+    for entry in entries {
+        let n = processes(entry) as usize;
+        if n == 0 {
+            continue;
+        }
+        if slot < acc + n {
+            return Some(entry);
+        }
+        acc += n;
+    }
+    None
+}
+
+/// Apply a `WorkerConfig` to a freshly owned `AppContext`. Callers are
+/// responsible for re-wrapping the context in `Arc` once mutation is done.
+fn apply_worker_cfg_to(
+    ctx: &mut AppContext,
+    worker_cfg: &crate::config::WorkerConfig,
+) -> PyResult<()> {
+    if let Some(threads) = worker_cfg.threads {
+        if threads == 0 {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "worker threads must be >= 1",
+            ));
+        }
+        ctx.worker_threads = threads as u64;
+    }
+    if let Some(polling_interval) = worker_cfg.polling_interval {
+        if !polling_interval.is_finite() || polling_interval < 0.0 {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "worker polling_interval must be finite and >= 0, got {}",
+                polling_interval
+            )));
+        }
+        ctx.worker_polling_interval = Duration::from_secs_f64(polling_interval);
+    }
+    if worker_cfg.queues.is_some() {
+        ctx.worker_queues = worker_cfg.queues.clone();
+    }
+    Ok(())
+}
+
+/// Apply a `DispatcherConfig` to a freshly owned `AppContext`. Validates the
+/// floating-point intervals to avoid `Duration::from_secs_f64` panics on NaN
+/// or negative values coming from queue.yml.
+fn apply_dispatcher_cfg_to(
+    ctx: &mut AppContext,
+    dispatcher_cfg: &crate::config::DispatcherConfig,
+) -> PyResult<()> {
+    if let Some(polling_interval) = dispatcher_cfg.polling_interval {
+        if !polling_interval.is_finite() || polling_interval < 0.0 {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "dispatcher polling_interval must be finite and >= 0, got {}",
+                polling_interval
+            )));
+        }
+        ctx.dispatcher_polling_interval = Duration::from_secs_f64(polling_interval);
+    }
+    if let Some(batch_size) = dispatcher_cfg.batch_size {
+        ctx.dispatcher_batch_size = batch_size;
+    }
+    if let Some(interval) = dispatcher_cfg.concurrency_maintenance_interval {
+        if !interval.is_finite() || interval < 0.0 {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "dispatcher concurrency_maintenance_interval must be finite and >= 0, got {}",
+                interval
+            )));
+        }
+        ctx.dispatcher_concurrency_maintenance_interval = Duration::from_secs_f64(interval);
+    }
+    Ok(())
+}
+
 #[pyfunction]
 fn signal_handler(
     py: Python<'_>,
@@ -281,6 +359,44 @@ impl PyQuebec {
                 self.rt.block_on(future)
             }
         }
+    }
+
+    /// Swap the current `AppContext` for the provided one and rebuild the four
+    /// role wrappers (`quebec`, `worker`, `dispatcher`, `scheduler`) so they
+    /// all reference it. Preserves any worker start/stop handlers registered
+    /// on the old `Worker`. Control-plane router and pyqueue mode are left
+    /// alone — callers that want them reset should clear them explicitly.
+    fn rebuild_wrappers_with_ctx(&mut self, py: Python<'_>, new_ctx: Arc<AppContext>) {
+        let preserved_start_handlers: Vec<Py<PyAny>> = self
+            .worker
+            .start_handlers
+            .read()
+            .map(|g| g.iter().map(|h| h.clone_ref(py)).collect())
+            .unwrap_or_default();
+        let preserved_stop_handlers: Vec<Py<PyAny>> = self
+            .worker
+            .stop_handlers
+            .read()
+            .map(|g| g.iter().map(|h| h.clone_ref(py)).collect())
+            .unwrap_or_default();
+
+        let new_quebec = Arc::new(Quebec::new(new_ctx.clone()));
+        let new_worker = Arc::new(Worker::new(new_ctx.clone()));
+        let new_dispatcher = Arc::new(Dispatcher::new(new_ctx.clone()));
+        let new_scheduler = Arc::new(Scheduler::new(new_ctx.clone()));
+
+        if let Ok(mut guard) = new_worker.start_handlers.write() {
+            *guard = preserved_start_handlers;
+        }
+        if let Ok(mut guard) = new_worker.stop_handlers.write() {
+            *guard = preserved_stop_handlers;
+        }
+
+        self.ctx = new_ctx;
+        self.quebec = new_quebec;
+        self.worker = new_worker;
+        self.dispatcher = new_dispatcher;
+        self.scheduler = new_scheduler;
     }
 }
 
@@ -586,18 +702,10 @@ impl PyQuebec {
                 }
             }
 
-            // Apply worker configuration
+            // Apply worker configuration. In supervisor mode multiple workers
+            // are valid; the first entry is used to seed the default ctx and
+            // child processes call apply_worker_config(index) to override.
             if let Some(workers) = config.workers {
-                // Warn if multiple workers are configured (not supported yet)
-                if workers.len() > 1 {
-                    warn!(
-                        "Multiple worker configurations detected ({} workers). Quebec currently only supports a single worker configuration. Only the first worker configuration will be used. \
-                        To run multiple workers, use separate config files or environments and start independent processes. \
-                        Example: QUEBEC_ENV=realtime python worker1.py & QUEBEC_ENV=background python worker2.py",
-                        workers.len()
-                    );
-                }
-
                 if let Some(worker) = workers.first() {
                     // Code/env parameters take precedence over config file
                     if let Some(threads) = worker.threads {
@@ -633,18 +741,10 @@ impl PyQuebec {
                 }
             }
 
-            // Apply dispatcher configuration
+            // Apply dispatcher configuration. Supervisor mode handles
+            // multiple dispatchers; first entry seeds ctx and children override
+            // via apply_dispatcher_config(index).
             if let Some(dispatchers) = config.dispatchers {
-                // Warn if multiple dispatchers are configured (not supported yet)
-                if dispatchers.len() > 1 {
-                    warn!(
-                        "Multiple dispatcher configurations detected ({} dispatchers). Quebec currently only supports a single dispatcher configuration. Only the first dispatcher configuration will be used. \
-                        To run multiple dispatchers, use separate config files or environments and start independent processes. \
-                        Example: QUEBEC_CONFIG=config/queue_dispatcher1.yml python dispatcher1.py & QUEBEC_CONFIG=config/queue_dispatcher2.yml python dispatcher2.py",
-                        dispatchers.len()
-                    );
-                }
-
                 if let Some(dispatcher) = dispatchers.first() {
                     if let Some(polling_interval) = dispatcher.polling_interval {
                         if _ctx.dispatcher_polling_interval == Duration::from_secs(1) {
@@ -955,6 +1055,298 @@ impl PyQuebec {
                 }
             });
         });
+        Ok(())
+    }
+
+    /// Reset internal state after `os.fork()` in a child process.
+    ///
+    /// Idempotent. Must be the first thing a forked child calls on its PyQuebec
+    /// instance. Rebuilds the tokio runtime and database pool (both broken by
+    /// fork because of inherited background threads / fd state), creates fresh
+    /// cancellation tokens, and clears child-specific state.
+    ///
+    /// Preserved across fork: config, runnables (job class registry),
+    /// concurrency_enabled, table_config, and any worker start/stop handlers
+    /// the user registered pre-fork.
+    fn reset_after_fork(&mut self, py: Python<'_>) -> PyResult<()> {
+        // Cancel the old tokens so any inherited tasks stop trying to run.
+        self.ctx.graceful_shutdown.cancel();
+        self.ctx.force_quit.cancel();
+
+        // Drop any inherited JoinHandles without awaiting (they belong to the
+        // parent's runtime, which we are about to discard).
+        {
+            let mut guard = self
+                .handles
+                .lock()
+                .map_err(|_| pyo3::exceptions::PyRuntimeError::new_err("handles lock poisoned"))?;
+            guard.clear();
+        }
+
+        // Remove ourselves from the process-global instance map, if present.
+        // Subsequent `get_instance(url)` in this child will build a fresh one
+        // rather than hand back this stale-by-fork handle.
+        if let Some(map) = INSTANCE_MAP.get(py) {
+            if let Ok(mut guard) = map.write() {
+                guard.remove(&self.url);
+            }
+        }
+
+        // Build a brand-new tokio runtime. The parent's worker threads did not
+        // survive fork; sqlx pool + reaper would deadlock on the old rt.
+        let new_rt = Arc::new(
+            tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(16)
+                .enable_all()
+                .build()
+                .map_err(|e| {
+                    PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
+                        "Failed to build runtime in forked child: {}",
+                        e
+                    ))
+                })?,
+        );
+
+        // Reconnect the database pool using the preserved connect options.
+        let opt = self.ctx.connect_options.clone();
+        let new_db = py.detach(|| -> PyResult<Arc<DatabaseConnection>> {
+            new_rt
+                .block_on(async { Database::connect(opt).await })
+                .map(Arc::new)
+                .map_err(|e| {
+                    pyo3::exceptions::PyConnectionError::new_err(format!(
+                        "Database reconnect after fork failed: {}",
+                        e
+                    ))
+                })
+        })?;
+
+        // Build a new AppContext that preserves config/registries but uses the
+        // new db pool, runtime handle, and fresh cancellation tokens.
+        let new_ctx = Arc::new(
+            self.ctx
+                .fork_clone(Some(new_db.clone()), new_rt.handle().clone()),
+        );
+
+        self.rt = new_rt;
+        self.rebuild_wrappers_with_ctx(py, new_ctx);
+
+        // Child processes do not run the control plane; reset the slot.
+        let cp = self.control_plane_router.clone();
+        if let Ok(mut guard) = cp.try_lock() {
+            *guard = None;
+        }
+        self.pyqueue_mode.store(false, Ordering::Relaxed);
+
+        Ok(())
+    }
+
+    /// Supervisor: register this process as kind="Supervisor" in the `processes`
+    /// table. Returns the new row id.
+    fn register_supervisor(&self, py: Python<'_>) -> PyResult<i64> {
+        let ctx = self.ctx.clone();
+        py.detach(|| {
+            self.rt.block_on(async move {
+                let sup = crate::supervisor::Supervisor::new(ctx);
+                sup.register().await.map_err(|e| {
+                    PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
+                        "register_supervisor failed: {}",
+                        e
+                    ))
+                })
+            })
+        })
+    }
+
+    /// Update heartbeat for an arbitrary process row (typically the supervisor's).
+    fn heartbeat_process(&self, py: Python<'_>, process_id: i64) -> PyResult<()> {
+        let ctx = self.ctx.clone();
+        py.detach(|| {
+            self.rt.block_on(async move {
+                let sup = crate::supervisor::Supervisor::new(ctx);
+                sup.heartbeat_process(process_id).await.map_err(|e| {
+                    PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
+                        "heartbeat_process failed: {}",
+                        e
+                    ))
+                })
+            })
+        })
+    }
+
+    /// Delete a process row (typically the supervisor's on shutdown).
+    fn deregister_process(&self, py: Python<'_>, process_id: i64) -> PyResult<()> {
+        let ctx = self.ctx.clone();
+        py.detach(|| {
+            self.rt.block_on(async move {
+                let sup = crate::supervisor::Supervisor::new(ctx);
+                sup.deregister_process(process_id).await.map_err(|e| {
+                    PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
+                        "deregister_process failed: {}",
+                        e
+                    ))
+                })
+            })
+        })
+    }
+
+    /// Supervisor: mark all claimed executions belonging to a crashed child's
+    /// process row as failed, then prune the row. Returns count of failed executions.
+    fn supervisor_fail_claimed_by_process_id(
+        &self,
+        py: Python<'_>,
+        process_id: i64,
+    ) -> PyResult<u64> {
+        let ctx = self.ctx.clone();
+        py.detach(|| {
+            self.rt.block_on(async move {
+                let sup = crate::supervisor::Supervisor::new(ctx);
+                sup.fail_claimed_by_process_id(process_id)
+                    .await
+                    .map_err(|e| {
+                        PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
+                            "fail_claimed_by_process_id failed: {}",
+                            e
+                        ))
+                    })
+            })
+        })
+    }
+
+    /// Supervisor: same as above but looks up by (pid, hostname). Returns 0 if
+    /// no such row exists.
+    fn supervisor_fail_claimed_by_pid(
+        &self,
+        py: Python<'_>,
+        pid: i32,
+        hostname: String,
+    ) -> PyResult<u64> {
+        let ctx = self.ctx.clone();
+        py.detach(|| {
+            self.rt.block_on(async move {
+                let sup = crate::supervisor::Supervisor::new(ctx);
+                sup.fail_claimed_by_pid(pid, &hostname).await.map_err(|e| {
+                    PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
+                        "fail_claimed_by_pid failed: {}",
+                        e
+                    ))
+                })
+            })
+        })
+    }
+
+    /// Return the process row id this child's Worker registered after on_start,
+    /// or None if the worker has not started yet.
+    fn current_worker_process_id(&self, py: Python<'_>) -> PyResult<Option<i64>> {
+        let handle = self.worker.process_id_handle();
+        py.detach(|| Ok(self.rt.block_on(async move { *handle.lock().await })))
+    }
+
+    fn current_dispatcher_process_id(&self, py: Python<'_>) -> PyResult<Option<i64>> {
+        let handle = self.dispatcher.process_id_handle();
+        py.detach(|| Ok(self.rt.block_on(async move { *handle.lock().await })))
+    }
+
+    fn current_scheduler_process_id(&self, py: Python<'_>) -> PyResult<Option<i64>> {
+        let handle = self.scheduler.process_id_handle();
+        py.detach(|| Ok(self.rt.block_on(async move { *handle.lock().await })))
+    }
+
+    /// Read `workers`/`dispatchers` from the loaded queue.yml and return a plan
+    /// dict suitable for `Supervisor(plan=...)`, or `None` if the config file
+    /// is absent or specifies fewer than 2 total child processes.
+    fn supervisor_plan_from_config(&self, py: Python<'_>) -> PyResult<Option<Py<PyDict>>> {
+        let env = std::env::var("QUEBEC_ENV").ok();
+        let Some(config) = crate::config::QueueConfig::find(env.as_deref()).ok() else {
+            return Ok(None);
+        };
+        let total_workers: u32 = config
+            .workers
+            .as_ref()
+            .map(|ws| ws.iter().map(|w| w.processes.unwrap_or(1)).sum())
+            .unwrap_or(0);
+        let total_dispatchers: u32 = config
+            .dispatchers
+            .as_ref()
+            .map(|ds| ds.iter().map(|d| d.processes.unwrap_or(1)).sum())
+            .unwrap_or(0);
+        // Only auto-enter supervisor mode when more than one of something is
+        // requested. A bare "1 worker + 1 dispatcher" config stays in the
+        // existing single-process threaded mode for backward compatibility.
+        if total_workers <= 1 && total_dispatchers <= 1 {
+            return Ok(None);
+        }
+        let dict = PyDict::new(py);
+        if total_workers > 0 {
+            dict.set_item("worker", total_workers)?;
+        }
+        if total_dispatchers > 0 {
+            dict.set_item("dispatcher", total_dispatchers)?;
+        }
+        Ok(Some(dict.into()))
+    }
+
+    /// Apply the Nth worker configuration from the loaded queue.yml, overriding
+    /// the ctx values set at __new__ time. Call after reset_after_fork in the
+    /// child process assigned to role=worker, slot_index=i (0..total_processes).
+    ///
+    /// The slot index maps across worker entries weighted by each entry's
+    /// `processes` field: for `[{processes: 2}, {processes: 3}]`, slots 0..=1
+    /// use entry 0 and slots 2..=4 use entry 1.
+    ///
+    /// No-op if no config file is loaded or the `workers` section is missing.
+    fn apply_worker_config(&mut self, py: Python<'_>, slot_index: usize) -> PyResult<()> {
+        let env = std::env::var("QUEBEC_ENV").ok();
+        let Some(config) = crate::config::QueueConfig::find(env.as_deref()).ok() else {
+            return Ok(());
+        };
+        let Some(workers) = config.workers else {
+            return Ok(());
+        };
+        let Some(worker_cfg) = slot_to_entry(slot_index, &workers, |w| w.processes.unwrap_or(1))
+        else {
+            let total: u32 = workers.iter().map(|w| w.processes.unwrap_or(1)).sum();
+            return Err(pyo3::exceptions::PyIndexError::new_err(format!(
+                "apply_worker_config: slot {} out of range (have {} total worker processes across {} entries)",
+                slot_index, total, workers.len()
+            )));
+        };
+
+        let mut new_inner = self
+            .ctx
+            .fork_clone(self.ctx.db.clone(), self.rt.handle().clone());
+        apply_worker_cfg_to(&mut new_inner, worker_cfg)?;
+        let new_ctx = Arc::new(new_inner);
+        self.rebuild_wrappers_with_ctx(py, new_ctx);
+        Ok(())
+    }
+
+    /// Apply the Nth dispatcher configuration. Same slot semantics as
+    /// apply_worker_config.
+    fn apply_dispatcher_config(&mut self, py: Python<'_>, slot_index: usize) -> PyResult<()> {
+        let env = std::env::var("QUEBEC_ENV").ok();
+        let Some(config) = crate::config::QueueConfig::find(env.as_deref()).ok() else {
+            return Ok(());
+        };
+        let Some(dispatchers) = config.dispatchers else {
+            return Ok(());
+        };
+        let Some(dispatcher_cfg) =
+            slot_to_entry(slot_index, &dispatchers, |d| d.processes.unwrap_or(1))
+        else {
+            let total: u32 = dispatchers.iter().map(|d| d.processes.unwrap_or(1)).sum();
+            return Err(pyo3::exceptions::PyIndexError::new_err(format!(
+                "apply_dispatcher_config: slot {} out of range (have {} total dispatcher processes across {} entries)",
+                slot_index, total, dispatchers.len()
+            )));
+        };
+
+        let mut new_inner = self
+            .ctx
+            .fork_clone(self.ctx.db.clone(), self.rt.handle().clone());
+        apply_dispatcher_cfg_to(&mut new_inner, dispatcher_cfg)?;
+        let new_ctx = Arc::new(new_inner);
+        self.rebuild_wrappers_with_ctx(py, new_ctx);
         Ok(())
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -392,6 +392,17 @@ impl PyQuebec {
             *guard = preserved_stop_handlers;
         }
 
+        let preserved_supervisor_pid = self
+            .ctx
+            .supervisor_pid
+            .load(std::sync::atomic::Ordering::Relaxed);
+        if preserved_supervisor_pid != 0 {
+            new_ctx.supervisor_pid.store(
+                preserved_supervisor_pid,
+                std::sync::atomic::Ordering::Relaxed,
+            );
+        }
+
         self.ctx = new_ctx;
         self.quebec = new_quebec;
         self.worker = new_worker;
@@ -1194,6 +1205,22 @@ impl PyQuebec {
         self.pyqueue_mode.store(false, Ordering::Relaxed);
 
         Ok(())
+    }
+
+    /// Record the current parent PID so role loops exit gracefully if the
+    /// supervisor dies. Called by the Python supervisor in each child right
+    /// after `reset_after_fork`. Mirrors Solid Queue's `supervised_by`.
+    fn watch_parent_pid(&self) -> PyResult<()> {
+        self.ctx.watch_parent_pid();
+        Ok(())
+    }
+
+    /// Whether the parent PID recorded by `watch_parent_pid` no longer matches
+    /// our current ppid — i.e. the supervisor died and we got reparented.
+    /// Returns `false` when `watch_parent_pid` was never called (the usual
+    /// single-process library case).
+    fn is_orphaned(&self) -> PyResult<bool> {
+        Ok(self.ctx.is_orphaned())
     }
 
     /// Supervisor: register this process as kind="Supervisor" in the `processes`

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1064,12 +1064,23 @@ impl Execution {
         self.timer = Instant::now();
         let mut job = self.job.clone();
         let jid = job.active_job_id.clone().unwrap_or_default();
+        let supervised = self
+            .ctx
+            .supervisor_pid
+            .load(std::sync::atomic::Ordering::Relaxed)
+            != 0;
         let span = tracing::info_span!(
             "runner",
             queue = job.queue_name,
             jid = jid,
-            tid = self.tid.clone()
+            tid = tracing::field::Empty,
+            pid = tracing::field::Empty,
         );
+        if supervised {
+            span.record("pid", std::process::id());
+        } else {
+            span.record("tid", self.tid.clone());
+        }
         // Get cancellation token from context for continuation support
         let cancellation_token = Some(self.ctx.graceful_shutdown.clone());
         let result = async {
@@ -1542,12 +1553,23 @@ impl Execution {
             crate::utils::increment_executions(job.arguments.as_deref(), Some(&exception_key));
 
         let jid = job.active_job_id.clone().unwrap_or_default();
+        let supervised = self
+            .ctx
+            .supervisor_pid
+            .load(std::sync::atomic::Ordering::Relaxed)
+            != 0;
         let span = tracing::info_span!(
             "runner",
             queue = job.queue_name,
             jid = jid,
-            tid = self.tid.clone()
+            tid = tracing::field::Empty,
+            pid = tracing::field::Empty,
         );
+        if supervised {
+            span.record("pid", std::process::id());
+        } else {
+            span.record("tid", self.tid.clone());
+        }
         let _enter = span.enter();
 
         let exception_count =
@@ -3100,8 +3122,23 @@ impl Worker {
             }
         });
 
+        let supervised = self
+            .ctx
+            .supervisor_pid
+            .load(std::sync::atomic::Ordering::Relaxed)
+            != 0;
+        let runner_span = info_span!(
+            "runner",
+            tid = tracing::field::Empty,
+            pid = tracing::field::Empty,
+        );
+        if supervised {
+            runner_span.record("pid", std::process::id());
+        } else {
+            runner_span.record("tid", tid.clone());
+        }
         let ret = runner(self.ctx.clone(), tid.clone(), state, rx)
-            .instrument(info_span!("runner", tid = tid.clone()))
+            .instrument(runner_span)
             .await;
 
         // Call worker stop handlers

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -2219,6 +2219,7 @@ impl Worker {
             &table_config,
             threshold,
             exclude_process_id,
+            self.ctx.use_skip_locked,
         )
         .await?;
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1689,6 +1689,10 @@ impl Worker {
         }
     }
 
+    pub fn process_id_handle(&self) -> Arc<tokio::sync::Mutex<Option<i64>>> {
+        self.process_id.clone()
+    }
+
     fn register_handler(
         &self,
         py: Python,
@@ -2538,7 +2542,7 @@ impl Worker {
     }
 
     /// Fail a single claimed execution: insert failure record, delete claim, release semaphore.
-    async fn fail_claimed_execution<C>(
+    pub(crate) async fn fail_claimed_execution<C>(
         ctx: &Arc<AppContext>,
         db: &C,
         table_config: &TableConfig,
@@ -2556,7 +2560,7 @@ impl Worker {
 
     /// Look up a job's concurrency config, release its semaphore, and unblock the next waiting job.
     /// Used during recovery (orphan/prune) to prevent blocked jobs from getting permanently stuck.
-    async fn unblock_next_job<C>(
+    pub(crate) async fn unblock_next_job<C>(
         ctx: &Arc<AppContext>,
         db: &C,
         table_config: &TableConfig,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -2734,6 +2734,8 @@ impl Worker {
             std::time::Duration::from_secs(3600) // dummy interval when disabled
         };
         let mut cleanup_interval = tokio::time::interval(cleanup_duration);
+        // Orphan check: detect supervisor death via ppid change (Solid Queue parity).
+        let mut parent_check_interval = tokio::time::interval(std::time::Duration::from_secs(1));
         let worker_threads = self.ctx.worker_threads;
         let tx = self.dispatch_sender.clone();
         let ctx = self.ctx.clone();
@@ -2798,6 +2800,14 @@ impl Worker {
                 _ = cleanup_interval.tick(), if cleanup_enabled => {
                     if let Err(e) = self.clear_finished_jobs().await {
                         warn!("Failed to clear finished jobs: {}", e);
+                    }
+                }
+                // Detect supervisor death: if our ppid changed we were reparented
+                // (usually to init/launchd), so shut down gracefully.
+                _ = parent_check_interval.tick() => {
+                    if self.ctx.is_orphaned() {
+                        warn!("Supervisor went away (ppid changed), initiating graceful shutdown");
+                        self.ctx.graceful_shutdown.cancel();
                     }
                 }
                 _ = quit.cancelled() => {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -2735,6 +2735,13 @@ impl Worker {
         };
         let mut cleanup_interval = tokio::time::interval(cleanup_duration);
         // Orphan check: detect supervisor death via ppid change (Solid Queue parity).
+        // Only enabled when running as a supervisor-managed child so the old
+        // single-process threaded mode is unaffected.
+        let supervised = self
+            .ctx
+            .supervisor_pid
+            .load(std::sync::atomic::Ordering::Relaxed)
+            != 0;
         let mut parent_check_interval = tokio::time::interval(std::time::Duration::from_secs(1));
         let worker_threads = self.ctx.worker_threads;
         let tx = self.dispatch_sender.clone();
@@ -2803,8 +2810,9 @@ impl Worker {
                     }
                 }
                 // Detect supervisor death: if our ppid changed we were reparented
-                // (usually to init/launchd), so shut down gracefully.
-                _ = parent_check_interval.tick() => {
+                // (usually to init/launchd), so shut down gracefully. Only armed
+                // for supervisor-managed children.
+                _ = parent_check_interval.tick(), if supervised => {
                     if self.ctx.is_orphaned() {
                         warn!("Supervisor went away (ppid changed), initiating graceful shutdown");
                         self.ctx.graceful_shutdown.cancel();

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -210,8 +210,93 @@ class TestSupervisorPlanFromConfig:
         assert plan is None or isinstance(plan, dict)
         if plan is not None:
             for key, val in plan.items():
-                assert key in {"worker", "dispatcher"}
+                assert key in {"worker", "dispatcher", "scheduler"}
                 assert isinstance(val, int) and val > 0
+
+    def test_scheduler_included_when_recurring_schedule_exists(
+        self, qc, tmp_path, monkeypatch
+    ):
+        """Supervisor plan should fork a scheduler child when recurring.yml
+        is configured, so the scheduler's cron loop runs in its own process
+        instead of piggybacking on the worker child's tokio runtime."""
+        queue_yml = tmp_path / "queue.yml"
+        queue_yml.write_text(
+            """
+development:
+  workers:
+    - queues: "*"
+      threads: 1
+      processes: 2
+"""
+        )
+        recurring_yml = tmp_path / "recurring.yml"
+        recurring_yml.write_text(
+            """
+development:
+  hourly_cleanup:
+    class: CleanupJob
+    schedule: "every hour"
+"""
+        )
+
+        monkeypatch.setenv("QUEBEC_CONFIG", str(queue_yml))
+        monkeypatch.setenv("QUEBEC_RECURRING_SCHEDULE", str(recurring_yml))
+        monkeypatch.delenv("QUEBEC_ENV", raising=False)
+        monkeypatch.delenv("SOLID_QUEUE_RECURRING_SCHEDULE", raising=False)
+
+        plan = qc.supervisor_plan_from_config()
+        assert plan is not None, "supervisor plan should trigger with processes=2"
+        assert plan.get("worker") == 2
+        assert plan.get("scheduler") == 1
+
+    def test_scheduler_omitted_when_no_recurring_schedule(
+        self, qc, tmp_path, monkeypatch
+    ):
+        """Without a recurring.yml, scheduler should NOT be forked — there's
+        nothing for it to do, and forking it would just trip the crash-loop
+        guard when Scheduler.run() exits immediately."""
+        queue_yml = tmp_path / "queue.yml"
+        queue_yml.write_text(
+            """
+development:
+  workers:
+    - queues: "*"
+      threads: 1
+      processes: 2
+"""
+        )
+
+        monkeypatch.setenv("QUEBEC_CONFIG", str(queue_yml))
+        monkeypatch.delenv("QUEBEC_ENV", raising=False)
+        monkeypatch.delenv("QUEBEC_RECURRING_SCHEDULE", raising=False)
+        monkeypatch.delenv("SOLID_QUEUE_RECURRING_SCHEDULE", raising=False)
+        monkeypatch.chdir(tmp_path)  # Ensure no recurring.yml in cwd picks up
+
+        plan = qc.supervisor_plan_from_config()
+        assert plan is not None
+        assert "scheduler" not in plan
+
+    def test_single_process_config_returns_none(self, qc, tmp_path, monkeypatch):
+        """Bare 1-worker + 1-dispatcher config must stay in the single-process
+        threaded path for backward compatibility — the supervisor shouldn't
+        take over just because a config file exists."""
+        queue_yml = tmp_path / "queue.yml"
+        queue_yml.write_text(
+            """
+development:
+  workers:
+    - queues: "*"
+      threads: 3
+  dispatchers:
+    - polling_interval: 1
+"""
+        )
+
+        monkeypatch.setenv("QUEBEC_CONFIG", str(queue_yml))
+        monkeypatch.delenv("QUEBEC_ENV", raising=False)
+        monkeypatch.chdir(tmp_path)
+
+        assert qc.supervisor_plan_from_config() is None
 
 
 class TestResetAfterFork:

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -1,0 +1,253 @@
+"""Tests for the supervisor DB-layer APIs and Python orchestration class.
+
+These tests exercise the Rust-exposed methods that the Python Supervisor
+relies on (register/heartbeat/deregister, fail_claimed_by_pid,
+fail_claimed_by_process_id, reset_after_fork, apply_*_config,
+supervisor_plan_from_config) without actually forking child processes.
+
+End-to-end fork tests are intentionally not included here: pytest + tokio
+runtimes + fork is fragile, and the individual pieces are covered below.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+
+import pytest
+from sqlalchemy import text
+
+
+def _insert_claimed(session, prefix: str, process_id: int, job_class: str = "TestJob"):
+    """Insert a minimal job + claimed_execution row for a given process_id.
+
+    Returns the new job_id.
+    """
+    now_sql = "CURRENT_TIMESTAMP"
+    session.execute(
+        text(
+            f"INSERT INTO {prefix}_jobs "
+            f"(queue_name, class_name, arguments, priority, active_job_id, "
+            f"scheduled_at, finished_at, concurrency_key, created_at, updated_at) "
+            f"VALUES ('default', :class_name, '[]', 0, 'ajid', NULL, NULL, NULL, "
+            f"{now_sql}, {now_sql})"
+        ),
+        {"class_name": job_class},
+    )
+    job_id = session.execute(text("SELECT last_insert_rowid()")).scalar()
+    session.execute(
+        text(
+            f"INSERT INTO {prefix}_claimed_executions "
+            f"(job_id, process_id, created_at) "
+            f"VALUES (:job_id, :process_id, {now_sql})"
+        ),
+        {"job_id": job_id, "process_id": process_id},
+    )
+    session.commit()
+    return job_id
+
+
+class TestSupervisorRegistration:
+    def test_register_supervisor_creates_processes_row(self, qc_with_sqlalchemy):
+        qc = qc_with_sqlalchemy["qc"]
+        session = qc_with_sqlalchemy["session"]
+        prefix = qc_with_sqlalchemy["prefix"]
+
+        pid = qc.register_supervisor()
+        assert isinstance(pid, int) and pid > 0
+
+        row = session.execute(
+            text(f"SELECT kind, pid, hostname FROM {prefix}_processes WHERE id = :id"),
+            {"id": pid},
+        ).fetchone()
+        assert row is not None
+        assert row.kind == "Supervisor"
+        assert row.pid == os.getpid()
+
+    def test_heartbeat_updates_last_heartbeat_at(self, qc_with_sqlalchemy):
+        qc = qc_with_sqlalchemy["qc"]
+        session = qc_with_sqlalchemy["session"]
+        prefix = qc_with_sqlalchemy["prefix"]
+
+        pid = qc.register_supervisor()
+        initial = session.execute(
+            text(f"SELECT last_heartbeat_at FROM {prefix}_processes WHERE id = :id"),
+            {"id": pid},
+        ).scalar()
+
+        qc.heartbeat_process(pid)
+        session.expire_all()
+        updated = session.execute(
+            text(f"SELECT last_heartbeat_at FROM {prefix}_processes WHERE id = :id"),
+            {"id": pid},
+        ).scalar()
+        # Timestamps are strings in SQLite; just require an update attempt
+        # actually ran without raising and the row still exists.
+        assert updated is not None
+        assert initial is not None
+
+    def test_deregister_removes_row(self, qc_with_sqlalchemy):
+        qc = qc_with_sqlalchemy["qc"]
+        session = qc_with_sqlalchemy["session"]
+        prefix = qc_with_sqlalchemy["prefix"]
+
+        pid = qc.register_supervisor()
+        qc.deregister_process(pid)
+
+        remaining = session.execute(
+            text(f"SELECT COUNT(*) FROM {prefix}_processes WHERE id = :id"),
+            {"id": pid},
+        ).scalar()
+        assert remaining == 0
+
+
+class TestFailClaimed:
+    def test_fail_claimed_by_process_id_moves_to_failed(self, qc_with_sqlalchemy):
+        qc = qc_with_sqlalchemy["qc"]
+        session = qc_with_sqlalchemy["session"]
+        prefix = qc_with_sqlalchemy["prefix"]
+
+        # Register a fake worker-like row to attach a claim to
+        process_id = qc.register_supervisor()  # kind doesn't matter here
+        job_id = _insert_claimed(session, prefix, process_id)
+
+        assert (
+            session.execute(
+                text(
+                    f"SELECT COUNT(*) FROM {prefix}_claimed_executions WHERE job_id = :id"
+                ),
+                {"id": job_id},
+            ).scalar()
+            == 1
+        )
+
+        failed = qc.supervisor_fail_claimed_by_process_id(process_id)
+        assert failed == 1
+
+        # Claim row removed, failed row created, process row pruned
+        session.expire_all()
+        assert (
+            session.execute(
+                text(
+                    f"SELECT COUNT(*) FROM {prefix}_claimed_executions WHERE job_id = :id"
+                ),
+                {"id": job_id},
+            ).scalar()
+            == 0
+        )
+        assert (
+            session.execute(
+                text(
+                    f"SELECT COUNT(*) FROM {prefix}_failed_executions WHERE job_id = :id"
+                ),
+                {"id": job_id},
+            ).scalar()
+            == 1
+        )
+        assert (
+            session.execute(
+                text(f"SELECT COUNT(*) FROM {prefix}_processes WHERE id = :id"),
+                {"id": process_id},
+            ).scalar()
+            == 0
+        )
+
+    def test_fail_claimed_by_pid_uses_hostname_scope(self, qc_with_sqlalchemy):
+        qc = qc_with_sqlalchemy["qc"]
+        session = qc_with_sqlalchemy["session"]
+        prefix = qc_with_sqlalchemy["prefix"]
+
+        # Register and insert a claim attached to that process row
+        process_id = qc.register_supervisor()
+        _insert_claimed(session, prefix, process_id)
+
+        # Wrong hostname finds nothing
+        assert qc.supervisor_fail_claimed_by_pid(os.getpid(), "wrong-host") == 0
+
+        # Correct hostname reaps the row
+        failed = qc.supervisor_fail_claimed_by_pid(os.getpid(), socket.gethostname())
+        assert failed == 1
+
+    def test_fail_claimed_missing_row_returns_zero(self, qc_with_sqlalchemy):
+        qc = qc_with_sqlalchemy["qc"]
+        assert qc.supervisor_fail_claimed_by_process_id(999999) == 0
+        assert qc.supervisor_fail_claimed_by_pid(999999, socket.gethostname()) == 0
+
+
+class TestCurrentProcessIds:
+    def test_accessors_none_before_start(self, qc):
+        assert qc.current_worker_process_id() is None
+        assert qc.current_dispatcher_process_id() is None
+        assert qc.current_scheduler_process_id() is None
+
+
+class TestApplyConfig:
+    def test_apply_worker_config_out_of_range_raises(self, qc):
+        # No queue.yml loaded in this test context; out-of-range should raise
+        # IndexError (or be a no-op if config missing). We can't guarantee
+        # which without a config file, so accept either behavior.
+        try:
+            qc.apply_worker_config(99)
+        except IndexError:
+            pass
+        except Exception as exc:
+            pytest.fail(f"unexpected exception: {exc!r}")
+
+    def test_apply_dispatcher_config_out_of_range_raises(self, qc):
+        try:
+            qc.apply_dispatcher_config(99)
+        except IndexError:
+            pass
+        except Exception as exc:
+            pytest.fail(f"unexpected exception: {exc!r}")
+
+
+class TestSupervisorPlanFromConfig:
+    def test_returns_dict_or_none(self, qc):
+        # Whether a queue.yml exists in the cwd is environment-dependent; just
+        # verify the method returns the right *shape* and never raises.
+        plan = qc.supervisor_plan_from_config()
+        assert plan is None or isinstance(plan, dict)
+        if plan is not None:
+            for key, val in plan.items():
+                assert key in {"worker", "dispatcher"}
+                assert isinstance(val, int) and val > 0
+
+
+class TestResetAfterFork:
+    def test_reset_after_fork_is_idempotent_and_preserves_apis(self, qc):
+        # Called without a fork, reset should still run: it rebuilds the
+        # runtime/pool from scratch. A second call should also succeed.
+        qc.reset_after_fork()
+        # Basic sanity: DB is still usable
+        assert qc.ping() is True
+        qc.reset_after_fork()
+        assert qc.ping() is True
+
+
+class TestSupervisorClassValidation:
+    def test_rejects_unknown_role(self, qc):
+        from quebec.supervisor import Supervisor
+
+        with pytest.raises(ValueError, match="unknown role"):
+            Supervisor(qc, {"ghost_role": 1})
+
+    def test_rejects_empty_plan(self, qc):
+        from quebec.supervisor import Supervisor
+
+        with pytest.raises(ValueError, match="at least one"):
+            Supervisor(qc, {})
+
+    def test_rejects_all_zero_plan(self, qc):
+        from quebec.supervisor import Supervisor
+
+        with pytest.raises(ValueError, match="at least one"):
+            Supervisor(qc, {"worker": 0})
+
+    def test_accepts_int_or_list_spec(self, qc):
+        from quebec.supervisor import Supervisor
+
+        # Integer count
+        Supervisor(qc, {"worker": 2})
+        # List-style (length is what matters)
+        Supervisor(qc, {"worker": [None, None, None]})


### PR DESCRIPTION
## Summary

Add a Solid Queue-style multi-process supervisor so Quebec can run worker / dispatcher / scheduler in **separate forked processes** under one parent. Until now Quebec was single-process tokio, with `workers.processes: N` in config silently ignored. This PR makes that field load-bearing and adds the matching parent process behavior: crash isolation, claim cleanup on child death, signal forwarding, graceful shutdown with SIGQUIT/SIGKILL escalation.

### Architecture

```
Parent (Supervisor)
 ├── Owns DB connection + control plane socket; registers as kind=Supervisor
 ├── No tokio worker/dispatcher/scheduler tasks
 ├── Forks N children (per-role per-instance from config)
 ├── waitpid loop: child died → fail its claimed_executions → respawn
 └── SIGTERM/INT → forward → SIGQUIT after timeout → SIGKILL last resort

Child (Worker / Dispatcher / Scheduler)
 ├── reset_after_fork() rebuilds tokio runtime + DB pool + tokens
 ├── apply_*_config(i) for the i-th instance from config
 └── Runs one role's normal loop
```

### Rust side

- **`PyQuebec::reset_after_fork`** rebuilds tokio runtime and DB pool after fork; preserves runnables / concurrency / table_config / job class registry; clears `INSTANCE_MAP` self-entry, `idle_notify`, `control_plane_router`, `handles`. Old runtime is intentionally **leaked** to avoid kqueue-fd panic on macOS (`8af5222`).
- **Supervisor DB API** (`src/supervisor.rs`): `fail_claimed_by_process_id`, maintenance task that prunes stale processes / claims with `FOR UPDATE SKIP LOCKED`, ran once at boot and periodically (`4011514`, `8f214cd`, `8bb67de`).
- **Process registration** for each role with `process_id` round-tripped to parent via `current_*_process_id()` getters; Dispatcher / Scheduler now hold `process_id: Arc<Mutex<Option<i64>>>` like Worker.
- **Per-role proctitle** rewriting via `setproctitle` (now handles short-argv buffers, `4d06b3a`); supervised children show pid in `runner` span instead of tid (`f730fee`).
- **Config**: `DispatcherConfig` gains `processes`; supervisor plan auto-includes scheduler when a recurring schedule exists (`bdd15d9`).

### Python side

- **`python/quebec/supervisor.py`** (new, ~450 lines): `Supervisor` class drives `os.fork()`, `waitpid` reap loop, signal handling, graceful shutdown with `shutdown_timeout` (default 5s, matching Solid Queue), SIGQUIT/SIGKILL escalation (`764c4d8`, `c9d1684`), self-termination of children when parent dies (`8174ecc`, `8b96c65`).
- **`python/quebec/__init__.py`**: `_quebec_run` recognizes the supervisor plan from config (worker / dispatcher / scheduler instances) and routes to `Supervisor.start()`. `qc.run()` no longer takes `processes=` kwarg — config is the source of truth (`f0eb111`).
- **Auto-detect** behind `QUEBEC_SUPERVISOR=1` to keep single-process mode the default for existing users (`027074a`).
- **Control plane** binds **after fork** in supervisor process to keep its listener socket parent-only (`1b6ed8e`).

### Robustness fixes encountered along the way

- Worker handlers preserved across `reset_after_fork` (`7f38d48`)
- Heartbeat sees its row gone → graceful self-shutdown rather than panic (`d3b1006`)
- Old tokio runtime leaked on reset (`8af5222`)

## Scope notes

- **Unix-only** (Phase 1); Windows lacks `fork()` and is out of scope here
- Single-process tokio mode is unchanged when supervisor is not enabled
- Crash-loop protection (StartLimitBurst-style) and Windows spawn fallback are deferred

## Test plan

- [x] `cargo check` / `cargo clippy --all-targets --all-features` / `cargo fmt --all -- --check`
- [x] `uv run --with maturin maturin develop`
- [x] `QUEBEC_SKIP_IMPORT_HOOK=1 uv run pytest --ignore=tests/step_defs` — full suite passes
- [x] **`tests/test_supervisor.py`** (new, 338 lines): normal startup, automatic restart on SIGKILL, `claimed_executions` failure marking, graceful shutdown via SIGTERM, SIGKILL on shutdown timeout
- [x] Manual smoke: `QUEBEC_SUPERVISOR=1 uv run python -m quebec demo.jobs` with `workers.processes: 2` — `ps` shows 1 supervisor + 2 workers + 1 dispatcher + 1 scheduler; `kill -9` a worker → respawn within seconds; `kill -TERM` supervisor → all children exit cleanly, `processes` table empty