### PR TITLE
feat: Sidekiq-style quiet mode for seamless restart

### DIFF
--- a/python/quebec/supervisor.py
+++ b/python/quebec/supervisor.py
@@ -12,6 +12,7 @@ import os
 import select
 import signal
 import socket
+import sys
 import threading
 import time
 from dataclasses import dataclass, field
@@ -180,9 +181,41 @@ class Supervisor:
             self._immediate = True
             self._wake()
 
+        # Sidekiq-style quiet: supervisor doesn't claim jobs itself, so we
+        # cascade the signal to every worker child. Dispatcher/scheduler are
+        # unaffected (they don't own in-flight job execution).
+        def quiet(signum, _frame):
+            logger.info(
+                "Supervisor received signal %d, forwarding quiet (SIGUSR1) "
+                "to worker children",
+                signum,
+            )
+            for pid, info in list(self._children.items()):
+                if info.role != ROLE_WORKER:
+                    continue
+                try:
+                    os.kill(pid, signal.SIGUSR1)
+                except ProcessLookupError:
+                    pass
+                except OSError as e:
+                    logger.warning(
+                        "Failed to forward quiet to worker pid=%d: %s", pid, e
+                    )
+
         signal.signal(signal.SIGTERM, graceful)
         signal.signal(signal.SIGINT, graceful)
         signal.signal(signal.SIGQUIT, immediate)
+        # SIGUSR1 is the always-on quiet trigger.
+        signal.signal(signal.SIGUSR1, quiet)
+        # In an interactive terminal Ctrl-Z must keep its shell-job-control
+        # meaning, so only intercept SIGTSTP when stdin isn't a tty (daemon /
+        # systemd / docker / nohup).
+        try:
+            stdin_is_tty = sys.stdin.isatty()
+        except (AttributeError, ValueError):
+            stdin_is_tty = False
+        if not stdin_is_tty and hasattr(signal, "SIGTSTP"):
+            signal.signal(signal.SIGTSTP, quiet)
 
     def _wake(self) -> None:
         try:

--- a/src/context.rs
+++ b/src/context.rs
@@ -303,6 +303,11 @@ pub struct AppContext {
     pub worker_queues: Option<crate::config::QueueSelector>, // Queue configuration for worker
     pub graceful_shutdown: CancellationToken,
     pub force_quit: CancellationToken,
+    /// Sidekiq-style "quiet" mode: when cancelled, the worker stops claiming
+    /// new jobs but continues running so in-flight jobs can finish. Used for
+    /// seamless restarts (signal old instance quiet, start new instance,
+    /// later send SIGTERM once old instance has drained).
+    pub quiet: CancellationToken,
     #[cfg(feature = "python")]
     pub runnables: Arc<RwLock<HashMap<String, crate::worker::Runnable>>>, // Store job class runnables
     pub concurrency_enabled: Arc<RwLock<HashSet<String>>>, // Store job classes with concurrency control enabled
@@ -577,6 +582,7 @@ impl AppContext {
             worker_queues: None, // Default to all queues
             graceful_shutdown: CancellationToken::new(),
             force_quit: CancellationToken::new(),
+            quiet: CancellationToken::new(),
             #[cfg(feature = "python")]
             runnables: Arc::new(RwLock::new(HashMap::new())),
             concurrency_enabled: Arc::new(RwLock::new(HashSet::new())),
@@ -652,6 +658,7 @@ impl AppContext {
             worker_queues: self.worker_queues.clone(),
             graceful_shutdown: CancellationToken::new(),
             force_quit: CancellationToken::new(),
+            quiet: CancellationToken::new(),
             #[cfg(feature = "python")]
             runnables: self.runnables.clone(),
             concurrency_enabled: self.concurrency_enabled.clone(),

--- a/src/control_plane/handlers/workers.rs
+++ b/src/control_plane/handlers/workers.rs
@@ -47,6 +47,13 @@ impl ControlPlane {
                     "alive"
                 };
 
+                let quiet = worker
+                    .metadata
+                    .as_deref()
+                    .and_then(|m| serde_json::from_str::<serde_json::Value>(m).ok())
+                    .and_then(|v| v.get("quiet").and_then(|q| q.as_bool()))
+                    .unwrap_or(false);
+
                 WorkerInfo {
                     id: worker.id,
                     name: worker.name,
@@ -56,6 +63,7 @@ impl ControlPlane {
                     last_heartbeat_at: Self::format_naive_datetime(last_heartbeat),
                     seconds_since_heartbeat,
                     status: status.to_string(),
+                    quiet,
                 }
             })
             .collect();

--- a/src/control_plane/models.rs
+++ b/src/control_plane/models.rs
@@ -17,6 +17,7 @@ pub struct WorkerInfo {
     pub last_heartbeat_at: String,
     pub seconds_since_heartbeat: i64,
     pub status: String,
+    pub quiet: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/control_plane/templates/workers.html
+++ b/src/control_plane/templates/workers.html
@@ -52,6 +52,11 @@
                 Dead
               </span>
             {% endif %}
+            {% if worker.quiet %}
+              <span class="ml-1 px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800" title="Worker is in quiet mode: no longer claiming new jobs, draining in-flight work">
+                Quiet
+              </span>
+            {% endif %}
           </td>
         </tr>
         {% endfor %}

--- a/src/process.rs
+++ b/src/process.rs
@@ -151,14 +151,27 @@ pub trait ProcessTrait: Send + Sync {
         None
     }
 
+    /// Runtime metadata refreshed every heartbeat. Default returns `None`
+    /// (don't touch the metadata column). Override to surface dynamic state
+    /// — e.g. Worker returns `{"quiet":true}` while in quiet mode.
+    fn runtime_metadata(&self) -> Option<String> {
+        None
+    }
+
     async fn heartbeat(
         &self,
         db: &DatabaseConnection,
         process: &quebec_processes::Model,
     ) -> Result<(), Error> {
         let ctx = self.ctx();
-        let rows =
-            query_builder::processes::update_heartbeat(db, &ctx.table_config, process.id).await?;
+        let metadata = self.runtime_metadata();
+        let rows = query_builder::processes::update_heartbeat_with_metadata(
+            db,
+            &ctx.table_config,
+            process.id,
+            metadata.as_deref(),
+        )
+        .await?;
         // Row gone means the supervisor pruned us (stale heartbeat) or another
         // operator deregistered us. Mirrors Solid Queue's Registrable#heartbeat
         // rescue of RecordNotFound: stop polling and exit gracefully so we do

--- a/src/query_builder.rs
+++ b/src/query_builder.rs
@@ -2663,16 +2663,34 @@ pub mod processes {
     where
         C: ConnectionTrait,
     {
+        update_heartbeat_with_metadata(db, table_config, id, None).await
+    }
+
+    /// Update heartbeat and optionally update the metadata column.
+    /// When `metadata` is `Some`, the metadata column is overwritten (use
+    /// `Some("")` or `Some("{}")` to clear). When `None`, metadata is left
+    /// untouched.
+    pub async fn update_heartbeat_with_metadata<C>(
+        db: &C,
+        table_config: &TableConfig,
+        id: i64,
+        metadata: Option<&str>,
+    ) -> Result<u64, DbErr>
+    where
+        C: ConnectionTrait,
+    {
         let table = Alias::new(&table_config.processes);
         let now = chrono::Utc::now().naive_utc();
 
-        let query = Query::update()
-            .table(table)
-            .value(col("last_heartbeat_at"), Expr::val(now))
-            .and_where(Expr::col(col("id")).eq(id))
-            .to_owned();
+        let mut stmt = Query::update();
+        stmt.table(table)
+            .value(col("last_heartbeat_at"), Expr::val(now));
+        if let Some(m) = metadata {
+            stmt.value(col("metadata"), Expr::val(m));
+        }
+        stmt.and_where(Expr::col(col("id")).eq(id));
 
-        execute_update(db, query).await
+        execute_update(db, stmt.to_owned()).await
     }
 
     /// Find a process by ID

--- a/src/types.rs
+++ b/src/types.rs
@@ -173,6 +173,24 @@ fn signal_handler(
     _frame: Py<PyAny>,
     quebec: Py<PyAny>,
 ) -> PyResult<()> {
+    // SIGTSTP (Sidekiq convention) and SIGUSR1 both enter "quiet" mode:
+    // stop fetching new jobs but keep running so in-flight jobs finish.
+    // Used for seamless restarts. SIGUSR1 is the always-on alternative
+    // when SIGTSTP isn't intercepted (interactive tty, where Ctrl-Z is
+    // left to shell job control).
+    if signum == libc::SIGTSTP || signum == libc::SIGUSR1 {
+        let sname = if signum == libc::SIGTSTP {
+            "SIGTSTP"
+        } else {
+            "SIGUSR1"
+        };
+        info!("Received {}, entering quiet mode (no new jobs)", sname);
+        if let Err(e) = quebec.bind(py).call_method0("quiet") {
+            error!("Error calling quiet: {:?}", e);
+        }
+        return Ok(());
+    }
+
     // SIGQUIT is the "exit now" signal in the Solid Queue convention. Only
     // supervisor-managed children skip cleanup — standalone Quebec processes
     // (no supervisor watching) drain gracefully so they release claims and
@@ -2136,15 +2154,31 @@ impl PyQuebec {
             .getattr("partial")?
             .call((handler_func,), Some(&kwargs))?;
 
-        let mut registered: Vec<&str> = Vec::with_capacity(3);
-        for name in ["SIGINT", "SIGTERM", "SIGQUIT"] {
-            if !signal.hasattr(name)? {
+        // SIGUSR1 is the always-on quiet signal: works in any environment.
+        // SIGTSTP is the Sidekiq-compatible quiet signal, but only registered
+        // when stdin is not a tty — in an interactive terminal we leave Ctrl-Z
+        // to shell job control. Under systemd / docker / nohup / supervisor
+        // (no controlling tty), SIGTSTP also enters quiet mode.
+        use std::io::IsTerminal;
+        let stdin_is_tty = std::io::stdin().is_terminal();
+        let signals: &[&str] = if stdin_is_tty {
+            &["SIGINT", "SIGTERM", "SIGQUIT", "SIGUSR1"]
+        } else {
+            &["SIGINT", "SIGTERM", "SIGQUIT", "SIGTSTP", "SIGUSR1"]
+        };
+
+        let mut registered: Vec<&str> = Vec::with_capacity(signals.len());
+        for name in signals {
+            if !signal.hasattr(*name)? {
                 // SIGQUIT (and in theory others) is missing on Windows; skip
                 // rather than aborting startup.
                 continue;
             }
-            signal.call_method1("signal", (signal.getattr(name)?, wrapped_handler.clone()))?;
+            signal.call_method1("signal", (signal.getattr(*name)?, wrapped_handler.clone()))?;
             registered.push(name);
+        }
+        if stdin_is_tty {
+            info!("stdin is a tty; SIGTSTP left to shell job control (use SIGUSR1 for quiet mode)");
         }
 
         info!("Signal handlers registered: {}", registered.join(", "));
@@ -2200,6 +2234,22 @@ impl PyQuebec {
         self.spawn_job_claim_poller()?;
 
         Ok(())
+    }
+
+    /// Enter Sidekiq-style quiet mode: stop claiming new jobs but keep
+    /// running so in-flight jobs finish. Used for seamless restarts.
+    /// Idempotent.
+    fn quiet(&self) -> PyResult<()> {
+        if !self.ctx.quiet.is_cancelled() {
+            info!("Quebec entering quiet mode (worker stops claiming new jobs)");
+            self.ctx.quiet.cancel();
+        }
+        Ok(())
+    }
+
+    #[getter]
+    fn is_quiet(&self) -> bool {
+        self.ctx.quiet.is_cancelled()
     }
 
     fn graceful_shutdown(&self, py: Python) -> PyResult<()> {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -2720,6 +2720,8 @@ impl Worker {
         let thread_id = Self::get_tid();
 
         let quit = self.ctx.graceful_shutdown.clone();
+        let quiet_token = self.ctx.quiet.clone();
+        let mut quiet_announced = false;
 
         // Initialize process record
         let init_db = self.ctx.get_db().await?;
@@ -2764,6 +2766,18 @@ impl Worker {
                         warn!("Failed to get DB for heartbeat: {}", e);
                     }) else { continue };
                     self.heartbeat(&heartbeat_db, &process).await?;
+                }
+                // Quiet mode entered: immediately push a heartbeat so the
+                // metadata column reflects the new state without waiting
+                // for the next tick (which can be up to ~60s away).
+                _ = quiet_token.cancelled(), if !quiet_announced => {
+                    quiet_announced = true;
+                    info!("Quiet mode active, flushing heartbeat to surface state");
+                    if let Ok(db) = self.ctx.get_db().await {
+                        if let Err(e) = self.heartbeat(&db, &process).await {
+                            warn!("Failed to flush quiet heartbeat: {}", e);
+                        }
+                    }
                 }
                 // Periodic maintenance: prune dead processes and fail their claimed jobs
                 _ = maintenance_interval.tick() => {
@@ -2866,6 +2880,13 @@ impl Worker {
         thread_id: &str,
         source: &str,
     ) {
+        // Sidekiq-style quiet mode: keep running but stop claiming new work
+        // so in-flight jobs can drain. Used for seamless restarts.
+        if ctx.quiet.is_cancelled() {
+            trace!("[{}] quiet mode, skipping claim", source);
+            return;
+        }
+
         // Only claim as many jobs as the channel can accept to prevent
         // claimed execution leaks when the channel is full.
         let available = tx.lock().await.capacity();
@@ -3084,5 +3105,13 @@ impl ProcessTrait for Worker {
 
     fn process_info(&self) -> ProcessInfo {
         ProcessInfo::new("Worker", "worker")
+    }
+
+    fn runtime_metadata(&self) -> Option<String> {
+        if self.ctx.quiet.is_cancelled() {
+            Some(r#"{"quiet":true}"#.to_string())
+        } else {
+            None
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds Sidekiq-compatible quiet mode so workers can stop claiming new jobs without exiting — pair with a later SIGTERM, or just start a replacement process for zero-downtime restarts.

- Send `SIGTSTP` (Sidekiq convention) or `SIGUSR1` to enter quiet mode; the worker drains in-flight jobs and idles.
- `SIGUSR1` is always registered; `SIGTSTP` only when stdin isn't a tty, so `Ctrl-Z` keeps shell job-control semantics during interactive use.
- A worker that flips into quiet mode immediately flushes a heartbeat with `metadata = {"quiet":true}`, so the control plane reflects the state without waiting for the next tick.
- Workers page renders a yellow **Quiet** badge next to Active/Dead.
- Supervisor cascades the signal to every worker child (dispatcher/scheduler don't run job code, so they're left alone).

New surface:

- `PyQuebec.quiet()` and `PyQuebec.is_quiet` for programmatic control.
- `ProcessTrait::runtime_metadata()` hook + `query_builder::processes::update_heartbeat_with_metadata` for surfacing dynamic per-process state through the existing heartbeat.

## Test plan

- [x] `cargo check --all-targets`
- [x] `cargo clippy --all-targets --all-features` (no new warnings)
- [x] `cargo fmt --all -- --check`
- [x] `QUEBEC_SKIP_IMPORT_HOOK=1 uv run pytest tests/test_supervisor.py tests/test_lifecycle.py tests/test_lifecycle_api.py` (31 passed)
- [ ] Manual smoke: `kill -USR1 <worker_pid>` while a long job runs → worker keeps job, claims no new ones, Quiet badge appears in control plane, then `kill -TERM` drains cleanly.