### PR TITLE
refactor(process): use crate::Result<T> in ProcessTrait methods

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -71,6 +71,14 @@ pub enum QuebecError {
     /// Unsupported operations
     #[error("Unsupported operation: {0}")]
     Unsupported(String),
+
+    /// Wrapped anyhow error preserving the underlying source chain
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+
+    /// PostgreSQL driver errors (preserves source chain)
+    #[error(transparent)]
+    Postgres(#[from] tokio_postgres::Error),
 }
 
 /// Type alias for simplified usage
@@ -98,13 +106,6 @@ impl QuebecError {
     }
 }
 
-/// Convert from anyhow::Error
-impl From<anyhow::Error> for QuebecError {
-    fn from(err: anyhow::Error) -> Self {
-        Self::Generic(err.to_string())
-    }
-}
-
 /// Convert from pyo3::PyErr
 #[cfg(feature = "python")]
 impl From<pyo3::PyErr> for QuebecError {
@@ -126,13 +127,6 @@ impl From<QuebecError> for pyo3::PyErr {
 impl From<croner::errors::CronError> for QuebecError {
     fn from(err: croner::errors::CronError) -> Self {
         Self::InvalidCron(err.to_string())
-    }
-}
-
-/// Convert from tokio_postgres errors
-impl From<tokio_postgres::Error> for QuebecError {
-    fn from(err: tokio_postgres::Error) -> Self {
-        Self::Database(DbErr::Custom(err.to_string()))
     }
 }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,8 +1,7 @@
 use crate::context::AppContext;
 use crate::entities::quebec_processes;
+use crate::error::Result;
 use crate::query_builder;
-use anyhow::Error;
-use anyhow::Result;
 use async_trait::async_trait;
 use sea_orm::{DatabaseConnection, DbErr, TransactionTrait};
 use std::sync::Arc;
@@ -62,7 +61,7 @@ pub trait ProcessTrait: Send + Sync {
     fn process_info(&self) -> ProcessInfo;
 
     /// Called when process starts - registers in database
-    async fn on_start(&self, db: &DatabaseConnection) -> Result<quebec_processes::Model, Error> {
+    async fn on_start(&self, db: &DatabaseConnection) -> Result<quebec_processes::Model> {
         let info = self.process_info();
         let ctx = self.ctx();
         let table_config = ctx.table_config.clone();
@@ -155,7 +154,7 @@ pub trait ProcessTrait: Send + Sync {
         &self,
         db: &DatabaseConnection,
         process: &quebec_processes::Model,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         let ctx = self.ctx();
         let rows =
             query_builder::processes::update_heartbeat(db, &ctx.table_config, process.id).await?;
@@ -191,7 +190,7 @@ pub trait ProcessTrait: Send + Sync {
         &self,
         db: &DatabaseConnection,
         process: &quebec_processes::Model,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         let process_name = process.name.clone();
         let process_pid = process.pid;
         let process_hostname = process.hostname.clone();


### PR DESCRIPTION
## Summary
- Switch `ProcessTrait` lifecycle methods (`on_start`, `heartbeat`, `on_stop`) from `Result<T, anyhow::Error>` to `crate::Result<T>`.
- `DbErr` still flows through transparently via the `#[from]` impl on `QuebecError`.

Phase B (3/n).

## Why
Lifecycle errors are well-covered by existing `QuebecError::Database` and `QuebecError::Transaction` variants. Implementors (Worker, Dispatcher, Scheduler, Supervisor) propagate via `?` without code changes — the `?` operator handles the conversion at each call site.

Depends on #33 (rebased on top).

## Test plan
- [x] `cargo check`
- [x] `cargo clippy --all-targets --all-features` (only pre-existing warnings)
- [x] `cargo fmt --all -- --check`
- [x] `uv run --with maturin maturin develop`
- [x] `QUEBEC_SKIP_IMPORT_HOOK=1 uv run pytest --ignore=tests/step_defs` → 97 passed