### PR TITLE
fix: read class queue_with_priority for scheduler-enqueued jobs

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -176,7 +176,12 @@ where
 
     // Step 1: Create the job first
     let queue_name = entry.queue.as_deref().unwrap_or("default");
-    let priority = entry.priority.unwrap_or(0);
+    // Priority precedence: YAML entry > class `queue_with_priority` > 0
+    let priority = entry.priority.unwrap_or_else(|| {
+        ctx.get_runnable(&entry.class)
+            .map(|r| r.priority as i32)
+            .unwrap_or(0)
+    });
 
     let now = chrono::Utc::now().naive_utc();
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1699,6 +1699,12 @@ impl Worker {
                 // Callable queue_as is re-evaluated per-enqueue in PyQuebec::perform_later.
             }
 
+            let priority = match bound.getattr("queue_with_priority") {
+                Ok(attr) => i64::from(attr.extract::<i32>()?),
+                Err(e) if e.is_instance_of::<pyo3::exceptions::PyAttributeError>(py) => 0,
+                Err(e) => return Err(e),
+            };
+
             let mut concurrency_limit: Option<i32> = None;
             let mut concurrency_duration: Option<i32> = None;
             let mut concurrency_on_conflict = ConcurrencyConflict::default();
@@ -1808,7 +1814,7 @@ impl Worker {
                 module_path,
                 handler: klass,
                 queue_as: queue_name,
-                priority: 0,
+                priority,
                 retry_info: None,
                 concurrency_limit,
                 concurrency_duration,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1010,7 +1010,17 @@ impl Execution {
         // Get cancellation token from context for continuation support
         let cancellation_token = Some(self.ctx.graceful_shutdown.clone());
         let result = async {
-            info!(delay_ms, "Job `{}' started", self.runnable.class_name);
+            let class_name = &self.runnable.class_name;
+            if job.priority == 0 {
+                info!(id = job.id, delay_ms, "Job `{class_name}' started");
+            } else {
+                info!(
+                    id = job.id,
+                    priority = job.priority,
+                    delay_ms,
+                    "Job `{class_name}' started"
+                );
+            }
             let invoke_result = self.runnable.invoke(&mut job, cancellation_token);
             // Move retry information from runnable to execution
             if let Some(retry_info) = self.runnable.retry_info.take() {


### PR DESCRIPTION
## Summary

- Scheduler-enqueued jobs now respect the job class's `queue_with_priority` attribute. Precedence: YAML entry > class attribute > 0.
- `register_job_class` now extracts `queue_with_priority` so it ends up on the cached `Runnable`, which the scheduler can read when no priority is set in the YAML entry.
- The "Job started" log line includes the job id, and shows priority when non-zero — easier to correlate execution with queue ordering.

## Test plan

- [x] `cargo clippy --all-targets --all-features`