### PR TITLE
refactor(context): use crate::Result<T> instead of anyhow::Result

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use crate::error::{QuebecError, Result};
 use croner::Cron;
 use english_to_cron::str_cron_syntax;
 use sea_orm::{ConnectOptions, Database, DatabaseConnection, DbErr};
@@ -704,14 +704,17 @@ impl AppContext {
 
     /// Get a runnable by class name
     #[cfg(feature = "python")]
-    pub fn get_runnable(&self, class_name: &str) -> Result<crate::worker::Runnable, anyhow::Error> {
+    pub fn get_runnable(&self, class_name: &str) -> Result<crate::worker::Runnable> {
         let runnables = self
             .runnables
             .read()
-            .map_err(|e| anyhow::anyhow!("Failed to acquire read lock: {}", e))?;
-        let runnable = runnables
-            .get(class_name)
-            .ok_or_else(|| anyhow::anyhow!("Runnable not found for class: {}", class_name))?;
+            .map_err(|e| QuebecError::Runtime(format!("Failed to acquire read lock: {}", e)))?;
+        let runnable =
+            runnables
+                .get(class_name)
+                .ok_or_else(|| QuebecError::JobClassNotRegistered {
+                    class_name: class_name.to_string(),
+                })?;
 
         // Clone with GIL since Runnable contains Py<PyAny>
         Python::attach(|py| Ok(runnable.clone_with_gil(py)))

--- a/src/error.rs
+++ b/src/error.rs
@@ -81,8 +81,10 @@ pub enum QuebecError {
     Postgres(#[from] tokio_postgres::Error),
 }
 
-/// Type alias for simplified usage
-pub type Result<T> = std::result::Result<T, QuebecError>;
+/// Type alias for simplified usage. Mirrors `anyhow::Result`, allowing an
+/// explicit error type (`Result<T, E>`) when a function deliberately surfaces
+/// a non-`QuebecError` (e.g. a sea-orm transaction returning `DbErr`).
+pub type Result<T, E = QuebecError> = std::result::Result<T, E>;
 
 impl QuebecError {
     /// Create a configuration error

--- a/src/error.rs
+++ b/src/error.rs
@@ -71,6 +71,14 @@ pub enum QuebecError {
     /// Unsupported operations
     #[error("Unsupported operation: {0}")]
     Unsupported(String),
+
+    /// Wrapped anyhow error preserving the underlying source chain
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+
+    /// PostgreSQL driver errors (preserves source chain)
+    #[error(transparent)]
+    Postgres(#[from] tokio_postgres::Error),
 }
 
 /// Type alias for simplified usage
@@ -98,13 +106,6 @@ impl QuebecError {
     }
 }
 
-/// Convert from anyhow::Error
-impl From<anyhow::Error> for QuebecError {
-    fn from(err: anyhow::Error) -> Self {
-        Self::Generic(err.to_string())
-    }
-}
-
 /// Convert from pyo3::PyErr
 #[cfg(feature = "python")]
 impl From<pyo3::PyErr> for QuebecError {
@@ -126,13 +127,6 @@ impl From<QuebecError> for pyo3::PyErr {
 impl From<croner::errors::CronError> for QuebecError {
     fn from(err: croner::errors::CronError) -> Self {
         Self::InvalidCron(err.to_string())
-    }
-}
-
-/// Convert from tokio_postgres errors
-impl From<tokio_postgres::Error> for QuebecError {
-    fn from(err: tokio_postgres::Error) -> Self {
-        Self::Database(DbErr::Custom(err.to_string()))
     }
 }
 


### PR DESCRIPTION
## Summary
- Switch `context.rs` from `anyhow::Result` to `crate::Result`.
- Allow `crate::Result` to take an explicit error type (`Result<T, E = QuebecError>`), matching `anyhow::Result` semantics. This keeps `pub async fn get_db(&self) -> Result<Arc<DatabaseConnection>, DbErr>` compiling with the same shape.
- `get_runnable` now returns `QuebecError::JobClassNotRegistered { class_name }` for the not-found case — semantically correct variant — instead of a generic anyhow message. Lock-poisoning becomes `QuebecError::Runtime`.

Phase C (2/4).

## Why
Promoting "class not registered" from a generic message to the dedicated `JobClassNotRegistered` variant means callers in `worker.rs` and `scheduler.rs` could later pattern-match on it (today they only `.ok()` it).

Depends on #33 (rebased on top).

## Test plan
- [x] `cargo check` / `cargo clippy` / `cargo fmt --check`
- [x] `uv run --with maturin maturin develop`
- [x] `QUEBEC_SKIP_IMPORT_HOOK=1 uv run pytest --ignore=tests/step_defs` → 97 passed