### PR TITLE
chore: clean up unwrap()/expect() patterns in production paths

### DIFF
--- a/src/continuation.rs
+++ b/src/continuation.rs
@@ -190,9 +190,8 @@ impl StepContext {
                 } else if let Ok(s) = val.extract::<String>() {
                     // For strings, try to implement succ-like behavior
                     // This is a simplified version - just increment last char
-                    let char_count = s.chars().count();
-                    if char_count > 0 {
-                        let last_char = s.chars().last().unwrap();
+                    if let Some(last_char) = s.chars().last() {
+                        let char_count = s.chars().count();
                         let next_char = char::from_u32(last_char as u32 + 1).unwrap_or(last_char);
                         let new_str: String = s.chars().take(char_count - 1).collect::<String>()
                             + &next_char.to_string();
@@ -219,9 +218,8 @@ impl StepContext {
                     }
                     Some(serde_json::Value::String(s)) => {
                         // String succ - use char count, not byte length
-                        let char_count = s.chars().count();
-                        if char_count > 0 {
-                            let last_char = s.chars().last().unwrap();
+                        if let Some(last_char) = s.chars().last() {
+                            let char_count = s.chars().count();
                             let next_char =
                                 char::from_u32(last_char as u32 + 1).unwrap_or(last_char);
                             let new_str: String =

--- a/src/control_plane/mod.rs
+++ b/src/control_plane/mod.rs
@@ -233,7 +233,7 @@ impl ControlPlane {
             http::Response::builder()
                 .status(500)
                 .body(axum::body::Body::from("Internal Server Error"))
-                .unwrap()
+                .expect("static response builder is infallible")
         });
 
         let status = response.status().as_u16();

--- a/src/control_plane/utils.rs
+++ b/src/control_plane/utils.rs
@@ -196,7 +196,7 @@ impl ControlPlane {
         Response::builder()
             .status(StatusCode::INTERNAL_SERVER_ERROR)
             .body(axum::body::Body::empty())
-            .unwrap()
+            .expect("static response builder is infallible")
     }
 
     /// Return a 404 Not Found response (for stale/missing rows)
@@ -204,7 +204,7 @@ impl ControlPlane {
         Response::builder()
             .status(StatusCode::NOT_FOUND)
             .body(axum::body::Body::empty())
-            .unwrap()
+            .expect("static response builder is infallible")
     }
 
     /// Redirect back to the given URL with 303 See Other
@@ -213,7 +213,7 @@ impl ControlPlane {
             .status(StatusCode::SEE_OTHER)
             .header(header::LOCATION, url)
             .body(axum::body::Body::empty())
-            .unwrap()
+            .expect("static response builder is infallible")
     }
 
     /// Get pagination parameters

--- a/src/query_builder.rs
+++ b/src/query_builder.rs
@@ -1917,16 +1917,13 @@ pub mod blocked_executions {
             .from(table.clone())
             .to_owned();
 
-        if class_name.is_some() {
+        if let Some(cn) = class_name {
             query.inner_join(
                 jobs,
                 Expr::col((table.clone(), col("job_id")))
                     .equals((Alias::new(&table_config.jobs), col("id"))),
             );
-            query.and_where(
-                Expr::col((Alias::new(&table_config.jobs), col("class_name")))
-                    .eq(class_name.unwrap()),
-            );
+            query.and_where(Expr::col((Alias::new(&table_config.jobs), col("class_name"))).eq(cn));
         }
         if let Some(qn) = queue_name {
             query.and_where(Expr::col((table, col("queue_name"))).eq(qn));
@@ -1971,16 +1968,13 @@ pub mod blocked_executions {
             .limit(limit)
             .to_owned();
 
-        if class_name.is_some() {
+        if let Some(cn) = class_name {
             query.inner_join(
                 jobs,
                 Expr::col((table.clone(), col("job_id")))
                     .equals((Alias::new(&table_config.jobs), col("id"))),
             );
-            query.and_where(
-                Expr::col((Alias::new(&table_config.jobs), col("class_name")))
-                    .eq(class_name.unwrap()),
-            );
+            query.and_where(Expr::col((Alias::new(&table_config.jobs), col("class_name"))).eq(cn));
         }
         if let Some(qn) = queue_name {
             query.and_where(Expr::col((table, col("queue_name"))).eq(qn));

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -896,20 +896,16 @@ impl Scheduler {
         trace!("Schedule: {:?}", schedule);
 
         // Match Solid Queue: when recurring_tasks is empty, don't start Scheduler.
-        let has_tasks = schedule
-            .as_ref()
-            .is_some_and(|s| s.iter().any(|m| !m.is_empty()));
-        if !has_tasks {
+        let Some(schedule) = schedule.filter(|s| s.iter().any(|m| !m.is_empty())) else {
             info!("No recurring tasks found, skipping scheduler");
             return Ok(());
-        }
+        };
 
         let process = self.on_start(&db).await?;
         info!(">> Process started: {:?}", process);
         *self.process_id.lock().await = Some(process.id);
 
-        let scheduled =
-            Self::sync_tasks_to_db(&*db, &self.ctx.table_config, schedule.unwrap()).await?;
+        let scheduled = Self::sync_tasks_to_db(&*db, &self.ctx.table_config, schedule).await?;
 
         let mut task_handles = Vec::new();
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -2338,11 +2338,12 @@ impl PyQuebec {
             rt.block_on(async {
                 let mut router = {
                     let mut guard = router_lock.lock().await;
-                    if guard.is_none() {
-                        let cp = Arc::new(ControlPlane::new(ctx).with_base_path(base_path));
-                        *guard = Some(cp.build_router());
-                    }
-                    guard.as_ref().unwrap().clone()
+                    guard
+                        .get_or_insert_with(|| {
+                            let cp = Arc::new(ControlPlane::new(ctx).with_base_path(base_path));
+                            cp.build_router()
+                        })
+                        .clone()
                 };
                 ControlPlane::handle_request(&mut router, &method, &uri, headers, body).await
             })


### PR DESCRIPTION
## Summary
Cleanup pass on `unwrap()`/`expect()` call sites flagged by a Rust best-practices review. No behavior change — all rewrites preserve the same semantics with safer / more idiomatic patterns.

- `src/query_builder.rs` (2 sites): `is_some() + .unwrap()` → `if let Some(cn)` — also resolves the standing `clippy::unnecessary_unwrap` warnings.
- `src/scheduler.rs`: collapse the `is_some_and(...)` check + `schedule.unwrap()` into a single `let-else` with `filter`.
- `src/types.rs`: `if guard.is_none() { ... } guard.as_ref().unwrap().clone()` → `guard.get_or_insert_with(...).clone()`.
- `src/continuation.rs` (2 sites): `if char_count > 0 { let last_char = s.chars().last().unwrap(); ... }` → `if let Some(last_char) = s.chars().last()`.
- `src/control_plane/{mod,utils}.rs` (4 sites): `Response::builder().body(...).unwrap()` → `.expect("static response builder is infallible")` (the builder is infallible for these inputs; keeping `expect` with justification per skill guidance).

## Test plan
- [x] `cargo check`
- [x] `cargo clippy --all-targets --all-features` (clean — `unnecessary_unwrap` warnings gone)
- [x] `cargo fmt --all -- --check`
- [x] `uv run --with maturin maturin develop`
- [x] `QUEBEC_SKIP_IMPORT_HOOK=1 uv run pytest --ignore=tests/step_defs` (97 passed)