### PR TITLE
refactor(supervisor): use crate::Result<T> instead of anyhow::Result

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -71,6 +71,14 @@ pub enum QuebecError {
     /// Unsupported operations
     #[error("Unsupported operation: {0}")]
     Unsupported(String),
+
+    /// Wrapped anyhow error preserving the underlying source chain
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+
+    /// PostgreSQL driver errors (preserves source chain)
+    #[error(transparent)]
+    Postgres(#[from] tokio_postgres::Error),
 }
 
 /// Type alias for simplified usage
@@ -98,13 +106,6 @@ impl QuebecError {
     }
 }
 
-/// Convert from anyhow::Error
-impl From<anyhow::Error> for QuebecError {
-    fn from(err: anyhow::Error) -> Self {
-        Self::Generic(err.to_string())
-    }
-}
-
 /// Convert from pyo3::PyErr
 #[cfg(feature = "python")]
 impl From<pyo3::PyErr> for QuebecError {
@@ -126,13 +127,6 @@ impl From<QuebecError> for pyo3::PyErr {
 impl From<croner::errors::CronError> for QuebecError {
     fn from(err: croner::errors::CronError) -> Self {
         Self::InvalidCron(err.to_string())
-    }
-}
-
-/// Convert from tokio_postgres errors
-impl From<tokio_postgres::Error> for QuebecError {
-    fn from(err: tokio_postgres::Error) -> Self {
-        Self::Database(DbErr::Custom(err.to_string()))
     }
 }
 

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -9,10 +9,10 @@
 #![allow(dead_code)]
 
 use crate::context::AppContext;
+use crate::error::Result;
 use crate::process::{ProcessInfo, ProcessTrait};
 use crate::query_builder;
 use crate::worker::Worker;
-use anyhow::Result;
 use async_trait::async_trait;
 use sea_orm::{DatabaseConnection, DbErr, TransactionTrait};
 use std::sync::Arc;
@@ -97,7 +97,8 @@ impl Supervisor {
         let table_config = self.ctx.table_config.clone();
 
         let threshold = chrono::Utc::now().naive_utc()
-            - chrono::Duration::from_std(self.ctx.process_alive_threshold)?;
+            - chrono::Duration::from_std(self.ctx.process_alive_threshold)
+                .map_err(|e| crate::error::QuebecError::Other(e.into()))?;
         let stale = query_builder::processes::find_prunable(
             db.as_ref(),
             &table_config,


### PR DESCRIPTION
## Summary
- Switch all `Supervisor` methods (`register`, `heartbeat_process`, `deregister_process`, `lookup_process_id_by_pid`, `fail_claimed_by_process_id`, `fail_claimed_by_pid`, `run_maintenance`) and the free `fail_claimed_by_process_id_inner` from `anyhow::Result` to `crate::Result`.
- One-off `chrono::OutOfRangeError` from `Duration::from_std` flows through the transparent `Other(anyhow::Error)` variant — no dedicated variant added for a single call site.

Phase C (1/4).

Depends on #33 (rebased on top).

## Test plan
- [x] \`cargo check\` / \`cargo clippy\` / \`cargo fmt --check\`
- [x] \`uv run --with maturin maturin develop\`
- [x] \`QUEBEC_SKIP_IMPORT_HOOK=1 uv run pytest --ignore=tests/step_defs\` → 97 passed