### PR TITLE
fix(control-plane): preserve filters across pagination on job list pages

### DIFF
--- a/src/control_plane/handlers/finished_jobs.rs
+++ b/src/control_plane/handlers/finished_jobs.rs
@@ -127,6 +127,8 @@ impl ControlPlane {
         context.insert("current_page_num", &pagination.page);
         context.insert("total_pages", &total_pages);
         context.insert("active_page", "finished-jobs");
+        context.insert("filter_class_name", &pagination.class_name);
+        context.insert("filter_queue_name", &pagination.queue_name);
 
         let html = state
             .render_template("finished-jobs.html", &mut context)

--- a/src/control_plane/handlers/in_progress_jobs.rs
+++ b/src/control_plane/handlers/in_progress_jobs.rs
@@ -152,6 +152,8 @@ impl ControlPlane {
         context.insert("current_page_num", &pagination.page);
         context.insert("total_pages", &total_pages);
         context.insert("active_page", "in-progress-jobs");
+        context.insert("filter_class_name", &pagination.class_name);
+        context.insert("filter_queue_name", &pagination.queue_name);
 
         let html = state
             .render_template("in-progress-jobs.html", &mut context)

--- a/src/control_plane/handlers/scheduled_jobs.rs
+++ b/src/control_plane/handlers/scheduled_jobs.rs
@@ -231,6 +231,8 @@ impl ControlPlane {
         context.insert("current_page_num", &pagination.page);
         context.insert("total_pages", &total_pages);
         context.insert("active_page", "scheduled-jobs");
+        context.insert("filter_class_name", &pagination.class_name);
+        context.insert("filter_queue_name", &pagination.queue_name);
 
         let html = state
             .render_template("scheduled-jobs.html", &mut context)

--- a/src/control_plane/templates/finished-jobs.html
+++ b/src/control_plane/templates/finished-jobs.html
@@ -41,6 +41,10 @@
   <div class="flex-grow"></div>
 </div>
 
+{% set filter_args = "" %}
+{% if filter_class_name %}{% set encoded_cn = filter_class_name | urlencode %}{% set filter_args = filter_args ~ "class_name=" ~ encoded_cn %}{% endif %}
+{% if filter_queue_name %}{% if filter_args %}{% set filter_args = filter_args ~ "&" %}{% endif %}{% set encoded_qn = filter_queue_name | urlencode %}{% set filter_args = filter_args ~ "queue_name=" ~ encoded_qn %}{% endif %}
+
 <!-- Table -->
 <div class="overflow-x-auto rounded-lg border border-gray-200">
   <table class="min-w-full divide-y divide-gray-200">
@@ -105,7 +109,7 @@
   </div>
   <div class="flex space-x-2">
     {% if current_page_num > 1 %}
-      <a href="{{ base_path }}/finished-jobs?page={{ current_page_num - 1 }}" data-turbo-action="advance" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 h-8 px-3 py-1">
+      <a href="{{ base_path }}/finished-jobs?page={{ current_page_num - 1 }}{% if filter_args %}&{{ filter_args }}{% endif %}" data-turbo-action="advance" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 h-8 px-3 py-1">
         Previous page
       </a>
     {% else %}
@@ -115,7 +119,7 @@
     {% endif %}
 
     {% if current_page_num < total_pages %}
-      <a href="{{ base_path }}/finished-jobs?page={{ current_page_num + 1 }}" data-turbo-action="advance" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 h-8 px-3 py-1">
+      <a href="{{ base_path }}/finished-jobs?page={{ current_page_num + 1 }}{% if filter_args %}&{{ filter_args }}{% endif %}" data-turbo-action="advance" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 h-8 px-3 py-1">
         Next page
       </a>
     {% else %}

--- a/src/control_plane/templates/in-progress-jobs.html
+++ b/src/control_plane/templates/in-progress-jobs.html
@@ -41,6 +41,10 @@
   <div class="flex-grow"></div>
 </div>
 
+{% set filter_args = "" %}
+{% if filter_class_name %}{% set encoded_cn = filter_class_name | urlencode %}{% set filter_args = filter_args ~ "class_name=" ~ encoded_cn %}{% endif %}
+{% if filter_queue_name %}{% if filter_args %}{% set filter_args = filter_args ~ "&" %}{% endif %}{% set encoded_qn = filter_queue_name | urlencode %}{% set filter_args = filter_args ~ "queue_name=" ~ encoded_qn %}{% endif %}
+
 <!-- Table -->
 <div class="overflow-x-auto rounded-lg border border-gray-200">
   <table class="min-w-full divide-y divide-gray-200">
@@ -104,7 +108,7 @@
   </div>
   <div class="flex space-x-2">
     {% if current_page_num > 1 %}
-      <a href="{{ base_path }}/in-progress-jobs?page={{ current_page_num - 1 }}" data-turbo-action="advance" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 h-8 px-3 py-1">
+      <a href="{{ base_path }}/in-progress-jobs?page={{ current_page_num - 1 }}{% if filter_args %}&{{ filter_args }}{% endif %}" data-turbo-action="advance" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 h-8 px-3 py-1">
         Previous page
       </a>
     {% else %}
@@ -114,7 +118,7 @@
     {% endif %}
 
     {% if current_page_num < total_pages %}
-      <a href="{{ base_path }}/in-progress-jobs?page={{ current_page_num + 1 }}" data-turbo-action="advance" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 h-8 px-3 py-1">
+      <a href="{{ base_path }}/in-progress-jobs?page={{ current_page_num + 1 }}{% if filter_args %}&{{ filter_args }}{% endif %}" data-turbo-action="advance" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 h-8 px-3 py-1">
         Next page
       </a>
     {% else %}

--- a/src/control_plane/templates/scheduled-jobs.html
+++ b/src/control_plane/templates/scheduled-jobs.html
@@ -41,6 +41,10 @@
   <div class="flex-grow"></div>
 </div>
 
+{% set filter_args = "" %}
+{% if filter_class_name %}{% set encoded_cn = filter_class_name | urlencode %}{% set filter_args = filter_args ~ "class_name=" ~ encoded_cn %}{% endif %}
+{% if filter_queue_name %}{% if filter_args %}{% set filter_args = filter_args ~ "&" %}{% endif %}{% set encoded_qn = filter_queue_name | urlencode %}{% set filter_args = filter_args ~ "queue_name=" ~ encoded_qn %}{% endif %}
+
 <!-- Table -->
 <div class="overflow-x-auto rounded-lg border border-gray-200">
   <table class="min-w-full divide-y divide-gray-200">
@@ -110,7 +114,7 @@
   </div>
   <div class="flex space-x-2">
     {% if current_page_num > 1 %}
-      <a href="{{ base_path }}/scheduled-jobs?page={{ current_page_num - 1 }}" data-turbo-action="advance" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 h-8 px-3 py-1">
+      <a href="{{ base_path }}/scheduled-jobs?page={{ current_page_num - 1 }}{% if filter_args %}&{{ filter_args }}{% endif %}" data-turbo-action="advance" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 h-8 px-3 py-1">
         Previous page
       </a>
     {% else %}
@@ -120,7 +124,7 @@
     {% endif %}
 
     {% if current_page_num < total_pages %}
-      <a href="{{ base_path }}/scheduled-jobs?page={{ current_page_num + 1 }}" data-turbo-action="advance" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 h-8 px-3 py-1">
+      <a href="{{ base_path }}/scheduled-jobs?page={{ current_page_num + 1 }}{% if filter_args %}&{{ filter_args }}{% endif %}" data-turbo-action="advance" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 h-8 px-3 py-1">
         Next page
       </a>
     {% else %}


### PR DESCRIPTION
## Summary
- Previous/Next pagination links on `finished-jobs`, `scheduled-jobs`, and `in-progress-jobs` dropped the active `class_name` / `queue_name` filter, forcing users to re-select the filter after every page navigation.
- Pass the current filter values from the handler into the template context and append URL-encoded `class_name` / `queue_name` query args to the pagination hrefs.

## Test plan
- [x] `cargo check`
- [x] `cargo clippy --all-targets`
- [ ] Manual: open `/finished-jobs`, apply a class filter, click Next page → filter persists. Repeat for `/scheduled-jobs` and `/in-progress-jobs`.

## Follow-up
The same pattern (rendering `filter_args` and injecting `filter_class_name` / `filter_queue_name`) now lives in 5+ handlers and 5+ templates. A Tera macro + small Rust helper could deduplicate it; deferred to a separate refactor PR.