### PR TITLE
perf(notify): per-queue NOTIFY throttle + bare-queue payload

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -285,6 +285,12 @@ pub struct AppContext {
     /// Disable when running through transaction-pooling proxies (RDS Proxy,
     /// PgBouncer transaction mode) that don't keep session state across queries.
     pub use_listen_notify: bool,
+    /// Per-queue minimum interval between NOTIFYs emitted by this process.
+    /// Producers that fall inside the window are silently dropped; the worker
+    /// catches up via polling / IDLE fallback. Set to `Duration::ZERO` to
+    /// disable throttling. Mitigates NOTIFY storms on Aurora-style clusters
+    /// where every NOTIFY incurs cross-AZ replication cost.
+    pub notify_throttle_interval: Duration,
     pub process_heartbeat_interval: Duration,
     pub process_alive_threshold: Duration,
     pub shutdown_timeout: Duration,
@@ -452,6 +458,9 @@ impl AppContext {
             if let Some(v) = get_bool("use_listen_notify") {
                 ctx.use_listen_notify = v;
             }
+            if let Some(v) = get_duration("notify_throttle_interval") {
+                ctx.notify_throttle_interval = v;
+            }
             if let Some(v) = get_duration("process_heartbeat_interval") {
                 ctx.process_heartbeat_interval = v;
             }
@@ -572,6 +581,7 @@ impl AppContext {
             name: std::env::var("QUEBEC_NAME").unwrap_or_else(|_| "quebec".to_string()),
             use_skip_locked: true,
             use_listen_notify: true,
+            notify_throttle_interval: Duration::from_secs(1),
             process_heartbeat_interval: Duration::from_secs(60),
             process_alive_threshold: Duration::from_secs(300),
             shutdown_timeout: Duration::from_secs(5),
@@ -688,6 +698,7 @@ impl AppContext {
             // Fresh state; child must call `watch_parent_pid` after fork.
             supervisor_pid: AtomicI32::new(0),
             use_listen_notify: self.use_listen_notify,
+            notify_throttle_interval: self.notify_throttle_interval,
         }
     }
 

--- a/src/control_plane/handlers/recurring_jobs.rs
+++ b/src/control_plane/handlers/recurring_jobs.rs
@@ -152,9 +152,10 @@ impl ControlPlane {
             })
             .await?;
 
-        // Send NOTIFY after transaction commits (only if job was created)
+        // Send NOTIFY after transaction commits (only if job was created).
+        // `should_send_notify` enforces backend + use_listen_notify + per-queue throttle.
         if let Some(ref queue) = enqueued_queue {
-            if state.ctx.is_postgres() {
+            if crate::notify::should_send_notify(&state.ctx, queue) {
                 NotifyManager::send_notify(&state.ctx.name, db, queue, "new_job")
                     .await
                     .inspect_err(|e| warn!("Failed to send NOTIFY: {}", e))

--- a/src/control_plane/handlers/recurring_jobs.rs
+++ b/src/control_plane/handlers/recurring_jobs.rs
@@ -156,7 +156,7 @@ impl ControlPlane {
         // `should_send_notify` enforces backend + use_listen_notify + per-queue throttle.
         if let Some(ref queue) = enqueued_queue {
             if crate::notify::should_send_notify(&state.ctx, queue) {
-                NotifyManager::send_notify(&state.ctx.name, db, queue, "new_job")
+                NotifyManager::send_notify(&state.ctx.name, db, queue)
                     .await
                     .inspect_err(|e| warn!("Failed to send NOTIFY: {}", e))
                     .ok();

--- a/src/core.rs
+++ b/src/core.rs
@@ -77,14 +77,16 @@ impl Quebec {
             .await
             .map_err(crate::error::QuebecError::from)?;
 
-        // Send NOTIFY only for queues that have ready jobs (consistent with perform_later)
-        if self.ctx.is_postgres() {
-            for queue_name in &ready_queues {
-                NotifyManager::send_notify(&self.ctx.name, &*db, queue_name, "new_job")
-                    .await
-                    .inspect_err(|e| warn!("Failed to send NOTIFY: {}", e))
-                    .ok();
+        // Send NOTIFY only for queues that have ready jobs (consistent with perform_later).
+        // `should_send_notify` enforces backend + use_listen_notify + per-queue throttle.
+        for queue_name in &ready_queues {
+            if !crate::notify::should_send_notify(&self.ctx, queue_name) {
+                continue;
             }
+            NotifyManager::send_notify(&self.ctx.name, &*db, queue_name, "new_job")
+                .await
+                .inspect_err(|e| warn!("Failed to send NOTIFY: {}", e))
+                .ok();
         }
 
         Ok(job_models)
@@ -106,7 +108,9 @@ impl Quebec {
             .await
             .map_err(crate::error::QuebecError::from)?;
 
-        if destination.should_notify() && self.ctx.is_postgres() {
+        if destination.should_notify()
+            && crate::notify::should_send_notify(&self.ctx, &job_model.queue_name)
+        {
             NotifyManager::send_notify(&self.ctx.name, &*db, &job_model.queue_name, "new_job")
                 .await
                 .inspect_err(|e| warn!("Failed to send NOTIFY: {}", e))

--- a/src/core.rs
+++ b/src/core.rs
@@ -83,7 +83,7 @@ impl Quebec {
             if !crate::notify::should_send_notify(&self.ctx, queue_name) {
                 continue;
             }
-            NotifyManager::send_notify(&self.ctx.name, &*db, queue_name, "new_job")
+            NotifyManager::send_notify(&self.ctx.name, &*db, queue_name)
                 .await
                 .inspect_err(|e| warn!("Failed to send NOTIFY: {}", e))
                 .ok();
@@ -111,7 +111,7 @@ impl Quebec {
         if destination.should_notify()
             && crate::notify::should_send_notify(&self.ctx, &job_model.queue_name)
         {
-            NotifyManager::send_notify(&self.ctx.name, &*db, &job_model.queue_name, "new_job")
+            NotifyManager::send_notify(&self.ctx.name, &*db, &job_model.queue_name)
                 .await
                 .inspect_err(|e| warn!("Failed to send NOTIFY: {}", e))
                 .ok();

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -233,11 +233,14 @@ impl Dispatcher {
                     .instrument(tracing::info_span!("polling", component = "dispatcher"))
                     .await;
 
-                    // Send NOTIFY for each unique queue after transaction commits
+                    // Send NOTIFY for each unique queue after transaction commits.
+                    // `should_send_notify` enforces backend + use_listen_notify + per-queue throttle.
                     let Ok(queues) = transaction_result else { continue };
-                    if !self.ctx.is_postgres() { continue; }
 
                     for queue_name in queues {
+                        if !crate::notify::should_send_notify(&self.ctx, &queue_name) {
+                            continue;
+                        }
                         crate::notify::NotifyManager::send_notify(&self.ctx.name, &*polling_db, &queue_name, "new_job")
                             .await
                             .inspect_err(|e| warn!("Failed to send NOTIFY for queue {}: {}", queue_name, e))

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -241,7 +241,7 @@ impl Dispatcher {
                         if !crate::notify::should_send_notify(&self.ctx, &queue_name) {
                             continue;
                         }
-                        crate::notify::NotifyManager::send_notify(&self.ctx.name, &*polling_db, &queue_name, "new_job")
+                        crate::notify::NotifyManager::send_notify(&self.ctx.name, &*polling_db, &queue_name)
                             .await
                             .inspect_err(|e| warn!("Failed to send NOTIFY for queue {}: {}", queue_name, e))
                             .ok();

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -16,6 +16,18 @@ use tracing::{error, info, trace, warn};
 static LAST_NOTIFY: LazyLock<Mutex<HashMap<String, Instant>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
+/// Should the producer emit a NOTIFY for `queue` given the current context?
+///
+/// Combines three checks: the backend is PostgreSQL, the operator hasn't
+/// opted out via `use_listen_notify = false`, and the per-queue throttle
+/// window has elapsed. Centralized so every producer call site (perform_later,
+/// perform_all_later, dispatcher) honors the same policy.
+pub fn should_send_notify(ctx: &AppContext, queue: &str) -> bool {
+    ctx.is_postgres()
+        && ctx.use_listen_notify
+        && should_emit_notify(queue, ctx.notify_throttle_interval)
+}
+
 /// Decide whether a NOTIFY for `queue` should be emitted now.
 ///
 /// Returns `true` and records the emission time when the queue has not been

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -2,9 +2,48 @@ use crate::context::AppContext;
 use crate::error::{QuebecError, Result};
 use sea_orm::*;
 use sqlx::postgres::PgListener;
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock, Mutex};
+use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 use tracing::{error, info, trace, warn};
+
+/// Per-queue last-NOTIFY timestamps, shared across the process. Producers
+/// consult this table before emitting a NOTIFY to coalesce bursts (e.g.
+/// thousands of `perform_later` calls in a loop) into one wake-up per
+/// `notify_throttle_interval`. The window is per process — workers still
+/// catch up via polling / IDLE fallback if a NOTIFY is dropped.
+static LAST_NOTIFY: LazyLock<Mutex<HashMap<String, Instant>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Decide whether a NOTIFY for `queue` should be emitted now.
+///
+/// Returns `true` and records the emission time when the queue has not been
+/// notified within the last `throttle`. Returns `false` when an earlier
+/// NOTIFY is still inside the throttle window. `throttle == Duration::ZERO`
+/// disables throttling and always returns `true` (no state recorded).
+pub fn should_emit_notify(queue: &str, throttle: Duration) -> bool {
+    if throttle.is_zero() {
+        return true;
+    }
+    let now = Instant::now();
+    let mut map = LAST_NOTIFY.lock().expect("notify throttle map poisoned");
+    match map.get(queue) {
+        Some(last) if now.duration_since(*last) < throttle => false,
+        _ => {
+            map.insert(queue.to_string(), now);
+            true
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn reset_notify_throttle() {
+    LAST_NOTIFY
+        .lock()
+        .expect("notify throttle map poisoned")
+        .clear();
+}
 
 /// PostgreSQL LISTEN/NOTIFY manager for reducing queue latency
 pub struct NotifyManager {
@@ -237,5 +276,43 @@ mod tests {
         let sqlite_dsn = DatabaseUrl::parse("sqlite://test.db").expect("Valid sqlite test URL");
         let sqlite_ctx = make_ctx(sqlite_dsn);
         assert!(!sqlite_ctx.is_postgres());
+    }
+
+    #[test]
+    fn test_throttle_zero_disables() {
+        reset_notify_throttle();
+        for _ in 0..5 {
+            assert!(should_emit_notify("zero", Duration::ZERO));
+        }
+    }
+
+    #[test]
+    fn test_throttle_drops_within_window() {
+        reset_notify_throttle();
+        let throttle = Duration::from_secs(60);
+        assert!(should_emit_notify("within", throttle));
+        // Subsequent calls inside the window are dropped.
+        for _ in 0..10 {
+            assert!(!should_emit_notify("within", throttle));
+        }
+    }
+
+    #[test]
+    fn test_throttle_allows_after_window() {
+        reset_notify_throttle();
+        let throttle = Duration::from_millis(10);
+        assert!(should_emit_notify("after", throttle));
+        std::thread::sleep(Duration::from_millis(20));
+        assert!(should_emit_notify("after", throttle));
+    }
+
+    #[test]
+    fn test_throttle_is_per_queue() {
+        reset_notify_throttle();
+        let throttle = Duration::from_secs(60);
+        assert!(should_emit_notify("queue_a", throttle));
+        assert!(should_emit_notify("queue_b", throttle));
+        assert!(!should_emit_notify("queue_a", throttle));
+        assert!(!should_emit_notify("queue_b", throttle));
     }
 }

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -192,20 +192,20 @@ impl NotifyManager {
         Ok(())
     }
 
-    /// Static method to send NOTIFY using existing database connection
-    pub async fn send_notify<C>(app_name: &str, db: &C, queue_name: &str, event: &str) -> Result<()>
+    /// Static method to send NOTIFY using existing database connection.
+    ///
+    /// Payload is the queue name as a plain string. Workers parse the payload
+    /// directly; legacy `{"queue":"...","event":"..."}` JSON is still accepted
+    /// on the consumer side for mid-upgrade compatibility. Postgres collapses
+    /// duplicate (channel, payload) NOTIFYs emitted from the same transaction
+    /// for free, so a smaller payload helps both bandwidth and dedup.
+    pub async fn send_notify<C>(app_name: &str, db: &C, queue_name: &str) -> Result<()>
     where
         C: ConnectionTrait,
     {
-        let message = NotifyMessage {
-            queue: queue_name.to_string(),
-            event: event.to_string(),
-        };
-        let message_json = serde_json::to_string(&message)?;
-
         // Use the same naming convention as LISTEN
         let channel_name = format!("{app_name}_jobs");
-        Self::send_notify_with_db(db, &channel_name, &message_json).await
+        Self::send_notify_with_db(db, &channel_name, queue_name).await
     }
 
     /// Internal helper to send NOTIFY with database connection and channel name

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -49,14 +49,6 @@ pub fn should_emit_notify(queue: &str, throttle: Duration) -> bool {
     }
 }
 
-#[cfg(test)]
-pub(crate) fn reset_notify_throttle() {
-    LAST_NOTIFY
-        .lock()
-        .expect("notify throttle map poisoned")
-        .clear();
-}
-
 /// PostgreSQL LISTEN/NOTIFY manager for reducing queue latency
 pub struct NotifyManager {
     ctx: Arc<AppContext>,
@@ -290,41 +282,49 @@ mod tests {
         assert!(!sqlite_ctx.is_postgres());
     }
 
+    // Throttle tests share the process-wide LAST_NOTIFY map and run in
+    // parallel under `cargo test`, so each test owns a unique queue-name
+    // prefix to stay independent without touching peers' state.
+
     #[test]
     fn test_throttle_zero_disables() {
-        reset_notify_throttle();
+        // Duration::ZERO short-circuits before the map is touched.
         for _ in 0..5 {
-            assert!(should_emit_notify("zero", Duration::ZERO));
+            assert!(should_emit_notify(
+                "throttle_test::zero_disables",
+                Duration::ZERO
+            ));
         }
     }
 
     #[test]
     fn test_throttle_drops_within_window() {
-        reset_notify_throttle();
         let throttle = Duration::from_secs(60);
-        assert!(should_emit_notify("within", throttle));
+        let queue = "throttle_test::drops_within_window";
+        assert!(should_emit_notify(queue, throttle));
         // Subsequent calls inside the window are dropped.
         for _ in 0..10 {
-            assert!(!should_emit_notify("within", throttle));
+            assert!(!should_emit_notify(queue, throttle));
         }
     }
 
     #[test]
     fn test_throttle_allows_after_window() {
-        reset_notify_throttle();
         let throttle = Duration::from_millis(10);
-        assert!(should_emit_notify("after", throttle));
+        let queue = "throttle_test::allows_after_window";
+        assert!(should_emit_notify(queue, throttle));
         std::thread::sleep(Duration::from_millis(20));
-        assert!(should_emit_notify("after", throttle));
+        assert!(should_emit_notify(queue, throttle));
     }
 
     #[test]
     fn test_throttle_is_per_queue() {
-        reset_notify_throttle();
         let throttle = Duration::from_secs(60);
-        assert!(should_emit_notify("queue_a", throttle));
-        assert!(should_emit_notify("queue_b", throttle));
-        assert!(!should_emit_notify("queue_a", throttle));
-        assert!(!should_emit_notify("queue_b", throttle));
+        let a = "throttle_test::per_queue_a";
+        let b = "throttle_test::per_queue_b";
+        assert!(should_emit_notify(a, throttle));
+        assert!(should_emit_notify(b, throttle));
+        assert!(!should_emit_notify(a, throttle));
+        assert!(!should_emit_notify(b, throttle));
     }
 }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -813,7 +813,7 @@ impl Scheduler {
             // `should_send_notify` enforces backend + use_listen_notify + per-queue throttle.
             if let Ok(Some(queue_name)) = result {
                 if crate::notify::should_send_notify(&ctx, &queue_name) {
-                    NotifyManager::send_notify(&ctx.name, db.as_ref(), &queue_name, "new_job")
+                    NotifyManager::send_notify(&ctx.name, db.as_ref(), &queue_name)
                         .await
                         .inspect_err(|e| warn!("Failed to send NOTIFY: {}", e))
                         .ok();

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -809,9 +809,10 @@ impl Scheduler {
                 .await
                 .inspect_err(|e| error!("Failed to enqueue scheduled job {}: {}", task_key, e));
 
-            // Send NOTIFY after transaction commits (only if job was actually created)
+            // Send NOTIFY after transaction commits (only if job was actually created).
+            // `should_send_notify` enforces backend + use_listen_notify + per-queue throttle.
             if let Ok(Some(queue_name)) = result {
-                if ctx.is_postgres() {
+                if crate::notify::should_send_notify(&ctx, &queue_name) {
                     NotifyManager::send_notify(&ctx.name, db.as_ref(), &queue_name, "new_job")
                         .await
                         .inspect_err(|e| warn!("Failed to send NOTIFY: {}", e))

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -2072,17 +2072,26 @@ impl Worker {
         Ok(jobs)
     }
 
-    /// Check if this worker should handle the notify message for the given queue
+    /// Check if this worker should handle the notify message for the given queue.
+    ///
+    /// Current producers emit the queue name as a plain string. Older releases
+    /// (and any third-party publisher) emitted `{"queue":"...","event":"..."}`
+    /// JSON; we still accept that shape transparently so a mid-upgrade fleet
+    /// keeps working.
     fn should_handle_notify(&self, msg: &str) -> bool {
-        let notify_msg = match serde_json::from_str::<crate::notify::NotifyMessage>(msg) {
-            Ok(m) => m,
-            Err(e) => {
-                warn!("Failed to parse NOTIFY message '{}': {}", msg, e);
-                return true; // If we can't parse, process anyway to be safe
+        let queue_name = if msg.starts_with('{') {
+            match serde_json::from_str::<crate::notify::NotifyMessage>(msg) {
+                Ok(m) => m.queue,
+                Err(e) => {
+                    warn!("Failed to parse legacy JSON NOTIFY '{}': {}", msg, e);
+                    return true; // best-effort: process anyway
+                }
             }
+        } else {
+            msg.to_string()
         };
 
-        trace!("Received NOTIFY for queue: {}", notify_msg.queue);
+        trace!("Received NOTIFY for queue: {}", queue_name);
 
         let Some(ref queues) = self.ctx.worker_queues else {
             return true; // No queue config, process all queues
@@ -2095,10 +2104,10 @@ impl Worker {
         let exact = queues.exact_names();
         let wildcards = queues.wildcard_prefixes();
 
-        exact.contains(&notify_msg.queue)
+        exact.contains(&queue_name)
             || wildcards
                 .iter()
-                .any(|prefix| notify_msg.queue.starts_with(prefix))
+                .any(|prefix| queue_name.starts_with(prefix))
     }
 
     /// Drain pending notify messages from the channel, return count drained


### PR DESCRIPTION
## Summary

- New `notify_throttle_interval` config (default 1s, `Duration::ZERO` disables): per-queue minimum interval between producer NOTIFYs.
- Centralize producer NOTIFY eligibility in `notify::should_send_notify`, combining backend check + `use_listen_notify` flag + per-queue throttle. Five producer call sites (`perform_later`, `perform_all_later`, dispatcher scheduled→ready promotion, scheduler cron enqueue, control-plane recurring trigger) all route through it.
- Shrink NOTIFY payload from `{"queue":"...","event":"..."}` JSON to the bare queue name. Worker `should_handle_notify` accepts both shapes for mid-upgrade compatibility (legacy JSON detected by leading `{`).

## Why

A burst of N `perform_later` calls on the same queue used to emit N independent NOTIFYs. On Aurora that's N cross-AZ replication log entries per burst — expensive at high enqueue rates. This branch coalesces those into one NOTIFY per throttle window per queue. Workers catch up via polling / IDLE fallback when a NOTIFY is dropped, so correctness is preserved.

Inspired by the same pattern in `douane_nl`'s Solid Queue extension, but the Rust implementation uses `std::sync::LazyLock<Mutex<HashMap<String, Instant>>>` for a ~30ns hot path (no new dependencies).

The branch also incidentally fixes a producer-side bug: `use_listen_notify = false` was only honored on the worker; producers kept emitting NOTIFYs. All five producer sites now honor the flag via `should_send_notify`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets` clean
- [x] `cargo check --all-targets` clean
- [x] `pytest tests/test_enqueue.py tests/test_execution.py` — 14/14 pass
- [x] Full `pytest --ignore=tests/step_defs` — 99 pass; the 2 `test_recurring.py` failures are pre-existing flakes on master (SQLite disk I/O on macOS), unrelated to this branch
- [ ] Manual: Aurora producer benchmark to confirm NOTIFY rate drop in a high-enqueue loop