### PR TITLE
refactor(types,control_plane): use crate::Result<T> instead of anyhow::Result

### DIFF
--- a/src/control_plane/handlers/recurring_jobs.rs
+++ b/src/control_plane/handlers/recurring_jobs.rs
@@ -10,6 +10,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::context::ScheduledEntry;
 use crate::control_plane::{models::RecurringTaskInfo, utils::clean_sql, ControlPlane};
+use crate::error::QuebecError;
 use crate::notify::NotifyManager;
 use crate::scheduler::enqueue_job;
 
@@ -96,7 +97,7 @@ impl ControlPlane {
         Redirect::to("/recurring-jobs")
     }
 
-    async fn do_run_recurring_job(state: &Arc<ControlPlane>, id: i64) -> Result<(), anyhow::Error> {
+    async fn do_run_recurring_job(state: &Arc<ControlPlane>, id: i64) -> crate::error::Result<()> {
         let db = state.ctx.get_db().await?;
         let db = db.as_ref();
         let table_config = &state.ctx.table_config;
@@ -114,7 +115,7 @@ impl ControlPlane {
                 [Value::from(id)],
             ))
             .await?
-            .ok_or_else(|| anyhow::anyhow!("Recurring task {} not found", id))?;
+            .ok_or_else(|| QuebecError::runtime(format!("Recurring task {} not found", id)))?;
 
         let key: String = row.try_get("", "key").unwrap_or_default();
         let class_name: String = row.try_get("", "class_name").unwrap_or_default();

--- a/src/types.rs
+++ b/src/types.rs
@@ -903,7 +903,7 @@ impl PyQuebec {
         })
     }
 
-    async fn post_job(&self) -> Result<(), anyhow::Error> {
+    async fn post_job(&self) -> crate::error::Result<()> {
         let _ = self.rt.spawn(async move {
             tokio::time::sleep(Duration::from_secs(5)).await;
         });


### PR DESCRIPTION
## Summary

Phase E cleanup: migrate the last two anyhow holdouts to `crate::Result<T>`.

- `src/types.rs`: `post_job` returns `crate::error::Result<()>`.
- `src/control_plane/handlers/recurring_jobs.rs`: `do_run_recurring_job` returns `crate::error::Result<()>`; the "task not found" path uses `QuebecError::runtime`. The bare `Result` alias is intentionally not imported here because the file already uses 2-param `Result<Html<String>, (StatusCode, String)>` for axum handlers — those would shadow.

After this PR lands, every `*.rs` outside `src/error.rs` is on `crate::Result<T>` (the audit `grep -rn "anyhow::" src/ --include="*.rs"` returns only `error.rs` lines on the merged tree).

## Test plan

- [x] `cargo check`
- [x] `cargo clippy --all-targets --all-features` (no new warnings)
- [x] `cargo fmt --all -- --check`
- [x] `maturin develop`
- [x] `QUEBEC_SKIP_IMPORT_HOOK=1 uv run pytest --ignore=tests/step_defs` (97 passed)