### PR TITLE
refactor: use map_or / map_or_else / is_some_and combinators

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -47,8 +47,7 @@ impl WorkerConfig {
             "WorkerConfig(queues={}, threads={:?}, polling_interval={:?})",
             self.queues
                 .as_ref()
-                .map(|q| q.to_string())
-                .unwrap_or_else(|| "None".to_string()),
+                .map_or_else(|| "None".to_string(), |q| q.to_string()),
             self.threads,
             self.polling_interval
         )
@@ -62,7 +61,7 @@ impl WorkerConfig {
 
     /// Check if processes all queues
     fn is_all_queues(&self) -> bool {
-        self.queues.as_ref().map(|q| q.is_all()).unwrap_or(false)
+        self.queues.as_ref().is_some_and(|q| q.is_all())
     }
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -743,8 +743,7 @@ impl AppContext {
     pub fn get_runnable_names(&self) -> Vec<String> {
         self.runnables
             .read()
-            .map(|r| r.keys().cloned().collect())
-            .unwrap_or_else(|_| Vec::new())
+            .map_or_else(|_| Vec::new(), |r| r.keys().cloned().collect())
     }
 
     /// Check if a job class has concurrency control enabled

--- a/src/control_plane/handlers/health.rs
+++ b/src/control_plane/handlers/health.rs
@@ -74,19 +74,17 @@ impl ControlPlane {
         let pending_seconds = query_builder::ready_executions::oldest_created_at(db, table_config)
             .await
             .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-            .map(|created_at| {
+            .map_or(0.0, |created_at| {
                 now.signed_duration_since(created_at).num_milliseconds() as f64 / 1000.0
-            })
-            .unwrap_or(0.0);
+            });
 
         let processing_seconds =
             query_builder::claimed_executions::oldest_created_at(db, table_config)
                 .await
                 .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-                .map(|created_at| {
+                .map_or(0.0, |created_at| {
                     now.signed_duration_since(created_at).num_milliseconds() as f64 / 1000.0
-                })
-                .unwrap_or(0.0);
+                });
 
         // Job counts — propagate errors so the health endpoint surfaces DB failures
         let map_err = |e: sea_orm::DbErr| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string());

--- a/src/control_plane/handlers/scheduled_jobs.rs
+++ b/src/control_plane/handlers/scheduled_jobs.rs
@@ -215,8 +215,7 @@ impl ControlPlane {
             ))
             .await
             .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-            .map(|row| row.try_get::<i64>("", "count").unwrap_or(0))
-            .unwrap_or(0);
+            .map_or(0, |row| row.try_get::<i64>("", "count").unwrap_or(0));
 
         let total_pages = ((total_count as f64) / (page_size as f64)).ceil() as u64;
         let total_pages = total_pages.max(1);

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -369,7 +369,7 @@ where
                             job.class_name,
                             constraint.key,
                             constraint.limit,
-                            constraint.duration.map(|d| d.num_seconds()).unwrap_or(0)
+                            constraint.duration.map_or(0, |d| d.num_seconds())
                         );
                         query_builder::jobs::mark_finished(db, &ctx.table_config, job.id).await?;
                         return Ok((job, false)); // discarded

--- a/src/types.rs
+++ b/src/types.rs
@@ -198,8 +198,7 @@ fn signal_handler(
             .bind(py)
             .cast::<PyQuebec>()
             .ok()
-            .map(|q| q.borrow().ctx.supervisor_pid.load(Ordering::Relaxed) != 0)
-            .unwrap_or(false);
+            .is_some_and(|q| q.borrow().ctx.supervisor_pid.load(Ordering::Relaxed) != 0);
         if supervised {
             warn!("Received SIGQUIT, exiting immediately");
             std::process::exit(0);
@@ -1383,13 +1382,11 @@ impl PyQuebec {
         let total_workers: u32 = config
             .workers
             .as_ref()
-            .map(|ws| ws.iter().map(|w| w.processes.unwrap_or(1)).sum())
-            .unwrap_or(0);
+            .map_or(0, |ws| ws.iter().map(|w| w.processes.unwrap_or(1)).sum());
         let total_dispatchers: u32 = config
             .dispatchers
             .as_ref()
-            .map(|ds| ds.iter().map(|d| d.processes.unwrap_or(1)).sum())
-            .unwrap_or(0);
+            .map_or(0, |ds| ds.iter().map(|d| d.processes.unwrap_or(1)).sum());
         // Only auto-enter supervisor mode when more than one of something is
         // requested. A bare "1 worker + 1 dispatcher" config stays in the
         // existing single-process threaded mode for backward compatibility.
@@ -2755,8 +2752,7 @@ fn resolve_quebec_from_cls(cls: &Bound<'_, PyType>) -> PyResult<PyQuebec> {
     let name_err = || {
         let name = cls
             .qualname()
-            .map(|s| s.to_string())
-            .unwrap_or_else(|_| "job class".to_string());
+            .map_or_else(|_| "job class".to_string(), |s| s.to_string());
         PyTypeError::new_err(format!(
             "{name} is not registered with a Quebec instance. Use \
              @qc.register_job, qc.register_job_class({name}), or \

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -383,8 +383,7 @@ impl Runnable {
         let error_name = error
             .get_type(py)
             .name()
-            .map(|s| s.to_string())
-            .unwrap_or_else(|_| "unknown error".to_string());
+            .map_or_else(|_| "unknown error".to_string(), |s| s.to_string());
         info!("Job discarded due to {}", error_name);
 
         // Call after_discard hook on the job instance — only if overridden
@@ -415,8 +414,7 @@ impl Runnable {
         let exception_class = error
             .get_type(py)
             .name()
-            .map(|s| s.to_string())
-            .unwrap_or_else(|_| "UnknownError".to_string());
+            .map_or_else(|_| "UnknownError".to_string(), |s| s.to_string());
 
         let error_payload = serde_json::json!({
             "exception_class": exception_class,
@@ -704,15 +702,12 @@ impl Runnable {
             .and_then(|attr| attr.extract::<bool>().ok())
             .unwrap_or(true);
 
-        let (has_continuation_progress, current_resumptions) = self
-            .continuation_info
-            .as_ref()
-            .map(|info| {
+        let (has_continuation_progress, current_resumptions) =
+            self.continuation_info.as_ref().map_or((false, 0), |info| {
                 // Check if state has any completed steps or current step with cursor
                 let has_progress = !info.state.completed.is_empty() || info.state.current.is_some();
                 (has_progress, info.resumptions)
-            })
-            .unwrap_or((false, 0));
+            });
 
         if resume_errors_after_advancing && has_continuation_progress {
             if current_resumptions >= max_resumptions {
@@ -860,8 +855,7 @@ impl Runnable {
         let error_type = error
             .get_type(py)
             .qualname()
-            .map(|q| q.to_string())
-            .unwrap_or_else(|_| "Unknown".to_string());
+            .map_or_else(|_| "Unknown".to_string(), |q| q.to_string());
         let exception_key = format!("[{error_type}]");
         job.arguments = Some(crate::utils::increment_executions(
             job.arguments.as_deref(),
@@ -1447,8 +1441,7 @@ impl Execution {
             let exception_class = e
                 .get_type()
                 .str()
-                .map(|s| s.to_string())
-                .unwrap_or_else(|_| "Unknown".to_string());
+                .map_or_else(|_| "Unknown".to_string(), |s| s.to_string());
 
             error!("error: {:?}", e);
             error!("error_type: {}", exception_class);
@@ -1579,15 +1572,14 @@ impl Execution {
             }
             .instrument(span.clone());
 
-            let job = self
-                .ctx
-                .get_runtime_handle()
-                .map(|h| h.block_on(retry_future))
-                .unwrap_or_else(|| {
+            let job = self.ctx.get_runtime_handle().map_or_else(
+                || {
                     Err(sea_orm::TransactionError::Connection(DbErr::Custom(
                         "Runtime handle unavailable".into(),
                     )))
-                });
+                },
+                |h| h.block_on(retry_future),
+            );
 
             if job.is_err() {
                 error!("Job failed to schedule: {:?}", job.err());
@@ -1883,8 +1875,7 @@ impl Worker {
 
                     let queue_patterns = queue_selector
                         .as_ref()
-                        .map(|q| q.ordered_patterns())
-                        .unwrap_or_else(|| vec![(false, "*".to_string())]);
+                        .map_or_else(|| vec![(false, "*".to_string())], |q| q.ordered_patterns());
 
                     // Helper macro to avoid duplicating find + claim logic
                     macro_rules! try_claim_one {
@@ -1974,8 +1965,7 @@ impl Worker {
                     // This preserves Solid Queue's queue ordering semantics
                     let queue_patterns = queue_selector
                         .as_ref()
-                        .map(|q| q.ordered_patterns())
-                        .unwrap_or_else(|| vec![(false, "*".to_string())]); // Default to all
+                        .map_or_else(|| vec![(false, "*".to_string())], |q| q.ordered_patterns()); // Default to all
 
                     // Helper macro to claim jobs from a queue (batch insert + batch delete)
                     macro_rules! claim_from_queue {
@@ -2535,14 +2525,13 @@ impl Worker {
         let (limit, duration) = Python::attach(|_py| {
             ctx.get_runnable(&job.class_name)
                 .ok()
-                .map(|r| {
+                .map_or((1, None), |r| {
                     (
                         r.concurrency_limit.unwrap_or(1),
                         r.concurrency_duration
                             .map(|s| chrono::Duration::seconds(s as i64)),
                     )
                 })
-                .unwrap_or((1, None))
         });
 
         if release_semaphore(db, table_config, key.clone(), limit, duration)


### PR DESCRIPTION
## Summary
- Apply `clippy::map_unwrap_or` across the codebase
- 19 sites fixed via `cargo clippy --fix`, 1 manual (worker.rs runtime handle fallback)
- `Option::map(...).unwrap_or(false)` → `is_some_and(...)`
- `Option::map(...).unwrap_or(x)` / `unwrap_or_else(g)` → `map_or(x, ...)` / `map_or_else(g, ...)`
- Same for `Result`

## Test plan
- [x] `cargo clippy --all-targets --all-features` clean
- [x] `cargo clippy -- -W clippy::map_unwrap_or` 0 hits
- [x] `cargo fmt --all -- --check` clean
- [ ] CI pytest suite green