### PR TITLE
refactor: inline format args

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -387,8 +387,7 @@ impl QueueConfig {
                 return Ok(path.to_path_buf());
             } else {
                 return Err(QuebecError::Config(format!(
-                    "Config file specified in QUEBEC_CONFIG not found: {}",
-                    env_path
+                    "Config file specified in QUEBEC_CONFIG not found: {env_path}"
                 )));
             }
         }

--- a/src/context.rs
+++ b/src/context.rs
@@ -110,17 +110,17 @@ impl TableConfig {
         // Strip trailing underscore to avoid double underscores (e.g., "hive_" -> "hive__jobs")
         let prefix = prefix.trim_end_matches('_');
         Self {
-            jobs: format!("{}_jobs", prefix),
-            ready_executions: format!("{}_ready_executions", prefix),
-            claimed_executions: format!("{}_claimed_executions", prefix),
-            scheduled_executions: format!("{}_scheduled_executions", prefix),
-            failed_executions: format!("{}_failed_executions", prefix),
-            blocked_executions: format!("{}_blocked_executions", prefix),
-            recurring_executions: format!("{}_recurring_executions", prefix),
-            recurring_tasks: format!("{}_recurring_tasks", prefix),
-            pauses: format!("{}_pauses", prefix),
-            processes: format!("{}_processes", prefix),
-            semaphores: format!("{}_semaphores", prefix),
+            jobs: format!("{prefix}_jobs"),
+            ready_executions: format!("{prefix}_ready_executions"),
+            claimed_executions: format!("{prefix}_claimed_executions"),
+            scheduled_executions: format!("{prefix}_scheduled_executions"),
+            failed_executions: format!("{prefix}_failed_executions"),
+            blocked_executions: format!("{prefix}_blocked_executions"),
+            recurring_executions: format!("{prefix}_recurring_executions"),
+            recurring_tasks: format!("{prefix}_recurring_tasks"),
+            pauses: format!("{prefix}_pauses"),
+            processes: format!("{prefix}_processes"),
+            semaphores: format!("{prefix}_semaphores"),
         }
     }
 }
@@ -716,7 +716,7 @@ impl AppContext {
         let runnables = self
             .runnables
             .read()
-            .map_err(|e| QuebecError::Runtime(format!("Failed to acquire read lock: {}", e)))?;
+            .map_err(|e| QuebecError::Runtime(format!("Failed to acquire read lock: {e}")))?;
         let runnable =
             runnables
                 .get(class_name)

--- a/src/continuation.rs
+++ b/src/continuation.rs
@@ -464,16 +464,14 @@ impl Continuable {
             // Validation 1: Step can't be nested inside another step
             if let Some(ref running) = ctx.running_step {
                 return Err(InvalidStepError::new_err(format!(
-                    "Step '{}' is nested inside step '{}'",
-                    name, running
+                    "Step '{name}' is nested inside step '{running}'"
                 )));
             }
 
             // Validation 2: Step can't be repeated in same execution
             if ctx.encountered.contains(&name.to_string()) {
                 return Err(InvalidStepError::new_err(format!(
-                    "Step '{}' has already been encountered",
-                    name
+                    "Step '{name}' has already been encountered"
                 )));
             }
 
@@ -481,8 +479,7 @@ impl Continuable {
             if let Some((current_name, _)) = &ctx.state.current {
                 if current_name != name && !ctx.state.is_completed(name) {
                     return Err(InvalidStepError::new_err(format!(
-                        "Step '{}' found, expected to resume from '{}'",
-                        name, current_name
+                        "Step '{name}' found, expected to resume from '{current_name}'"
                     )));
                 }
             }
@@ -493,8 +490,7 @@ impl Continuable {
                 let expected = &ctx.state.completed[encountered_count];
                 if expected != name {
                     return Err(InvalidStepError::new_err(format!(
-                        "Step '{}' found, expected to see '{}'",
-                        name, expected
+                        "Step '{name}' found, expected to see '{expected}'"
                     )));
                 }
             }
@@ -511,8 +507,7 @@ impl Continuable {
                 // Drop lock before raising exception
                 drop(ctx);
                 return Err(JobInterrupted::new_err(format!(
-                    "Isolated step '{}' requires separate execution",
-                    name
+                    "Isolated step '{name}' requires separate execution"
                 )));
             }
 

--- a/src/control_plane/handlers/blocked_jobs.rs
+++ b/src/control_plane/handlers/blocked_jobs.rs
@@ -181,7 +181,7 @@ impl ControlPlane {
                         query_builder::blocked_executions::find_by_id(txn, &table_config, id)
                             .await?
                             .ok_or_else(|| {
-                                DbErr::Custom(format!("Blocked execution with ID {} not found", id))
+                                DbErr::Custom(format!("Blocked execution with ID {id} not found"))
                             })?;
 
                     query_builder::blocked_executions::delete_by_id(txn, &table_config, id).await?;
@@ -230,7 +230,7 @@ impl ControlPlane {
                         query_builder::blocked_executions::find_by_id(txn, &table_config, id)
                             .await?
                             .ok_or_else(|| {
-                                DbErr::Custom(format!("Blocked execution with ID {} not found", id))
+                                DbErr::Custom(format!("Blocked execution with ID {id} not found"))
                             })?;
 
                     let job_id = blocked_execution.job_id;

--- a/src/control_plane/handlers/failed_jobs.rs
+++ b/src/control_plane/handlers/failed_jobs.rs
@@ -167,8 +167,7 @@ impl ControlPlane {
                             Ok(())
                         }
                         None => Err(DbErr::Custom(format!(
-                            "Failed execution for job {} not found",
-                            id
+                            "Failed execution for job {id} not found"
                         ))),
                     }
                 })
@@ -218,8 +217,7 @@ impl ControlPlane {
                             Ok(())
                         }
                         None => Err(DbErr::Custom(format!(
-                            "Failed execution for job {} not found",
-                            id
+                            "Failed execution for job {id} not found"
                         ))),
                     }
                 })

--- a/src/control_plane/handlers/in_progress_jobs.rs
+++ b/src/control_plane/handlers/in_progress_jobs.rs
@@ -71,7 +71,7 @@ impl ControlPlane {
                             Some(p) => {
                                 format!("{}:{}", p.hostname.as_deref().unwrap_or("unknown"), p.pid)
                             }
-                            None => format!("pid:{}", pid),
+                            None => format!("pid:{pid}"),
                         }
                     }
                     None => "unknown".to_string(),

--- a/src/control_plane/handlers/job_details.rs
+++ b/src/control_plane/handlers/job_details.rs
@@ -364,10 +364,7 @@ impl ControlPlane {
 
             Ok(Html(html))
         } else {
-            Err((
-                StatusCode::NOT_FOUND,
-                format!("Job with ID {} not found", id),
-            ))
+            Err((StatusCode::NOT_FOUND, format!("Job with ID {id} not found")))
         }
     }
 }

--- a/src/control_plane/handlers/overview.rs
+++ b/src/control_plane/handlers/overview.rs
@@ -147,7 +147,7 @@ impl ControlPlane {
                 format!("{:.1}m", secs / 60.0)
             }
             Some(secs) => {
-                format!("{:.1}s", secs)
+                format!("{secs:.1}s")
             }
             None => "N/A".to_string(),
         };
@@ -359,7 +359,7 @@ impl ControlPlane {
                     format!("{:.1}m", secs / 60.0)
                 }
                 Some(secs) => {
-                    format!("{:.1}s", secs)
+                    format!("{secs:.1}s")
                 }
                 None => "N/A".to_string(),
             };

--- a/src/control_plane/handlers/queues.rs
+++ b/src/control_plane/handlers/queues.rs
@@ -158,7 +158,7 @@ impl ControlPlane {
             return StatusCode::INTERNAL_SERVER_ERROR.into_response();
         }
 
-        Self::redirect_back(&format!("/queues/{}", queue_name))
+        Self::redirect_back(&format!("/queues/{queue_name}"))
     }
 
     pub async fn resume_queue(
@@ -180,7 +180,7 @@ impl ControlPlane {
             return StatusCode::INTERNAL_SERVER_ERROR.into_response();
         }
 
-        Self::redirect_back(&format!("/queues/{}", queue_name))
+        Self::redirect_back(&format!("/queues/{queue_name}"))
     }
 
     pub async fn pause_all_queues(State(state): State<Arc<ControlPlane>>) -> Response {

--- a/src/control_plane/handlers/recurring_jobs.rs
+++ b/src/control_plane/handlers/recurring_jobs.rs
@@ -115,7 +115,7 @@ impl ControlPlane {
                 [Value::from(id)],
             ))
             .await?
-            .ok_or_else(|| QuebecError::runtime(format!("Recurring task {} not found", id)))?;
+            .ok_or_else(|| QuebecError::runtime(format!("Recurring task {id} not found")))?;
 
         let key: String = row.try_get("", "key").unwrap_or_default();
         let class_name: String = row.try_get("", "class_name").unwrap_or_default();

--- a/src/control_plane/handlers/scheduled_jobs.rs
+++ b/src/control_plane/handlers/scheduled_jobs.rs
@@ -47,19 +47,19 @@ impl ControlPlane {
         if let Some(ref cn) = pagination.class_name {
             param_idx += 1;
             let placeholder = match backend {
-                sea_orm::DbBackend::Postgres => format!("${}", param_idx),
+                sea_orm::DbBackend::Postgres => format!("${param_idx}"),
                 _ => "?".to_string(),
             };
-            conditions.push(format!("j.class_name = {}", placeholder));
+            conditions.push(format!("j.class_name = {placeholder}"));
             values.push(Value::from(cn.clone()));
         }
         if let Some(ref qn) = pagination.queue_name {
             param_idx += 1;
             let placeholder = match backend {
-                sea_orm::DbBackend::Postgres => format!("${}", param_idx),
+                sea_orm::DbBackend::Postgres => format!("${param_idx}"),
                 _ => "?".to_string(),
             };
-            conditions.push(format!("j.queue_name = {}", placeholder));
+            conditions.push(format!("j.queue_name = {placeholder}"));
             values.push(Value::from(qn.clone()));
         }
 
@@ -181,19 +181,19 @@ impl ControlPlane {
         if let Some(ref cn) = pagination.class_name {
             count_idx += 1;
             let placeholder = match backend {
-                sea_orm::DbBackend::Postgres => format!("${}", count_idx),
+                sea_orm::DbBackend::Postgres => format!("${count_idx}"),
                 _ => "?".to_string(),
             };
-            count_conditions.push(format!("j.class_name = {}", placeholder));
+            count_conditions.push(format!("j.class_name = {placeholder}"));
             count_values.push(Value::from(cn.clone()));
         }
         if let Some(ref qn) = pagination.queue_name {
             count_idx += 1;
             let placeholder = match backend {
-                sea_orm::DbBackend::Postgres => format!("${}", count_idx),
+                sea_orm::DbBackend::Postgres => format!("${count_idx}"),
                 _ => "?".to_string(),
             };
-            count_conditions.push(format!("j.queue_name = {}", placeholder));
+            count_conditions.push(format!("j.queue_name = {placeholder}"));
             count_values.push(Value::from(qn.clone()));
         }
         let _ = count_idx;
@@ -277,8 +277,7 @@ impl ControlPlane {
                         info!("Cancelled scheduled job ID: {}", id);
                     } else {
                         return Err(DbErr::Custom(format!(
-                            "Scheduled job with ID {} not found",
-                            id
+                            "Scheduled job with ID {id} not found"
                         )));
                     }
 

--- a/src/control_plane/utils.rs
+++ b/src/control_plane/utils.rs
@@ -55,7 +55,7 @@ impl ControlPlane {
         let seconds = duration.num_seconds();
 
         if seconds < 60 {
-            format!("{}s", seconds)
+            format!("{seconds}s")
         } else if seconds < 3600 {
             format!("{}m", seconds / 60)
         } else if seconds < 86400 {
@@ -270,7 +270,7 @@ impl ControlPlane {
 
             // Build readable error line
             if !exception_class.is_empty() {
-                job.error = Some(format!("{}: {}", exception_class, message));
+                job.error = Some(format!("{exception_class}: {message}"));
             } else if !message.is_empty() {
                 job.error = Some(message.to_string());
             }
@@ -301,7 +301,7 @@ impl ControlPlane {
                     .unwrap_or("");
                 let message = json.get("message").and_then(|v| v.as_str()).unwrap_or("");
                 if !exception_class.is_empty() {
-                    item.error = Some(format!("{}: {}", exception_class, message));
+                    item.error = Some(format!("{exception_class}: {message}"));
                 } else if !message.is_empty() {
                     item.error = Some(message.to_string());
                 }
@@ -372,7 +372,7 @@ impl ControlPlane {
             error!("Failed to acquire read lock: {}", e);
             return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to acquire template lock: {}", e),
+                format!("Failed to acquire template lock: {e}"),
             ));
         }
 
@@ -382,7 +382,7 @@ impl ControlPlane {
                 error!("Failed to acquire read lock: {}", e);
                 return Err((
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to acquire template lock: {}", e),
+                    format!("Failed to acquire template lock: {e}"),
                 ));
             }
         };
@@ -396,12 +396,12 @@ impl ControlPlane {
                 error!("Failed to render {}: {}", template_name, e);
 
                 // Output complete error chain
-                let mut error_detail = format!("Template error: {}", e);
+                let mut error_detail = format!("Template error: {e}");
                 let mut current_error = e.source();
                 let mut level = 1;
 
                 while let Some(source) = current_error {
-                    error_detail.push_str(&format!("\n  Caused by ({}): {}", level, source));
+                    error_detail.push_str(&format!("\n  Caused by ({level}): {source}"));
                     current_error = source.source();
                     level += 1;
                 }
@@ -433,7 +433,7 @@ impl ControlPlane {
 
                 Err((
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Template error: {}", e),
+                    format!("Template error: {e}"),
                 ))
             }
         }

--- a/src/core.rs
+++ b/src/core.rs
@@ -128,7 +128,7 @@ async fn enqueue_job(
 
     // Validate arguments JSON without full parsing (zero-copy validation)
     let args: Box<serde_json::value::RawValue> = serde_json::from_str(&job.arguments)
-        .map_err(|e| DbErr::Custom(format!("Invalid JSON in arguments: {}", e)))?;
+        .map_err(|e| DbErr::Custom(format!("Invalid JSON in arguments: {e}")))?;
 
     let params = crate::utils::build_job_params(serde_json::json!({
         "job_class": job.class_name,

--- a/src/database_url.rs
+++ b/src/database_url.rs
@@ -216,13 +216,13 @@ fn normalize_sqlite(url: &str) -> String {
         return url.to_string();
     };
     if let Some(tail) = rest.strip_prefix("/:memory:") {
-        return format!("sqlite::memory:{}", tail);
+        return format!("sqlite::memory:{tail}");
     }
     if let Some(abs) = rest.strip_prefix("//") {
-        return format!("sqlite:///{}", abs);
+        return format!("sqlite:///{abs}");
     }
     if let Some(rel) = rest.strip_prefix('/') {
-        return format!("sqlite://{}", rel);
+        return format!("sqlite://{rel}");
     }
     url.to_string()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,8 +167,7 @@ fn init_logging() {
 
     if result.is_err() {
         eprintln!(
-            "quebec: tracing subscriber already initialized, QUEBEC_LOG_FORMAT={} ignored",
-            format
+            "quebec: tracing subscriber already initialized, QUEBEC_LOG_FORMAT={format} ignored"
         );
     }
 }

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -153,7 +153,7 @@ impl NotifyManager {
         let message_json = serde_json::to_string(&message)?;
 
         // Use the same naming convention as LISTEN
-        let channel_name = format!("{}_jobs", app_name);
+        let channel_name = format!("{app_name}_jobs");
         Self::send_notify_with_db(db, &channel_name, &message_json).await
     }
 
@@ -164,7 +164,7 @@ impl NotifyManager {
     {
         // PostgreSQL NOTIFY doesn't support parameterized queries, so we need to escape and format directly
         let escaped_message = message.replace("'", "''"); // Escape single quotes
-        let sql = format!("NOTIFY {}, '{}'", channel_name, escaped_message);
+        let sql = format!("NOTIFY {channel_name}, '{escaped_message}'");
 
         match db
             .execute(Statement::from_sql_and_values(

--- a/src/process.rs
+++ b/src/process.rs
@@ -131,7 +131,7 @@ pub trait ProcessTrait: Send + Sync {
                         .unwrap_or(0);
                 });
 
-                let py_tid = format!("{}", thread_id);
+                let py_tid = format!("{thread_id}");
                 trace!("python thread_id: {:?}", py_tid);
                 return py_tid;
             }

--- a/src/query_builder.rs
+++ b/src/query_builder.rs
@@ -673,9 +673,7 @@ pub mod jobs {
         };
 
         let sql = format!(
-            r#"SELECT DISTINCT {q}queue_name{q} FROM {q}{table}{q} ORDER BY {q}queue_name{q} ASC"#,
-            q = q,
-            table = table_name
+            r#"SELECT DISTINCT {q}queue_name{q} FROM {q}{table_name}{q} ORDER BY {q}queue_name{q} ASC"#
         );
 
         let stmt = Statement::from_string(backend, sql);
@@ -703,9 +701,7 @@ pub mod jobs {
         };
 
         let sql = format!(
-            r#"SELECT DISTINCT {q}class_name{q} FROM {q}{table}{q} ORDER BY {q}class_name{q} ASC"#,
-            q = q,
-            table = table_name
+            r#"SELECT DISTINCT {q}class_name{q} FROM {q}{table_name}{q} ORDER BY {q}class_name{q} ASC"#
         );
 
         let stmt = Statement::from_string(backend, sql);
@@ -841,16 +837,13 @@ pub mod jobs {
         // This pattern: DELETE FROM table WHERE id IN (SELECT id FROM table WHERE ... LIMIT ?)
         let sql = match backend {
             DbBackend::Postgres => format!(
-                r#"DELETE FROM "{table}" WHERE "id" IN (SELECT "id" FROM "{table}" WHERE "finished_at" IS NOT NULL AND "finished_at" < $1 LIMIT $2)"#,
-                table = table_name
+                r#"DELETE FROM "{table_name}" WHERE "id" IN (SELECT "id" FROM "{table_name}" WHERE "finished_at" IS NOT NULL AND "finished_at" < $1 LIMIT $2)"#
             ),
             DbBackend::MySql => format!(
-                r#"DELETE FROM `{table}` WHERE `id` IN (SELECT `id` FROM (SELECT `id` FROM `{table}` WHERE `finished_at` IS NOT NULL AND `finished_at` < ? LIMIT ?) AS tmp)"#,
-                table = table_name
+                r#"DELETE FROM `{table_name}` WHERE `id` IN (SELECT `id` FROM (SELECT `id` FROM `{table_name}` WHERE `finished_at` IS NOT NULL AND `finished_at` < ? LIMIT ?) AS tmp)"#
             ),
             DbBackend::Sqlite => format!(
-                r#"DELETE FROM "{table}" WHERE "id" IN (SELECT "id" FROM "{table}" WHERE "finished_at" IS NOT NULL AND "finished_at" < ? LIMIT ?)"#,
-                table = table_name
+                r#"DELETE FROM "{table_name}" WHERE "id" IN (SELECT "id" FROM "{table_name}" WHERE "finished_at" IS NOT NULL AND "finished_at" < ? LIMIT ?)"#
             ),
         };
 
@@ -1088,7 +1081,7 @@ pub mod ready_executions {
         // Helper to generate placeholder based on backend
         let placeholder = |idx: usize| -> String {
             match backend {
-                DbBackend::Postgres => format!("${}", idx),
+                DbBackend::Postgres => format!("${idx}"),
                 DbBackend::MySql | DbBackend::Sqlite => "?".to_string(),
             }
         };
@@ -1141,12 +1134,7 @@ pub mod ready_executions {
         };
 
         let sql = format!(
-            r#"SELECT * FROM {tq}{table}{tq} {where_clause} ORDER BY {q}priority{q} ASC, {q}job_id{q} ASC LIMIT 1 {lock}"#,
-            tq = tq,
-            table = table_name,
-            where_clause = where_clause,
-            q = q,
-            lock = lock_clause
+            r#"SELECT * FROM {tq}{table_name}{tq} {where_clause} ORDER BY {q}priority{q} ASC, {q}job_id{q} ASC LIMIT 1 {lock_clause}"#
         );
 
         let stmt = Statement::from_sql_and_values(backend, sql, params);
@@ -1175,7 +1163,7 @@ pub mod ready_executions {
         // Helper to generate placeholder based on backend
         let placeholder = |idx: usize| -> String {
             match backend {
-                DbBackend::Postgres => format!("${}", idx),
+                DbBackend::Postgres => format!("${idx}"),
                 DbBackend::MySql | DbBackend::Sqlite => "?".to_string(),
             }
         };
@@ -1232,13 +1220,7 @@ pub mod ready_executions {
         let limit_placeholder = placeholder(params.len());
 
         let sql = format!(
-            r#"SELECT * FROM {tq}{table}{tq} {where_clause} ORDER BY {q}priority{q} ASC, {q}job_id{q} ASC LIMIT {limit_ph} {lock}"#,
-            tq = tq,
-            table = table_name,
-            where_clause = where_clause,
-            q = q,
-            limit_ph = limit_placeholder,
-            lock = lock_clause
+            r#"SELECT * FROM {tq}{table_name}{tq} {where_clause} ORDER BY {q}priority{q} ASC, {q}job_id{q} ASC LIMIT {limit_placeholder} {lock_clause}"#
         );
 
         let stmt = Statement::from_sql_and_values(backend, sql, params);
@@ -1257,20 +1239,17 @@ pub mod ready_executions {
         C: ConnectionTrait,
     {
         let table_name = &table_config.ready_executions;
-        let like_pattern = format!("{}%", pattern);
+        let like_pattern = format!("{pattern}%");
 
         let sql = match db.get_database_backend() {
             DbBackend::Postgres => format!(
-                r#"SELECT DISTINCT "queue_name" FROM "{}" WHERE "queue_name" LIKE $1 ORDER BY "queue_name" ASC"#,
-                table_name
+                r#"SELECT DISTINCT "queue_name" FROM "{table_name}" WHERE "queue_name" LIKE $1 ORDER BY "queue_name" ASC"#
             ),
             DbBackend::MySql => format!(
-                r#"SELECT DISTINCT `queue_name` FROM `{}` WHERE `queue_name` LIKE ? ORDER BY `queue_name` ASC"#,
-                table_name
+                r#"SELECT DISTINCT `queue_name` FROM `{table_name}` WHERE `queue_name` LIKE ? ORDER BY `queue_name` ASC"#
             ),
             DbBackend::Sqlite => format!(
-                r#"SELECT DISTINCT "queue_name" FROM "{}" WHERE "queue_name" LIKE ? ORDER BY "queue_name" ASC"#,
-                table_name
+                r#"SELECT DISTINCT "queue_name" FROM "{table_name}" WHERE "queue_name" LIKE ? ORDER BY "queue_name" ASC"#
             ),
         };
 
@@ -1877,17 +1856,14 @@ pub mod blocked_executions {
         let table_name = &table_config.blocked_executions;
         let sql = match db.get_database_backend() {
             DbBackend::Postgres => format!(
-                r#"SELECT * FROM "{}" WHERE "concurrency_key" = $1 ORDER BY "priority" ASC, "job_id" ASC LIMIT 1 FOR UPDATE SKIP LOCKED"#,
-                table_name
+                r#"SELECT * FROM "{table_name}" WHERE "concurrency_key" = $1 ORDER BY "priority" ASC, "job_id" ASC LIMIT 1 FOR UPDATE SKIP LOCKED"#
             ),
             DbBackend::MySql => format!(
-                r#"SELECT * FROM `{}` WHERE `concurrency_key` = ? ORDER BY `priority` ASC, `job_id` ASC LIMIT 1 FOR UPDATE SKIP LOCKED"#,
-                table_name
+                r#"SELECT * FROM `{table_name}` WHERE `concurrency_key` = ? ORDER BY `priority` ASC, `job_id` ASC LIMIT 1 FOR UPDATE SKIP LOCKED"#
             ),
             DbBackend::Sqlite => format!(
                 // SQLite doesn't support SKIP LOCKED
-                r#"SELECT * FROM "{}" WHERE "concurrency_key" = ? ORDER BY "priority" ASC, "job_id" ASC LIMIT 1"#,
-                table_name
+                r#"SELECT * FROM "{table_name}" WHERE "concurrency_key" = ? ORDER BY "priority" ASC, "job_id" ASC LIMIT 1"#
             ),
         };
         let stmt = Statement::from_sql_and_values(
@@ -2082,11 +2058,10 @@ pub mod failed_executions {
                 // For PostgreSQL, use query_one to handle RETURNING properly
                 // When conflict occurs, no row is returned
                 let sql = format!(
-                    r#"INSERT INTO "{}" ("job_id", "error", "created_at")
+                    r#"INSERT INTO "{table}" ("job_id", "error", "created_at")
                        VALUES ($1, $2, $3)
                        ON CONFLICT ("job_id") DO NOTHING
-                       RETURNING "id""#,
-                    table
+                       RETURNING "id""#
                 );
                 let stmt = Statement::from_sql_and_values(
                     backend,
@@ -2104,9 +2079,8 @@ pub mod failed_executions {
             }
             DbBackend::Sqlite => {
                 let sql = format!(
-                    r#"INSERT OR IGNORE INTO "{}" ("job_id", "error", "created_at")
-                       VALUES (?, ?, ?)"#,
-                    table
+                    r#"INSERT OR IGNORE INTO "{table}" ("job_id", "error", "created_at")
+                       VALUES (?, ?, ?)"#
                 );
                 let stmt = Statement::from_sql_and_values(
                     backend,
@@ -2118,9 +2092,8 @@ pub mod failed_executions {
             }
             DbBackend::MySql => {
                 let sql = format!(
-                    r#"INSERT IGNORE INTO `{}` (`job_id`, `error`, `created_at`)
-                       VALUES (?, ?, ?)"#,
-                    table
+                    r#"INSERT IGNORE INTO `{table}` (`job_id`, `error`, `created_at`)
+                       VALUES (?, ?, ?)"#
                 );
                 let stmt = Statement::from_sql_and_values(
                     backend,
@@ -2461,17 +2434,14 @@ pub mod scheduled_executions {
             // doesn't directly support lock behavior
             let sql = match db.get_database_backend() {
                 DbBackend::Postgres => format!(
-                    r#"SELECT * FROM "{}" WHERE "scheduled_at" <= $1 ORDER BY "scheduled_at" ASC, "priority" ASC, "job_id" ASC LIMIT $2 FOR UPDATE SKIP LOCKED"#,
-                    table_name
+                    r#"SELECT * FROM "{table_name}" WHERE "scheduled_at" <= $1 ORDER BY "scheduled_at" ASC, "priority" ASC, "job_id" ASC LIMIT $2 FOR UPDATE SKIP LOCKED"#
                 ),
                 DbBackend::MySql => format!(
-                    r#"SELECT * FROM `{}` WHERE `scheduled_at` <= ? ORDER BY `scheduled_at` ASC, `priority` ASC, `job_id` ASC LIMIT ? FOR UPDATE SKIP LOCKED"#,
-                    table_name
+                    r#"SELECT * FROM `{table_name}` WHERE `scheduled_at` <= ? ORDER BY `scheduled_at` ASC, `priority` ASC, `job_id` ASC LIMIT ? FOR UPDATE SKIP LOCKED"#
                 ),
                 DbBackend::Sqlite => format!(
                     // SQLite doesn't support SKIP LOCKED, fallback to regular query
-                    r#"SELECT * FROM "{}" WHERE "scheduled_at" <= ? ORDER BY "scheduled_at" ASC, "priority" ASC, "job_id" ASC LIMIT ?"#,
-                    table_name
+                    r#"SELECT * FROM "{table_name}" WHERE "scheduled_at" <= ? ORDER BY "scheduled_at" ASC, "priority" ASC, "job_id" ASC LIMIT ?"#
                 ),
             };
             let stmt = Statement::from_sql_and_values(
@@ -2886,12 +2856,10 @@ pub mod processes {
 
             let sql = match backend {
                 DbBackend::Postgres => format!(
-                    r#"SELECT * FROM "{}" WHERE "last_heartbeat_at" < $1{} FOR UPDATE SKIP LOCKED"#,
-                    table_name, where_extra
+                    r#"SELECT * FROM "{table_name}" WHERE "last_heartbeat_at" < $1{where_extra} FOR UPDATE SKIP LOCKED"#
                 ),
                 DbBackend::MySql => format!(
-                    r#"SELECT * FROM `{}` WHERE `last_heartbeat_at` < ?{} FOR UPDATE SKIP LOCKED"#,
-                    table_name, where_extra
+                    r#"SELECT * FROM `{table_name}` WHERE `last_heartbeat_at` < ?{where_extra} FOR UPDATE SKIP LOCKED"#
                 ),
                 DbBackend::Sqlite => unreachable!(),
             };
@@ -2984,24 +2952,21 @@ pub mod recurring_executions {
         let sql = match backend {
             DbBackend::Postgres => {
                 format!(
-                    r#"INSERT INTO "{}" ("job_id", "task_key", "run_at", "created_at")
+                    r#"INSERT INTO "{table}" ("job_id", "task_key", "run_at", "created_at")
                        VALUES ($1, $2, $3, $4)
-                       ON CONFLICT ("task_key", "run_at") DO NOTHING"#,
-                    table
+                       ON CONFLICT ("task_key", "run_at") DO NOTHING"#
                 )
             }
             DbBackend::Sqlite => {
                 format!(
-                    r#"INSERT OR IGNORE INTO "{}" ("job_id", "task_key", "run_at", "created_at")
-                       VALUES (?, ?, ?, ?)"#,
-                    table
+                    r#"INSERT OR IGNORE INTO "{table}" ("job_id", "task_key", "run_at", "created_at")
+                       VALUES (?, ?, ?, ?)"#
                 )
             }
             DbBackend::MySql => {
                 format!(
-                    r#"INSERT IGNORE INTO `{}` (`job_id`, `task_key`, `run_at`, `created_at`)
-                       VALUES (?, ?, ?, ?)"#,
-                    table
+                    r#"INSERT IGNORE INTO `{table}` (`job_id`, `task_key`, `run_at`, `created_at`)
+                       VALUES (?, ?, ?, ?)"#
                 )
             }
         };
@@ -3138,9 +3103,9 @@ pub mod pauses {
     {
         let table_name = &table_config.pauses;
         let sql = match db.get_database_backend() {
-            DbBackend::Postgres => format!(r#"SELECT "queue_name" FROM "{}""#, table_name),
-            DbBackend::MySql => format!(r#"SELECT `queue_name` FROM `{}`"#, table_name),
-            DbBackend::Sqlite => format!(r#"SELECT "queue_name" FROM "{}""#, table_name),
+            DbBackend::Postgres => format!(r#"SELECT "queue_name" FROM "{table_name}""#),
+            DbBackend::MySql => format!(r#"SELECT `queue_name` FROM `{table_name}`"#),
+            DbBackend::Sqlite => format!(r#"SELECT "queue_name" FROM "{table_name}""#),
         };
         let stmt = Statement::from_string(db.get_database_backend(), sql);
         let rows = db.query_all(stmt).await?;
@@ -3184,11 +3149,10 @@ pub mod pauses {
         match backend {
             DbBackend::Postgres => {
                 let sql = format!(
-                    r#"INSERT INTO "{}" ("queue_name", "created_at")
+                    r#"INSERT INTO "{table}" ("queue_name", "created_at")
                        VALUES ($1, $2)
                        ON CONFLICT ("queue_name") DO NOTHING
-                       RETURNING "id""#,
-                    table
+                       RETURNING "id""#
                 );
                 let stmt = Statement::from_sql_and_values(
                     backend,
@@ -3205,9 +3169,8 @@ pub mod pauses {
             }
             DbBackend::Sqlite => {
                 let sql = format!(
-                    r#"INSERT OR IGNORE INTO "{}" ("queue_name", "created_at")
-                       VALUES (?, ?)"#,
-                    table
+                    r#"INSERT OR IGNORE INTO "{table}" ("queue_name", "created_at")
+                       VALUES (?, ?)"#
                 );
                 let stmt = Statement::from_sql_and_values(
                     backend,
@@ -3223,9 +3186,8 @@ pub mod pauses {
             }
             DbBackend::MySql => {
                 let sql = format!(
-                    r#"INSERT IGNORE INTO `{}` (`queue_name`, `created_at`)
-                       VALUES (?, ?)"#,
-                    table
+                    r#"INSERT IGNORE INTO `{table}` (`queue_name`, `created_at`)
+                       VALUES (?, ?)"#
                 );
                 let stmt = Statement::from_sql_and_values(
                     backend,

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -49,22 +49,22 @@ where
         DbBackend::Postgres => {
             // PostgreSQL: ON CONFLICT DO UPDATE with IS NOT DISTINCT FROM for NULL-safe comparison
             format!(
-                r#"INSERT INTO "{t}" (
+                r#"INSERT INTO "{table}" (
                     "key", "schedule", "command", "class_name", "arguments",
                     "queue_name", "priority", "static", "description",
                     "created_at", "updated_at"
                 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
                 ON CONFLICT ("key") DO UPDATE SET
                     "updated_at" = CASE
-                        WHEN "{t}"."schedule" IS NOT DISTINCT FROM excluded."schedule"
-                            AND "{t}"."command" IS NOT DISTINCT FROM excluded."command"
-                            AND "{t}"."class_name" IS NOT DISTINCT FROM excluded."class_name"
-                            AND "{t}"."arguments" IS NOT DISTINCT FROM excluded."arguments"
-                            AND "{t}"."queue_name" IS NOT DISTINCT FROM excluded."queue_name"
-                            AND "{t}"."priority" IS NOT DISTINCT FROM excluded."priority"
-                            AND "{t}"."static" IS NOT DISTINCT FROM excluded."static"
-                            AND "{t}"."description" IS NOT DISTINCT FROM excluded."description"
-                        THEN "{t}"."updated_at"
+                        WHEN "{table}"."schedule" IS NOT DISTINCT FROM excluded."schedule"
+                            AND "{table}"."command" IS NOT DISTINCT FROM excluded."command"
+                            AND "{table}"."class_name" IS NOT DISTINCT FROM excluded."class_name"
+                            AND "{table}"."arguments" IS NOT DISTINCT FROM excluded."arguments"
+                            AND "{table}"."queue_name" IS NOT DISTINCT FROM excluded."queue_name"
+                            AND "{table}"."priority" IS NOT DISTINCT FROM excluded."priority"
+                            AND "{table}"."static" IS NOT DISTINCT FROM excluded."static"
+                            AND "{table}"."description" IS NOT DISTINCT FROM excluded."description"
+                        THEN "{table}"."updated_at"
                         ELSE CURRENT_TIMESTAMP
                     END,
                     "schedule" = excluded."schedule",
@@ -74,29 +74,28 @@ where
                     "queue_name" = excluded."queue_name",
                     "priority" = excluded."priority",
                     "static" = excluded."static",
-                    "description" = excluded."description""#,
-                t = table
+                    "description" = excluded."description""#
             )
         }
         DbBackend::Sqlite => {
             // SQLite: ON CONFLICT DO UPDATE with IS for NULL-safe comparison
             format!(
-                r#"INSERT INTO "{t}" (
+                r#"INSERT INTO "{table}" (
                     "key", "schedule", "command", "class_name", "arguments",
                     "queue_name", "priority", "static", "description",
                     "created_at", "updated_at"
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
                 ON CONFLICT ("key") DO UPDATE SET
                     "updated_at" = CASE
-                        WHEN "{t}"."schedule" IS excluded."schedule"
-                            AND "{t}"."command" IS excluded."command"
-                            AND "{t}"."class_name" IS excluded."class_name"
-                            AND "{t}"."arguments" IS excluded."arguments"
-                            AND "{t}"."queue_name" IS excluded."queue_name"
-                            AND "{t}"."priority" IS excluded."priority"
-                            AND "{t}"."static" IS excluded."static"
-                            AND "{t}"."description" IS excluded."description"
-                        THEN "{t}"."updated_at"
+                        WHEN "{table}"."schedule" IS excluded."schedule"
+                            AND "{table}"."command" IS excluded."command"
+                            AND "{table}"."class_name" IS excluded."class_name"
+                            AND "{table}"."arguments" IS excluded."arguments"
+                            AND "{table}"."queue_name" IS excluded."queue_name"
+                            AND "{table}"."priority" IS excluded."priority"
+                            AND "{table}"."static" IS excluded."static"
+                            AND "{table}"."description" IS excluded."description"
+                        THEN "{table}"."updated_at"
                         ELSE CURRENT_TIMESTAMP
                     END,
                     "schedule" = excluded."schedule",
@@ -106,15 +105,14 @@ where
                     "queue_name" = excluded."queue_name",
                     "priority" = excluded."priority",
                     "static" = excluded."static",
-                    "description" = excluded."description""#,
-                t = table
+                    "description" = excluded."description""#
             )
         }
         DbBackend::MySql => {
             // MySQL 8.0.20+: Use alias syntax instead of deprecated VALUES()
             // https://dev.mysql.com/doc/refman/8.0/en/insert-on-duplicate.html
             format!(
-                r#"INSERT INTO `{t}` (
+                r#"INSERT INTO `{table}` (
                     `key`, `schedule`, `command`, `class_name`, `arguments`,
                     `queue_name`, `priority`, `static`, `description`,
                     `created_at`, `updated_at`
@@ -140,8 +138,7 @@ where
                     `queue_name` = new_vals.`queue_name`,
                     `priority` = new_vals.`priority`,
                     `static` = new_vals.`static`,
-                    `description` = new_vals.`description`"#,
-                t = table
+                    `description` = new_vals.`description`"#
             )
         }
     };
@@ -187,8 +184,7 @@ where
     let args = match &entry.args {
         Some(a) => serde_json::to_value(a).map_err(|e| {
             DbErr::Custom(format!(
-                "Failed to serialize args for task '{}': {}",
-                task_key, e
+                "Failed to serialize args for task '{task_key}': {e}"
             ))
         })?,
         None => serde_json::Value::Array(vec![]),
@@ -244,11 +240,11 @@ where
                 pyo3::Python::attach(|py| -> std::result::Result<Option<&str>, DbErr> {
                     let runnable = ctx
                         .get_runnable(&entry.class)
-                        .map_err(|e| DbErr::Custom(format!("Failed to get runnable: {}", e)))?;
+                        .map_err(|e| DbErr::Custom(format!("Failed to get runnable: {e}")))?;
                     let bound = runnable.handler.bind(py);
                     let instance = bound
                         .call0()
-                        .map_err(|e| DbErr::Custom(format!("Failed to create instance: {}", e)))?;
+                        .map_err(|e| DbErr::Custom(format!("Failed to create instance: {e}")))?;
                     if let Ok(cell) = instance.cast::<crate::types::ActiveJob>() {
                         let mut inner = cell.borrow_mut();
                         inner.queue_name = queue_name.to_string();
@@ -266,8 +262,7 @@ where
                             }
                             Err(e) => {
                                 return Err(DbErr::Custom(format!(
-                                    "before_enqueue hook error: {}",
-                                    e
+                                    "before_enqueue hook error: {e}"
                                 )));
                             }
                         }
@@ -276,10 +271,10 @@ where
                     // around_enqueue: advance generator to yield, unbind to keep alive
                     if hooks.around_enqueue {
                         let gen = instance.call_method0("around_enqueue").map_err(|e| {
-                            DbErr::Custom(format!("around_enqueue hook error: {}", e))
+                            DbErr::Custom(format!("around_enqueue hook error: {e}"))
                         })?;
                         let builtins = py.import("builtins").map_err(|e| {
-                            DbErr::Custom(format!("Failed to import builtins: {}", e))
+                            DbErr::Custom(format!("Failed to import builtins: {e}"))
                         })?;
                         let first_next = builtins
                             .getattr("next")
@@ -293,8 +288,7 @@ where
                             }
                             Err(e) => {
                                 return Err(DbErr::Custom(format!(
-                                    "around_enqueue before-yield error: {}",
-                                    e
+                                    "around_enqueue before-yield error: {e}"
                                 )));
                             }
                             Ok(_) => {}
@@ -421,7 +415,7 @@ where
             #[cfg(feature = "python")]
             if let Some(gen) = around_gen.take() {
                 pyo3::Python::attach(|py| {
-                    let err_msg = format!("{}", e);
+                    let err_msg = format!("{e}");
                     let exc = pyo3::exceptions::PyRuntimeError::new_err(err_msg);
                     gen.bind(py)
                         .call_method1("throw", (exc.get_type(py), exc.value(py)))
@@ -616,13 +610,13 @@ impl Scheduler {
                 // All tasks removed from config — delete all static rows
                 let sql = match backend {
                     sea_orm::DbBackend::Postgres => {
-                        format!(r#"DELETE FROM "{}" WHERE "static" = TRUE"#, table)
+                        format!(r#"DELETE FROM "{table}" WHERE "static" = TRUE"#)
                     }
                     sea_orm::DbBackend::MySql => {
-                        format!(r#"DELETE FROM `{}` WHERE `static` = 1"#, table)
+                        format!(r#"DELETE FROM `{table}` WHERE `static` = 1"#)
                     }
                     sea_orm::DbBackend::Sqlite => {
-                        format!(r#"DELETE FROM "{}" WHERE "static" = 1"#, table)
+                        format!(r#"DELETE FROM "{table}" WHERE "static" = 1"#)
                     }
                 };
                 (sql, vec![])
@@ -643,16 +637,13 @@ impl Scheduler {
 
                 let sql = match backend {
                     sea_orm::DbBackend::Postgres => format!(
-                        r#"DELETE FROM "{}" WHERE "static" = TRUE AND "key" NOT IN ({})"#,
-                        table, placeholders,
+                        r#"DELETE FROM "{table}" WHERE "static" = TRUE AND "key" NOT IN ({placeholders})"#,
                     ),
                     sea_orm::DbBackend::MySql => format!(
-                        r#"DELETE FROM `{}` WHERE `static` = 1 AND `key` NOT IN ({})"#,
-                        table, placeholders,
+                        r#"DELETE FROM `{table}` WHERE `static` = 1 AND `key` NOT IN ({placeholders})"#,
                     ),
                     sea_orm::DbBackend::Sqlite => format!(
-                        r#"DELETE FROM "{}" WHERE "static" = 1 AND "key" NOT IN ({})"#,
-                        table, placeholders,
+                        r#"DELETE FROM "{table}" WHERE "static" = 1 AND "key" NOT IN ({placeholders})"#,
                     ),
                 };
 
@@ -911,7 +902,7 @@ impl Scheduler {
             let db = self.ctx.get_db().await?;
             let graceful_shutdown = self.ctx.graceful_shutdown.clone();
             let ctx = self.ctx.clone();
-            let task_key = entry.key.clone().unwrap_or_else(|| format!("task_{}", i));
+            let task_key = entry.key.clone().unwrap_or_else(|| format!("task_{i}"));
 
             let handle = tokio::spawn(Self::run_task_loop(
                 ctx,

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -180,8 +180,7 @@ async fn fail_claimed_by_process_id_inner(
     };
 
     let error_msg = format!(
-        "Child process {} (pid={}, host={:?}) crashed",
-        process_id, process_pid, process_hostname
+        "Child process {process_id} (pid={process_pid}, host={process_hostname:?}) crashed"
     );
 
     let ctx = ctx.clone();

--- a/src/types.rs
+++ b/src/types.rs
@@ -123,8 +123,7 @@ fn apply_worker_cfg_to(
     if let Some(polling_interval) = worker_cfg.polling_interval {
         if !polling_interval.is_finite() || polling_interval < 0.0 {
             return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                "worker polling_interval must be finite and >= 0, got {}",
-                polling_interval
+                "worker polling_interval must be finite and >= 0, got {polling_interval}"
             )));
         }
         ctx.worker_polling_interval = Duration::from_secs_f64(polling_interval);
@@ -145,8 +144,7 @@ fn apply_dispatcher_cfg_to(
     if let Some(polling_interval) = dispatcher_cfg.polling_interval {
         if !polling_interval.is_finite() || polling_interval < 0.0 {
             return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                "dispatcher polling_interval must be finite and >= 0, got {}",
-                polling_interval
+                "dispatcher polling_interval must be finite and >= 0, got {polling_interval}"
             )));
         }
         ctx.dispatcher_polling_interval = Duration::from_secs_f64(polling_interval);
@@ -157,8 +155,7 @@ fn apply_dispatcher_cfg_to(
     if let Some(interval) = dispatcher_cfg.concurrency_maintenance_interval {
         if !interval.is_finite() || interval < 0.0 {
             return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                "dispatcher concurrency_maintenance_interval must be finite and >= 0, got {}",
-                interval
+                "dispatcher concurrency_maintenance_interval must be finite and >= 0, got {interval}"
             )));
         }
         ctx.dispatcher_concurrency_maintenance_interval = Duration::from_secs_f64(interval);
@@ -342,8 +339,7 @@ fn resolve_scheduled_at(
             .map(|dt| Some(dt.naive_utc()))
             .ok_or_else(|| {
                 pyo3::exceptions::PyValueError::new_err(format!(
-                    "wait_until timestamp out of range: {}",
-                    ts
+                    "wait_until timestamp out of range: {ts}"
                 ))
             });
     }
@@ -454,7 +450,7 @@ impl PyQuebec {
     #[new]
     fn new(url: String, kwargs: Option<&Bound<'_, PyDict>>) -> PyResult<Self> {
         let dsn = crate::database_url::DatabaseUrl::parse(&url).map_err(|e| {
-            PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Invalid database URL: {}", e))
+            PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("Invalid database URL: {e}"))
         })?;
 
         let sslmode: Option<String> = extract_kwarg_or_env_opt(kwargs, "sslmode", "QUEBEC_SSLMODE");
@@ -480,8 +476,7 @@ impl PyQuebec {
             )
             .map_err(|e| {
                 PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                    "Failed to apply SSL params: {}",
-                    e
+                    "Failed to apply SSL params: {e}"
                 ))
             })?
         } else {
@@ -515,8 +510,7 @@ impl PyQuebec {
                 .build()
                 .map_err(|e| {
                     PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                        "Failed to build runtime: {}",
-                        e
+                        "Failed to build runtime: {e}"
                     ))
                 })?,
         );
@@ -658,8 +652,7 @@ impl PyQuebec {
             })
             .map_err(|e| {
                 pyo3::exceptions::PyConnectionError::new_err(format!(
-                    "Database connection failed: {}",
-                    e
+                    "Database connection failed: {e}"
                 ))
             })?;
         let db_option = Some(Arc::new(db));
@@ -672,8 +665,7 @@ impl PyQuebec {
                     .map(|(k, v)| {
                         let key = k.extract::<String>().map_err(|_| {
                             PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                                "Invalid option key: {:?}",
-                                k
+                                "Invalid option key: {k:?}"
                             ))
                         })?;
                         let obj: Py<PyAny> = v.into_pyobject(py)?.into();
@@ -770,7 +762,7 @@ impl PyQuebec {
                         if !has_explicit_polling {
                             if !polling_interval.is_finite() || polling_interval < 0.0 {
                                 return Err(pyo3::exceptions::PyValueError::new_err(
-                                    format!("worker_polling_interval must be finite and >= 0 (set via queue.yml workers.polling_interval, got {})", polling_interval),
+                                    format!("worker_polling_interval must be finite and >= 0 (set via queue.yml workers.polling_interval, got {polling_interval})"),
                                 ));
                             }
                             _ctx.worker_polling_interval =
@@ -871,8 +863,7 @@ impl PyQuebec {
             let ret = self.rt.block_on(async move { worker.pick_job().await });
             ret.map_err(|e| {
                 PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                    "Failed to pick job: {}",
-                    e
+                    "Failed to pick job: {e}"
                 ))
             })
         })
@@ -889,8 +880,7 @@ impl PyQuebec {
             self.rt.block_on(async move {
                 let claimed = worker.claim_job().await.map_err(|e| {
                     PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                        "No ready job to claim: {}",
-                        e
+                        "No ready job to claim: {e}"
                     ))
                 })?;
 
@@ -911,8 +901,7 @@ impl PyQuebec {
                 let runnable =
                     Python::attach(|_py| ctx.get_runnable(&job.class_name)).map_err(|e| {
                         PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                            "Job handler not found: {}",
-                            e
+                            "Job handler not found: {e}"
                         ))
                     })?;
 
@@ -1051,8 +1040,7 @@ impl PyQuebec {
         self.rt.block_on(async move {
             let db = self.ctx.get_db().await.map_err(|e| {
                 pyo3::exceptions::PyConnectionError::new_err(format!(
-                    "Database connection failed: {}",
-                    e
+                    "Database connection failed: {e}"
                 ))
             })?;
             Ok(db
@@ -1148,8 +1136,7 @@ impl PyQuebec {
                 .build()
                 .map_err(|e| {
                     PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                        "Failed to build runtime in forked child: {}",
-                        e
+                        "Failed to build runtime in forked child: {e}"
                     ))
                 })?,
         );
@@ -1162,8 +1149,7 @@ impl PyQuebec {
                 .map(Arc::new)
                 .map_err(|e| {
                     pyo3::exceptions::PyConnectionError::new_err(format!(
-                        "Database reconnect after fork failed: {}",
-                        e
+                        "Database reconnect after fork failed: {e}"
                     ))
                 })
         })?;
@@ -1266,8 +1252,7 @@ impl PyQuebec {
                 let sup = crate::supervisor::Supervisor::new(ctx);
                 sup.register().await.map_err(|e| {
                     PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                        "register_supervisor failed: {}",
-                        e
+                        "register_supervisor failed: {e}"
                     ))
                 })
             })
@@ -1282,8 +1267,7 @@ impl PyQuebec {
                 let sup = crate::supervisor::Supervisor::new(ctx);
                 sup.heartbeat_process(process_id).await.map_err(|e| {
                     PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                        "heartbeat_process failed: {}",
-                        e
+                        "heartbeat_process failed: {e}"
                     ))
                 })
             })
@@ -1306,8 +1290,7 @@ impl PyQuebec {
                 let sup = crate::supervisor::Supervisor::new(ctx);
                 sup.run_maintenance(exclude_process_id).await.map_err(|e| {
                     PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                        "supervisor_run_maintenance failed: {}",
-                        e
+                        "supervisor_run_maintenance failed: {e}"
                     ))
                 })
             })
@@ -1322,8 +1305,7 @@ impl PyQuebec {
                 let sup = crate::supervisor::Supervisor::new(ctx);
                 sup.deregister_process(process_id).await.map_err(|e| {
                     PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                        "deregister_process failed: {}",
-                        e
+                        "deregister_process failed: {e}"
                     ))
                 })
             })
@@ -1345,8 +1327,7 @@ impl PyQuebec {
                     .await
                     .map_err(|e| {
                         PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                            "fail_claimed_by_process_id failed: {}",
-                            e
+                            "fail_claimed_by_process_id failed: {e}"
                         ))
                     })
             })
@@ -1367,8 +1348,7 @@ impl PyQuebec {
                 let sup = crate::supervisor::Supervisor::new(ctx);
                 sup.fail_claimed_by_pid(pid, &hostname).await.map_err(|e| {
                     PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                        "fail_claimed_by_pid failed: {}",
-                        e
+                        "fail_claimed_by_pid failed: {e}"
                     ))
                 })
             })
@@ -1501,8 +1481,7 @@ impl PyQuebec {
         self.rt.block_on(async move {
             let db = self.ctx.get_db().await.map_err(|e| {
                 pyo3::exceptions::PyConnectionError::new_err(format!(
-                    "Database connection failed: {}",
-                    e
+                    "Database connection failed: {e}"
                 ))
             })?;
 
@@ -1672,8 +1651,7 @@ impl PyQuebec {
                 .get_runnable(&class_name.to_string())
                 .map_err(|e| {
                     pyo3::exceptions::PyRuntimeError::new_err(format!(
-                        "Failed to get runnable: {:?}",
-                        e
+                        "Failed to get runnable: {e:?}"
                     ))
                 })?;
 
@@ -1681,8 +1659,7 @@ impl PyQuebec {
                 .get_concurrency_constraint(Some(args), kwargs)
                 .map_err(|e| {
                     pyo3::exceptions::PyRuntimeError::new_err(format!(
-                        "Failed to get concurrency info: {:?}",
-                        e
+                        "Failed to get concurrency info: {e:?}"
                     ))
                 })?;
 
@@ -1751,8 +1728,7 @@ impl PyQuebec {
 
         let arguments = serde_json::to_string(&job_data).map_err(|e| {
             PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                "Failed to serialize job data: {}",
-                e
+                "Failed to serialize job data: {e}"
             ))
         })?;
 
@@ -1858,7 +1834,7 @@ impl PyQuebec {
             let obj_clone = obj.clone();
             let enqueue_result = py
                 .detach(|| self.block_on(async move { quebec.perform_later(obj_clone).await }))
-                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("Error: {:?}", e)));
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("Error: {e:?}")));
 
             let job_id_result;
             match enqueue_result {
@@ -1896,9 +1872,7 @@ impl PyQuebec {
             let obj_clone = obj.clone();
             let job = py
                 .detach(|| self.block_on(async move { quebec.perform_later(obj_clone).await }))
-                .map_err(|e| {
-                    pyo3::exceptions::PyRuntimeError::new_err(format!("Error: {:?}", e))
-                })?;
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("Error: {e:?}")))?;
             obj.id.replace(job.id);
             debug!("Job queued in {:?}: {:?}", start_time.elapsed(), obj);
 
@@ -2033,8 +2007,7 @@ impl PyQuebec {
 
             let arguments = serde_json::to_string(&job_data).map_err(|e| {
                 PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                    "Failed to serialize job data: {}",
-                    e
+                    "Failed to serialize job data: {e}"
                 ))
             })?;
 
@@ -2051,8 +2024,7 @@ impl PyQuebec {
                             .get_concurrency_constraint(Some(args_bound), kwargs_opt)
                             .map_err(|e| {
                                 pyo3::exceptions::PyRuntimeError::new_err(format!(
-                                    "Failed to get concurrency info: {:?}",
-                                    e
+                                    "Failed to get concurrency info: {e:?}"
                                 ))
                             })?;
                         match constraint {
@@ -2093,7 +2065,7 @@ impl PyQuebec {
             })
             .map_err(|e| {
                 error!("perform_all_later error: {:?}", e);
-                pyo3::exceptions::PyRuntimeError::new_err(format!("Error: {:?}", e))
+                pyo3::exceptions::PyRuntimeError::new_err(format!("Error: {e:?}"))
             })?;
 
         let now = chrono::Utc::now().naive_utc();
@@ -2196,16 +2168,14 @@ impl PyQuebec {
         let check_result: PyResult<bool> = self.rt.block_on(async {
             let db = ctx.get_db().await.map_err(|e| {
                 PyErr::new::<pyo3::exceptions::PyConnectionError, _>(format!(
-                    "Database connection failed: {}",
-                    e
+                    "Database connection failed: {e}"
                 ))
             })?;
             crate::schema_builder::check_tables_exist(db.as_ref(), &ctx.table_config)
                 .await
                 .map_err(|e| {
                     PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                        "Database error: {}",
-                        e
+                        "Database error: {e}"
                     ))
                 })
         });
@@ -2475,16 +2445,14 @@ impl PyQuebec {
                     .map(|dt| dt.naive_utc())
                     .ok_or_else(|| {
                         pyo3::exceptions::PyValueError::new_err(format!(
-                            "Invalid timestamp: {} is out of range",
-                            ts
+                            "Invalid timestamp: {ts} is out of range"
                         ))
                     })?
             }
             None => {
                 let duration = chrono::Duration::from_std(clear_after).map_err(|e| {
                     pyo3::exceptions::PyValueError::new_err(format!(
-                        "Invalid clear_finished_jobs_after duration: {}",
-                        e
+                        "Invalid clear_finished_jobs_after duration: {e}"
                     ))
                 })?;
                 chrono::Utc::now().naive_utc() - duration
@@ -2495,8 +2463,7 @@ impl PyQuebec {
             self.rt.block_on(async {
                 let db = self.ctx.get_db().await.map_err(|e| {
                     pyo3::exceptions::PyRuntimeError::new_err(format!(
-                        "Database connection failed: {}",
-                        e
+                        "Database connection failed: {e}"
                     ))
                 })?;
                 let mut total_deleted: u64 = 0;
@@ -2511,8 +2478,7 @@ impl PyQuebec {
                     .await
                     .map_err(|e| {
                         pyo3::exceptions::PyRuntimeError::new_err(format!(
-                            "Failed to delete finished jobs: {}",
-                            e
+                            "Failed to delete finished jobs: {e}"
                         ))
                     })?;
 
@@ -2564,16 +2530,14 @@ impl PyQuebec {
                     .map(|dt| dt.naive_utc())
                     .ok_or_else(|| {
                         pyo3::exceptions::PyValueError::new_err(format!(
-                            "Invalid timestamp: {} is out of range",
-                            ts
+                            "Invalid timestamp: {ts} is out of range"
                         ))
                     })?
             }
             None => {
                 let duration = chrono::Duration::from_std(clear_after).map_err(|e| {
                     pyo3::exceptions::PyValueError::new_err(format!(
-                        "Invalid clear_finished_jobs_after duration: {}",
-                        e
+                        "Invalid clear_finished_jobs_after duration: {e}"
                     ))
                 })?;
                 chrono::Utc::now().naive_utc() - duration
@@ -2584,8 +2548,7 @@ impl PyQuebec {
             self.rt.block_on(async {
                 let db = self.ctx.get_db().await.map_err(|e| {
                     pyo3::exceptions::PyRuntimeError::new_err(format!(
-                        "Database connection failed: {}",
-                        e
+                        "Database connection failed: {e}"
                     ))
                 })?;
                 crate::query_builder::jobs::count_finished_before(
@@ -2596,8 +2559,7 @@ impl PyQuebec {
                 .await
                 .map_err(|e| {
                     pyo3::exceptions::PyRuntimeError::new_err(format!(
-                        "Failed to count clearable jobs: {}",
-                        e
+                        "Failed to count clearable jobs: {e}"
                     ))
                 })
             })

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -398,7 +398,6 @@ where
     // Environment not found, return error with available environments
     let available: Vec<String> = env_config.keys().cloned().collect();
     Err(crate::error::QuebecError::Config(format!(
-        "Environment '{}' not found in config. Available environments: {:?}",
-        environment, available
+        "Environment '{environment}' not found in config. Available environments: {available:?}"
     )))
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -216,7 +216,7 @@ impl Runnable {
             };
 
             // Build final concurrency_key as "group/key"
-            let key = format!("{}/{}", concurrency_group, raw_key);
+            let key = format!("{concurrency_group}/{raw_key}");
 
             // Return explicit limit or default to 1 (per Solid Queue spec)
             let limit = self.concurrency_limit.unwrap_or(1);
@@ -233,7 +233,7 @@ impl Runnable {
                 on_conflict: self.concurrency_on_conflict,
             }))
         })
-        .map_err(|e: PyErr| QuebecError::Python(format!("get_concurrency_constraint: {}", e)))
+        .map_err(|e: PyErr| QuebecError::Python(format!("get_concurrency_constraint: {e}")))
     }
 
     /// Check if should retry, return matching retry strategy and its exception key.
@@ -621,7 +621,7 @@ impl Runnable {
 
         let binding = json_to_py(py, &v)?;
         let args = binding.cast_bound::<pyo3::types::PyList>(py).map_err(|e| {
-            PyException::new_err(format!("Failed to convert arguments to PyList: {:?}", e))
+            PyException::new_err(format!("Failed to convert arguments to PyList: {e:?}"))
         })?;
 
         // Initialize kwargs
@@ -816,7 +816,7 @@ impl Runnable {
         let delay = strategy.wait;
         let scheduled_at = chrono::Utc::now().naive_utc()
             + chrono::Duration::from_std(delay)
-                .map_err(|e| QuebecError::validation(format!("Invalid delay duration: {}", e)))?;
+                .map_err(|e| QuebecError::validation(format!("Invalid delay duration: {e}")))?;
         let new_arguments =
             crate::utils::increment_executions(job.arguments.as_deref(), Some(exception_key));
 
@@ -862,7 +862,7 @@ impl Runnable {
             .qualname()
             .map(|q| q.to_string())
             .unwrap_or_else(|_| "Unknown".to_string());
-        let exception_key = format!("[{}]", error_type);
+        let exception_key = format!("[{error_type}]");
         job.arguments = Some(crate::utils::increment_executions(
             job.arguments.as_deref(),
             Some(&exception_key),
@@ -952,7 +952,7 @@ impl Execution {
         let thread_id = std::thread::current().id();
 
         // Convert ThreadId to string
-        let thread_id_str = format!("{:?}", thread_id);
+        let thread_id_str = format!("{thread_id:?}");
 
         // Extract numeric part (fallback to 0 if parsing fails)
         let thread_id_num: u64 = thread_id_str
@@ -963,7 +963,7 @@ impl Execution {
         Self {
             ctx,
             timer: Instant::now(),
-            tid: format!("{}", thread_id_num),
+            tid: format!("{thread_id_num}"),
             claimed,
             job,
             runnable,
@@ -1097,7 +1097,7 @@ impl Execution {
                 info!(
                     "Job `{}' executed in: {}",
                     self.runnable.class_name,
-                    format!("{:?}", eplased).bright_purple(),
+                    format!("{eplased:?}").bright_purple(),
                 );
             } else {
                 error!(
@@ -1357,8 +1357,7 @@ impl Execution {
         match transaction_result {
             Ok(_) => Ok(self.job.clone()),
             Err(e) => Err(QuebecError::Transaction(format!(
-                "Database error during job processing: {}",
-                e
+                "Database error during job processing: {e}"
             ))),
         }
     }
@@ -1665,8 +1664,7 @@ impl Worker {
     ) -> PyResult<()> {
         if !handler.bind(py).is_callable() {
             return Err(PyTypeError::new_err(format!(
-                "Expected a callable object for worker {} handler",
-                handler_type
+                "Expected a callable object for worker {handler_type} handler"
             )));
         }
         if let Ok(mut h) = handlers.write() {
@@ -2200,8 +2198,7 @@ impl Worker {
             let process_pid = process.pid;
             let process_hostname = process.hostname.clone();
             let error_msg = format!(
-                "Worker process {} (pid={}, host={:?}) stopped responding",
-                process_id, process_pid, process_hostname
+                "Worker process {process_id} (pid={process_pid}, host={process_hostname:?}) stopped responding"
             );
 
             let ctx = self.ctx.clone();
@@ -2262,10 +2259,7 @@ impl Worker {
         // Calculate the cutoff timestamp
         let finished_before = chrono::Utc::now().naive_utc()
             - chrono::Duration::from_std(clear_after).map_err(|e| {
-                QuebecError::validation(format!(
-                    "Invalid clear_finished_jobs_after duration: {}",
-                    e
-                ))
+                QuebecError::validation(format!("Invalid clear_finished_jobs_after duration: {e}"))
             })?;
 
         let mut total_deleted: u64 = 0;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -303,7 +303,7 @@ mod jobs {
                 &db,
                 &tc,
                 "q",
-                &format!("Job{}", i),
+                &format!("Job{i}"),
                 None,
                 0,
                 None,


### PR DESCRIPTION
## Summary
- Apply `clippy::uninlined_format_args` across the codebase via `cargo clippy --fix`
- 161 call sites converted from `format!("... {}", x)` to `format!("... {x}")`
- Pure mechanical rewrite, no behavior change

## Test plan
- [x] `cargo clippy --all-targets --all-features` clean
- [x] `cargo fmt --all -- --check` clean
- [ ] CI pytest suite green