### PR TITLE
fix(asgi): prevent doubled mount prefix in redirect Location headers

### DIFF
--- a/python/quebec/__init__.py
+++ b/python/quebec/__init__.py
@@ -588,11 +588,19 @@ class ControlPlaneASGI:
         status, headers, response_body = self.qc.handle_control_plane_request(req)
 
         # Rewrite Location headers for redirects (303 etc.)
+        # Idempotent: skip if the Location already starts with the mount prefix
+        # (some Rust handlers derive the redirect from Referer / base_path and
+        # therefore emit a path that already includes root_path).
         if root_path:
             prefix = root_path.encode()
             rewritten = []
             for name, value in headers:
-                if name.lower() == b"location" and value.startswith(b"/"):
+                if (
+                    name.lower() == b"location"
+                    and value.startswith(b"/")
+                    and value != prefix
+                    and not value.startswith(prefix + b"/")
+                ):
                     value = prefix + value
                 rewritten.append((name, value))
             headers = rewritten


### PR DESCRIPTION
## Summary
- When the control plane is mounted under a sub-path (e.g. `app.mount("/quebec", qc.asgi_app())`), retrying a failed job redirected to `/quebec/quebec/failed-jobs` (doubled prefix) and the page broke.
- Root cause: `ControlPlaneASGI.__call__` unconditionally prepended `root_path` to every `Location` starting with `/`, but some Rust handlers derive the redirect from the `Referer` URL or interpolate `state.base_path` directly, so the path already includes the mount prefix.
- Make the rewrite idempotent: skip if the Location already equals `root_path` or starts with `root_path + "/"`. Plain `Redirect::to("/queues")` still receives the prefix; previously-prefixed paths are left untouched.

## Verification
- Unit-tested the wrapper in isolation against 5 cases (with-prefix, without-prefix, exact prefix, prefix-as-substring `/quebecadmin`, no-mount); all pass.
- `cargo check`, `cargo clippy --all-targets` pass.
- Pre-existing `F401` ruff diagnostics in `python/quebec/__init__.py` are unrelated to this change.

## Test plan
- [ ] Manually mount `app.mount("/quebec", qc.asgi_app())` in a FastAPI app
- [ ] Trigger a failed-job retry from the dashboard
- [ ] Confirm browser ends up on `/quebec/failed-jobs` (not `/quebec/quebec/...`)
- [ ] Spot-check pause/resume on a queue page, cancel on a scheduled job, and out-of-range pagination — none should produce `/quebec/quebec/...`