### PR TITLE
chore: misc cleanups (drop unreachable!, unused macros, eprintln!)

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -673,28 +673,29 @@ impl AppContext {
     }
 
     pub async fn get_db(&self) -> Result<Arc<DatabaseConnection>, DbErr> {
-        for retry in 0..3 {
+        const MAX_RETRIES: u32 = 3;
+        let mut attempt: u32 = 0;
+        loop {
             match self.get_db_inner().await {
                 Ok(db) => return Ok(db),
                 Err(e) => {
-                    if retry < 2 {
-                        warn!(
-                            "Failed to get database connection, retrying ({}/3): {}",
-                            retry + 1,
-                            e
+                    attempt += 1;
+                    if attempt >= MAX_RETRIES {
+                        error!(
+                            "Failed to get database connection after {} retries: {}",
+                            MAX_RETRIES, e
                         );
-                        tokio::time::sleep(tokio::time::Duration::from_millis(
-                            100 * (retry + 1) as u64,
-                        ))
-                        .await;
-                    } else {
-                        error!("Failed to get database connection after 3 retries: {}", e);
                         return Err(e);
                     }
+                    warn!(
+                        "Failed to get database connection, retrying ({}/{}): {}",
+                        attempt, MAX_RETRIES, e
+                    );
+                    tokio::time::sleep(tokio::time::Duration::from_millis(100 * attempt as u64))
+                        .await;
                 }
             }
         }
-        unreachable!()
     }
 
     /// Check if the database is PostgreSQL

--- a/src/error.rs
+++ b/src/error.rs
@@ -149,22 +149,6 @@ where
     }
 }
 
-/// Helper macro for quickly creating errors
-#[macro_export]
-macro_rules! quebec_error {
-    ($variant:ident, $($arg:tt)*) => {
-        $crate::error::QuebecError::$variant(format!($($arg)*))
-    };
-}
-
-/// Helper macro for quickly returning errors
-#[macro_export]
-macro_rules! bail {
-    ($($arg:tt)*) => {
-        return Err($crate::error::QuebecError::Runtime(format!($($arg)*)))
-    };
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/proctitle_macos.rs
+++ b/src/proctitle_macos.rs
@@ -7,6 +7,7 @@ use std::ffi::CString;
 use std::os::raw::c_char;
 use std::ptr;
 use std::sync::Mutex;
+use tracing::error;
 
 static PROCTITLE_STATE: Mutex<Option<ProcTitleState>> = Mutex::new(None);
 
@@ -127,7 +128,7 @@ pub fn set_title(title: &str) {
                 state.write_title(title);
             }
         } else {
-            eprintln!("Failed to initialize proctitle system");
+            error!("Failed to initialize proctitle system");
         }
     }
 


### PR DESCRIPTION
## Summary
Three small, independent cleanups from the Rust best-practices review. No behavior change.

- **`src/context.rs::get_db()`** — replace `for retry in 0..3 { ... } unreachable!()` with `loop { match ... }`. Every branch returns from inside the loop, so the type checker no longer needs the unreachable panic. Retry count and backoff schedule (100ms × attempt) are unchanged.
- **`src/error.rs`** — delete the unused `quebec_error!` and `bail!` helper macros. They had no callers, and `bail!` shadowed `anyhow::bail!` while degrading any structured variants down to the generic `Runtime` string.
- **`src/proctitle_macos.rs`** — replace a lone `eprintln!("Failed to initialize proctitle system")` with `tracing::error!` so the failure lands in the standard log pipeline.

## Test plan
- [x] `cargo check`
- [x] `cargo clippy --all-targets --all-features` (only the two pre-existing `unnecessary_unwrap` warnings already fixed in #30)
- [x] `cargo fmt --all -- --check`
- [x] `uv run --with maturin maturin develop`
- [x] `QUEBEC_SKIP_IMPORT_HOOK=1 uv run pytest --ignore=tests/step_defs` — 97 passed