### PR TITLE
refactor(notify): use crate::Result<T> instead of anyhow::Result

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -71,6 +71,14 @@ pub enum QuebecError {
     /// Unsupported operations
     #[error("Unsupported operation: {0}")]
     Unsupported(String),
+
+    /// Wrapped anyhow error preserving the underlying source chain
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+
+    /// PostgreSQL driver errors (preserves source chain)
+    #[error(transparent)]
+    Postgres(#[from] tokio_postgres::Error),
 }
 
 /// Type alias for simplified usage
@@ -98,13 +106,6 @@ impl QuebecError {
     }
 }
 
-/// Convert from anyhow::Error
-impl From<anyhow::Error> for QuebecError {
-    fn from(err: anyhow::Error) -> Self {
-        Self::Generic(err.to_string())
-    }
-}
-
 /// Convert from pyo3::PyErr
 #[cfg(feature = "python")]
 impl From<pyo3::PyErr> for QuebecError {
@@ -126,13 +127,6 @@ impl From<QuebecError> for pyo3::PyErr {
 impl From<croner::errors::CronError> for QuebecError {
     fn from(err: croner::errors::CronError) -> Self {
         Self::InvalidCron(err.to_string())
-    }
-}
-
-/// Convert from tokio_postgres errors
-impl From<tokio_postgres::Error> for QuebecError {
-    fn from(err: tokio_postgres::Error) -> Self {
-        Self::Database(DbErr::Custom(err.to_string()))
     }
 }
 

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -1,4 +1,5 @@
 use crate::context::AppContext;
+use crate::error::{QuebecError, Result};
 use sea_orm::*;
 use sqlx::postgres::PgListener;
 use std::sync::Arc;
@@ -28,10 +29,10 @@ impl NotifyManager {
 
     /// Start listening for PostgreSQL NOTIFY messages
     /// Returns a receiver that will get notifications when new jobs are available
-    pub async fn start_listener(&self) -> Result<mpsc::Receiver<String>, anyhow::Error> {
+    pub async fn start_listener(&self) -> Result<mpsc::Receiver<String>> {
         if !self.ctx.is_postgres() {
-            return Err(anyhow::anyhow!(
-                "LISTEN/NOTIFY is only supported on PostgreSQL"
+            return Err(QuebecError::Unsupported(
+                "LISTEN/NOTIFY is only supported on PostgreSQL".into(),
             ));
         }
 
@@ -85,13 +86,18 @@ impl NotifyManager {
         channel: &str,
         tx: &mpsc::Sender<String>,
         graceful_shutdown: &tokio_util::sync::CancellationToken,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<()> {
         // Create a dedicated connection for LISTEN with optimized settings
         // Note: PgListener creates its own connection internally, so we use the DSN directly
-        let mut listener = PgListener::connect(dsn).await?;
+        let mut listener = PgListener::connect(dsn)
+            .await
+            .map_err(|e| QuebecError::Other(e.into()))?;
 
         // Start listening on the channel
-        listener.listen(channel).await?;
+        listener
+            .listen(channel)
+            .await
+            .map_err(|e| QuebecError::Other(e.into()))?;
         info!(
             "Started LISTEN on channel: {} (dedicated connection)",
             channel
@@ -104,7 +110,7 @@ impl NotifyManager {
                         Ok(n) => n,
                         Err(e) => {
                             error!("Error receiving NOTIFY on {}: {}", channel, e);
-                            return Err(anyhow::anyhow!("LISTEN receive error: {}", e));
+                            return Err(QuebecError::Other(e.into()));
                         }
                     };
 
@@ -136,12 +142,7 @@ impl NotifyManager {
     }
 
     /// Static method to send NOTIFY using existing database connection
-    pub async fn send_notify<C>(
-        app_name: &str,
-        db: &C,
-        queue_name: &str,
-        event: &str,
-    ) -> Result<(), anyhow::Error>
+    pub async fn send_notify<C>(app_name: &str, db: &C, queue_name: &str, event: &str) -> Result<()>
     where
         C: ConnectionTrait,
     {
@@ -149,8 +150,7 @@ impl NotifyManager {
             queue: queue_name.to_string(),
             event: event.to_string(),
         };
-        let message_json = serde_json::to_string(&message)
-            .map_err(|e| anyhow::anyhow!("Failed to serialize notify message: {}", e))?;
+        let message_json = serde_json::to_string(&message)?;
 
         // Use the same naming convention as LISTEN
         let channel_name = format!("{}_jobs", app_name);
@@ -158,11 +158,7 @@ impl NotifyManager {
     }
 
     /// Internal helper to send NOTIFY with database connection and channel name
-    async fn send_notify_with_db<C>(
-        db: &C,
-        channel_name: &str,
-        message: &str,
-    ) -> Result<(), anyhow::Error>
+    async fn send_notify_with_db<C>(db: &C, channel_name: &str, message: &str) -> Result<()>
     where
         C: ConnectionTrait,
     {
@@ -170,22 +166,21 @@ impl NotifyManager {
         let escaped_message = message.replace("'", "''"); // Escape single quotes
         let sql = format!("NOTIFY {}, '{}'", channel_name, escaped_message);
 
-        let ret = db
+        match db
             .execute(Statement::from_sql_and_values(
                 db.get_database_backend(),
                 sql,
                 vec![],
             ))
-            .await;
-
-        match ret {
+            .await
+        {
             Ok(_) => {
                 trace!("NOTIFY sent on channel {}: {}", channel_name, message);
                 Ok(())
             }
             Err(e) => {
                 warn!("Failed to send NOTIFY on channel {}: {}", channel_name, e);
-                Err(anyhow::anyhow!("NOTIFY failed: {}", e))
+                Err(e.into())
             }
         }
     }


### PR DESCRIPTION
## Summary
- Switch `notify.rs` public/internal signatures from `Result<_, anyhow::Error>` to `crate::Result<_>` (= `Result<_, QuebecError>`).
- "LISTEN/NOTIFY only on PostgreSQL" returns `QuebecError::Unsupported` (semantically appropriate variant).
- External `sqlx::Error` flows through the transparent `Other(anyhow::Error)` variant — preserves source chain via `Phase A`.
- Internal `serde_json::Error` and `DbErr` propagate via `?` (already had `#[from]` on `QuebecError`).

This is **Phase B (1/n)** of a larger consistency pass aligning the codebase on `crate::Result` everywhere — see PR #33 for the boundary plumbing this depends on.

## Why
Mixing `anyhow::Result` and `crate::Result` in the same codebase forces every author to make a (subjective) call about whether a function is "boundary" or "plumbing." The whole point of having `QuebecError` is to give the codebase **one** error type — not two competing conventions. With Phase A in place, the cost of using `crate::Result` in plumbing modules is essentially zero (just an extra `use` line).

Call sites in `core.rs`, `worker.rs`, `dispatcher.rs`, `scheduler.rs`, `control_plane/handlers/recurring_jobs.rs` all use `.inspect_err(...).ok()` or pattern-match on the error via `Display` only — fully backwards compatible.

Depends on #33 (rebased on top).

## Test plan
- [x] \`cargo check\`
- [x] \`cargo clippy --all-targets --all-features\`
- [x] \`cargo fmt --all -- --check\`
- [x] \`uv run --with maturin maturin develop\`
- [x] \`QUEBEC_SKIP_IMPORT_HOOK=1 uv run pytest --ignore=tests/step_defs\` → 97 passed