### PR TITLE
refactor(utils): use crate::Result<T> in parse_env_config helpers

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -71,6 +71,14 @@ pub enum QuebecError {
     /// Unsupported operations
     #[error("Unsupported operation: {0}")]
     Unsupported(String),
+
+    /// Wrapped anyhow error preserving the underlying source chain
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+
+    /// PostgreSQL driver errors (preserves source chain)
+    #[error(transparent)]
+    Postgres(#[from] tokio_postgres::Error),
 }
 
 /// Type alias for simplified usage
@@ -98,13 +106,6 @@ impl QuebecError {
     }
 }
 
-/// Convert from anyhow::Error
-impl From<anyhow::Error> for QuebecError {
-    fn from(err: anyhow::Error) -> Self {
-        Self::Generic(err.to_string())
-    }
-}
-
 /// Convert from pyo3::PyErr
 #[cfg(feature = "python")]
 impl From<pyo3::PyErr> for QuebecError {
@@ -126,13 +127,6 @@ impl From<QuebecError> for pyo3::PyErr {
 impl From<croner::errors::CronError> for QuebecError {
     fn from(err: croner::errors::CronError) -> Self {
         Self::InvalidCron(err.to_string())
-    }
-}
-
-/// Convert from tokio_postgres errors
-impl From<tokio_postgres::Error> for QuebecError {
-    fn from(err: tokio_postgres::Error) -> Self {
-        Self::Database(DbErr::Custom(err.to_string()))
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -340,7 +340,7 @@ pub fn increment_executions(arguments: Option<&str>, exception_key: Option<&str>
 /// available environment if the specified one isn't found.
 pub fn parse_env_config_cloneable<T>(
     env_config: std::collections::HashMap<String, T>,
-) -> anyhow::Result<T>
+) -> crate::Result<T>
 where
     T: Clone + std::fmt::Debug,
 {
@@ -365,7 +365,9 @@ where
     }
 
     warn!("No environments found in configuration");
-    Err(anyhow::anyhow!("No environments found in configuration"))
+    Err(crate::error::QuebecError::Config(
+        "No environments found in configuration".into(),
+    ))
 }
 
 /// Parse environment-specific configuration from a HashMap (strict mode)
@@ -375,7 +377,7 @@ where
 pub fn parse_env_config_strict<T>(
     env_config: std::collections::HashMap<String, T>,
     env: Option<&str>,
-) -> anyhow::Result<T>
+) -> crate::Result<T>
 where
     T: Clone + std::fmt::Debug,
 {
@@ -395,9 +397,8 @@ where
 
     // Environment not found, return error with available environments
     let available: Vec<String> = env_config.keys().cloned().collect();
-    anyhow::bail!(
+    Err(crate::error::QuebecError::Config(format!(
         "Environment '{}' not found in config. Available environments: {:?}",
-        environment,
-        available
-    )
+        environment, available
+    )))
 }


### PR DESCRIPTION
## Summary
- Switch `parse_env_config_cloneable` and `parse_env_config_strict` from `anyhow::Result<T>` to `crate::Result<T>`.
- Both error paths now produce `QuebecError::Config(...)`, which is the semantically appropriate variant (env config validation failure).

Phase B (2/n) of the codebase-wide consistency pass on `crate::Result`.

## Why
Both call sites (`config.rs:363`, `scheduler.rs:562`) currently return `anyhow::Result` and accept the typed error transparently via `std::error::Error`, so this change is fully backwards-compatible — but it makes the helper itself follow the project convention.

Depends on #33 (rebased on top).

## Test plan
- [x] `cargo check`
- [x] `cargo clippy --all-targets --all-features` (only pre-existing warnings unrelated to this PR)
- [x] `cargo fmt --all -- --check`
- [x] `uv run --with maturin maturin develop`
- [x] `QUEBEC_SKIP_IMPORT_HOOK=1 uv run pytest --ignore=tests/step_defs` → 97 passed