### PR TITLE
refactor(error): preserve source chain across error boundaries

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -71,6 +71,14 @@ pub enum QuebecError {
     /// Unsupported operations
     #[error("Unsupported operation: {0}")]
     Unsupported(String),
+
+    /// Wrapped anyhow error preserving the underlying source chain
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+
+    /// PostgreSQL driver errors (preserves source chain)
+    #[error(transparent)]
+    Postgres(#[from] tokio_postgres::Error),
 }
 
 /// Type alias for simplified usage
@@ -98,13 +106,6 @@ impl QuebecError {
     }
 }
 
-/// Convert from anyhow::Error
-impl From<anyhow::Error> for QuebecError {
-    fn from(err: anyhow::Error) -> Self {
-        Self::Generic(err.to_string())
-    }
-}
-
 /// Convert from pyo3::PyErr
 #[cfg(feature = "python")]
 impl From<pyo3::PyErr> for QuebecError {
@@ -126,13 +127,6 @@ impl From<QuebecError> for pyo3::PyErr {
 impl From<croner::errors::CronError> for QuebecError {
     fn from(err: croner::errors::CronError) -> Self {
         Self::InvalidCron(err.to_string())
-    }
-}
-
-/// Convert from tokio_postgres errors
-impl From<tokio_postgres::Error> for QuebecError {
-    fn from(err: tokio_postgres::Error) -> Self {
-        Self::Database(DbErr::Custom(err.to_string()))
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `Other(#[from] anyhow::Error)` and `Postgres(#[from] tokio_postgres::Error)` variants on `QuebecError`, both `#[error(transparent)]`.
- Remove the manual `From<anyhow::Error>` / `From<tokio_postgres::Error>` impls that stringified into `Generic(String)` / `Database(DbErr::Custom(...))`.

This is **Phase A** of an incremental migration toward standardizing on `crate::Result` (= `Result<T, QuebecError>`) at internal boundaries. It is intentionally tiny and focused on the conversion semantics — no call sites change.

## Why
Both pre-existing impls discarded the source chain via `err.to_string()`, so consumers of `QuebecError::source()` (e.g. log formatters, future `anyhow`-style backtrace propagation) only saw the top-level message. After this change, `Display` is unchanged (transparent forwards to the inner error), but `source()` now returns the original error.

## Test plan
- [x] `cargo check`
- [x] `cargo clippy --all-targets --all-features` (only pre-existing warnings unrelated to this PR)
- [x] `cargo fmt --all -- --check`
- [x] `uv run --with maturin maturin develop`
- [x] `QUEBEC_SKIP_IMPORT_HOOK=1 uv run pytest --ignore=tests/step_defs` → 97 passed