### PR TITLE
feat: pythonic priority/queue attributes + scheduler defaults

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -340,6 +340,14 @@ pub(crate) fn parse_duration_f64_env(s: &str) -> Option<Duration> {
         .or_else(|| s.parse::<u64>().ok().map(Duration::from_secs))
 }
 
+/// Class-level scheduling metadata captured at `register_job_class` time.
+/// Plain Rust types only — readable without the GIL.
+#[derive(Debug, Clone)]
+pub struct RunnableDefaults {
+    pub queue_as: String,
+    pub priority: i32,
+}
+
 impl AppContext {
     #[cfg(feature = "python")]
     pub fn new(
@@ -736,6 +744,26 @@ impl AppContext {
             .ok()
             .and_then(|r| r.get(class_name).map(|r| r.hooks.clone()))
             .unwrap_or_default()
+    }
+
+    /// Get the registered queue/priority defaults for a job class. Avoids the
+    /// GIL by skipping the `Py<PyAny>` clone that `get_runnable` performs, so
+    /// callers that only need scheduling metadata pay just a HashMap lookup.
+    #[cfg(feature = "python")]
+    pub fn get_runnable_defaults(&self, class_name: &str) -> Option<RunnableDefaults> {
+        self.runnables.read().ok().and_then(|r| {
+            r.get(class_name).map(|r| RunnableDefaults {
+                queue_as: r.queue_as.clone(),
+                priority: r.priority as i32,
+            })
+        })
+    }
+
+    /// No-op fallback when the `python` feature is disabled — there is no
+    /// runnable registry without Python job classes.
+    #[cfg(not(feature = "python"))]
+    pub fn get_runnable_defaults(&self, _class_name: &str) -> Option<RunnableDefaults> {
+        None
     }
 
     /// Get all registered runnable class names

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -175,13 +175,18 @@ where
         .ok_or_else(|| DbErr::Custom("Task key is missing".to_string()))?;
 
     // Step 1: Create the job first
-    let queue_name = entry.queue.as_deref().unwrap_or("default");
-    // Priority precedence: YAML entry > class `queue_with_priority` > 0
-    let priority = entry.priority.unwrap_or_else(|| {
-        ctx.get_runnable(&entry.class)
-            .map(|r| r.priority as i32)
-            .unwrap_or(0)
-    });
+    // Queue/priority precedence: YAML entry > class attribute > default.
+    let defaults = ctx.get_runnable_defaults(&entry.class);
+    let queue_name = entry
+        .queue
+        .clone()
+        .or_else(|| defaults.as_ref().map(|d| d.queue_as.clone()))
+        .unwrap_or_else(|| "default".to_string());
+    let queue_name = queue_name.as_str();
+    let priority = entry
+        .priority
+        .or_else(|| defaults.as_ref().map(|d| d.priority))
+        .unwrap_or(0);
 
     let now = chrono::Utc::now().naive_utc();
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1594,10 +1594,10 @@ impl PyQuebec {
         let bound = klass;
         let class_name = bound.cast::<PyType>()?.qualname()?;
 
-        let queue_name = match bound.getattr("queue_as") {
-            Ok(attr) if attr.is_callable() => {
+        let queue_name = match crate::utils::lookup_class_queue(bound, py)? {
+            Some((attr, _)) if attr.is_callable() => {
                 // Filter out internal _-prefixed kwargs (e.g. _queue, _priority, _scheduled_at)
-                // injected by JobBuilder.set() before passing to user's queue_as callable
+                // injected by JobBuilder.set() before passing to user's queue callable
                 let filtered = PyDict::new(py);
                 if let Some(k) = kwargs {
                     for (key, value) in k.iter() {
@@ -1621,18 +1621,13 @@ impl PyQuebec {
                     name
                 }
             }
-            Ok(attr) => attr.extract::<String>()?,
-            Err(e) if e.is_instance_of::<pyo3::exceptions::PyAttributeError>(py) => {
-                "default".to_string()
+            Some((attr, attr_name)) => {
+                crate::utils::extract_queue_name_attr(bound, &attr, attr_name)?
             }
-            Err(e) => return Err(e),
+            None => "default".to_string(),
         };
 
-        let priority = match bound.getattr("queue_with_priority") {
-            Ok(attr) => attr.extract::<i32>()?,
-            Err(e) if e.is_instance_of::<pyo3::exceptions::PyAttributeError>(py) => 0,
-            Err(e) => return Err(e),
-        };
+        let priority = crate::utils::extract_class_priority(bound, py)?;
 
         let instance = bound.call0()?;
 
@@ -1912,8 +1907,8 @@ impl PyQuebec {
             let args_bound = py_args.cast::<PyTuple>()?;
             let kwargs_bound = py_kwargs.cast::<PyDict>()?;
 
-            let queue_name = match job_class.getattr("queue_as") {
-                Ok(attr) if attr.is_callable() => {
+            let queue_name = match crate::utils::lookup_class_queue(&job_class, py)? {
+                Some((attr, _)) if attr.is_callable() => {
                     // Filter out internal _-prefixed kwargs for consistency with perform_later
                     let filtered = PyDict::new(py);
                     for (key, value) in kwargs_bound.iter() {
@@ -1936,18 +1931,13 @@ impl PyQuebec {
                         name
                     }
                 }
-                Ok(attr) => attr.extract::<String>()?,
-                Err(e) if e.is_instance_of::<pyo3::exceptions::PyAttributeError>(py) => {
-                    "default".to_string()
+                Some((attr, attr_name)) => {
+                    crate::utils::extract_queue_name_attr(&job_class, &attr, attr_name)?
                 }
-                Err(e) => return Err(e),
+                None => "default".to_string(),
             };
 
-            let priority = match job_class.getattr("queue_with_priority") {
-                Ok(attr) => attr.extract::<i32>()?,
-                Err(e) if e.is_instance_of::<pyo3::exceptions::PyAttributeError>(py) => 0,
-                Err(e) => return Err(e),
-            };
+            let priority = crate::utils::extract_class_priority(&job_class, py)?;
 
             // Apply option overrides
             let options = py_options.cast::<PyDict>()?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -17,6 +17,97 @@ pub fn generate_job_id() -> String {
     nanoid::nanoid!(12, &NANOID_ALPHABET)
 }
 
+/// Read a job class's queue priority, preferring the Pythonic `priority` attribute
+/// and falling back to `queue_with_priority` for Solid Queue compatibility.
+/// Returns 0 when neither attribute is defined.
+///
+/// `BaseClass` inherits from `ActiveJob`, which exposes a `priority` getset
+/// descriptor — when that descriptor is what's resolved (no user override) we
+/// fall through. A non-int override raises a TypeError naming the offending
+/// attribute and class so misconfiguration is easy to diagnose.
+#[cfg(feature = "python")]
+pub fn extract_class_priority(bound: &Bound<'_, PyAny>, py: Python<'_>) -> PyResult<i32> {
+    for attr_name in ["priority", "queue_with_priority"] {
+        match bound.getattr(attr_name) {
+            Ok(attr) if is_getset_descriptor(&attr) => continue,
+            Ok(attr) => {
+                return attr.extract::<i32>().map_err(|_| {
+                    pyo3::exceptions::PyTypeError::new_err(format!(
+                        "{}.{} must be int, got {}",
+                        class_qualname(bound),
+                        attr_name,
+                        type_qualname(&attr),
+                    ))
+                });
+            }
+            Err(e) if e.is_instance_of::<pyo3::exceptions::PyAttributeError>(py) => continue,
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(0)
+}
+
+#[cfg(feature = "python")]
+fn is_getset_descriptor(attr: &Bound<'_, PyAny>) -> bool {
+    type_qualname(attr) == "getset_descriptor"
+}
+
+#[cfg(feature = "python")]
+fn type_qualname(obj: &Bound<'_, PyAny>) -> String {
+    obj.get_type()
+        .qualname()
+        .ok()
+        .and_then(|q| q.extract::<String>().ok())
+        .unwrap_or_else(|| "<unknown>".to_string())
+}
+
+#[cfg(feature = "python")]
+fn class_qualname(bound: &Bound<'_, PyAny>) -> String {
+    bound
+        .getattr("__qualname__")
+        .ok()
+        .and_then(|q| q.extract::<String>().ok())
+        .unwrap_or_else(|| "<class>".to_string())
+}
+
+/// Look up a job class's queue declaration, preferring the Pythonic `queue`
+/// attribute and falling back to `queue_as` for Solid Queue compatibility.
+/// Returns the resolved attribute together with the name it was found under,
+/// so callers can produce diagnostic errors. Returns `None` when neither
+/// attribute is defined.
+#[cfg(feature = "python")]
+pub fn lookup_class_queue<'py>(
+    bound: &Bound<'py, PyAny>,
+    py: Python<'py>,
+) -> PyResult<Option<(Bound<'py, PyAny>, &'static str)>> {
+    for attr_name in ["queue", "queue_as"] {
+        match bound.getattr(attr_name) {
+            Ok(attr) => return Ok(Some((attr, attr_name))),
+            Err(e) if e.is_instance_of::<pyo3::exceptions::PyAttributeError>(py) => continue,
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(None)
+}
+
+/// Extract a static queue name attribute as a string, raising a TypeError
+/// that names the offending class and attribute when it is not a string.
+#[cfg(feature = "python")]
+pub fn extract_queue_name_attr(
+    class: &Bound<'_, PyAny>,
+    attr: &Bound<'_, PyAny>,
+    attr_name: &str,
+) -> PyResult<String> {
+    attr.extract::<String>().map_err(|_| {
+        pyo3::exceptions::PyTypeError::new_err(format!(
+            "{}.{} must be str, got {}",
+            class_qualname(class),
+            attr_name,
+            type_qualname(attr),
+        ))
+    })
+}
+
 /// Convert YAML value to Python object
 #[cfg(feature = "python")]
 pub fn yaml_value_to_python(py: Python<'_>, value: &serde_yaml::Value) -> PyResult<Py<PyAny>> {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1701,19 +1701,14 @@ impl Worker {
             debug!("Registered job class: {:?}", class_name);
 
             let mut queue_name = "default".to_string();
-            if bound.hasattr("queue_as")? {
-                let attr = bound.getattr("queue_as")?;
+            if let Some((attr, attr_name)) = crate::utils::lookup_class_queue(bound, py)? {
                 if !attr.is_callable() {
-                    queue_name = attr.extract::<String>()?;
+                    queue_name = crate::utils::extract_queue_name_attr(bound, &attr, attr_name)?;
                 }
-                // Callable queue_as is re-evaluated per-enqueue in PyQuebec::perform_later.
+                // Callable queue is re-evaluated per-enqueue in PyQuebec::perform_later.
             }
 
-            let priority = match bound.getattr("queue_with_priority") {
-                Ok(attr) => i64::from(attr.extract::<i32>()?),
-                Err(e) if e.is_instance_of::<pyo3::exceptions::PyAttributeError>(py) => 0,
-                Err(e) => return Err(e),
-            };
+            let priority = i64::from(crate::utils::extract_class_priority(bound, py)?);
 
             let mut concurrency_limit: Option<i32> = None;
             let mut concurrency_duration: Option<i32> = None;

--- a/tests/test_enqueue.py
+++ b/tests/test_enqueue.py
@@ -283,3 +283,90 @@ def test_perform_all_later_returns_empty_list_for_empty_input(
     qc.register_job(BulkJob)
 
     assert qc.perform_all_later([]) == []
+
+
+class PythonicAliasJob(quebec.BaseClass):
+    queue = "alias-q"
+    priority = 11
+
+    def perform(self, value: int) -> None:
+        return None
+
+
+class AliasOverridesSolidQueueJob(quebec.BaseClass):
+    # Pythonic names take precedence when both are present.
+    queue = "primary-q"
+    queue_as = "fallback-q"
+    priority = 21
+    queue_with_priority = 99
+
+    def perform(self, value: int) -> None:
+        return None
+
+
+def test_perform_later_reads_pythonic_queue_and_priority(
+    qc_with_sqlalchemy, db_assert
+) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    qc.register_job(PythonicAliasJob)
+
+    enqueued = PythonicAliasJob.perform_later(qc, 5)
+    persisted = get_job_by_active_job_id(session, prefix, enqueued.active_job_id)
+
+    assert persisted["queue_name"] == "alias-q"
+    assert persisted["priority"] == 11
+    assert db_assert.count_jobs() == 1
+
+
+def test_perform_later_prefers_pythonic_aliases_over_solid_queue_names(
+    qc_with_sqlalchemy, db_assert
+) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    qc.register_job(AliasOverridesSolidQueueJob)
+
+    enqueued = AliasOverridesSolidQueueJob.perform_later(qc, 7)
+    persisted = get_job_by_active_job_id(session, prefix, enqueued.active_job_id)
+
+    assert persisted["queue_name"] == "primary-q"
+    assert persisted["priority"] == 21
+    assert db_assert.count_jobs() == 1
+
+
+class StringPriorityJob(quebec.BaseClass):
+    priority = "10"  # type: ignore[assignment]
+
+    def perform(self, value: int) -> None:
+        return None
+
+
+def test_register_job_raises_for_non_int_priority(qc_with_sqlalchemy) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+
+    import pytest
+
+    with pytest.raises(
+        TypeError, match=r"StringPriorityJob\.priority must be int, got str"
+    ):
+        qc.register_job(StringPriorityJob)
+
+
+class NonStrQueueJob(quebec.BaseClass):
+    queue = 100  # type: ignore[assignment]
+
+    def perform(self, value: int) -> None:
+        return None
+
+
+def test_register_job_raises_for_non_str_queue(qc_with_sqlalchemy) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+
+    import pytest
+
+    with pytest.raises(TypeError, match=r"NonStrQueueJob\.queue must be str, got int"):
+        qc.register_job(NonStrQueueJob)


### PR DESCRIPTION
## Summary

- Job classes can use Pythonic `priority` and `queue` class attributes; Solid Queue's `queue_with_priority` and `queue_as` still work as a fallback for migrations.
- Misconfigured types raise a TypeError naming the class and attribute — e.g. `Foo.priority must be int, got str`, `Foo.queue must be str, got int` — instead of an opaque `'int' object is not an instance of 'str'`.
- The scheduler now respects class `queue`/`queue_as` when the YAML entry doesn't override it (it already respected `queue_with_priority`).
- Cache class queue/priority defaults in `AppContext` as plain Rust (`RunnableDefaults`) so the scheduler reads them without acquiring the GIL.

## Test plan

- [x] `cargo clippy --all-targets --all-features`
- [x] `uv run pytest` — 101 passed (3 new tests covering the alias precedence and the friendly TypeError messages)