### PR TITLE
chore: replace unmaintained atty with std::io::IsTerminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,17 +154,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,15 +946,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hex"
@@ -2007,7 +1987,6 @@ dependencies = [
  "anyhow",
  "async-stream",
  "async-trait",
- "atty",
  "axum",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,6 @@ http-body-util = "0.1"
 tera = "1.19"
 tower-http = { version = "0.5", features = ["trace", "fs"] }
 rust-embed = { version = "8.7.2", features = ["include-exclude", "debug-embed"] }
-atty = "0.2.14"
 regex = "1.10"
 proctitle = "0.1.1"
 libc = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ fn init_logging() {
     let use_ansi = match std::env::var("QUEBEC_COLOR").as_deref() {
         Ok("always") => true,
         Ok("never") => false,
-        _ => atty::is(atty::Stream::Stdout),
+        _ => std::io::IsTerminal::is_terminal(&std::io::stdout()),
     };
 
     let result = match format.as_str() {


### PR DESCRIPTION
## Summary
- `atty 0.2.14` is unmaintained (RUSTSEC-2021-0145).
- `std::io::IsTerminal` has been stable since Rust 1.70 and is a drop-in replacement for the single call site in `src/lib.rs`.
- Removes the dependency from `Cargo.toml` and `Cargo.lock`.

## Test plan
- [x] `cargo check`
- [x] `cargo clippy --all-targets --all-features` (only pre-existing warnings)
- [x] `cargo fmt --all -- --check`