### PR TITLE
feat: QUEBEC_FORCE_OVERRIDE_QUEUE for multi-branch dev isolation

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -613,7 +613,8 @@ impl AppContext {
             notify_throttle_interval: Duration::from_secs(1),
             force_override_queue: std::env::var("QUEBEC_FORCE_OVERRIDE_QUEUE")
                 .ok()
-                .filter(|s| !s.trim().is_empty()),
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty()),
             process_heartbeat_interval: Duration::from_secs(60),
             process_alive_threshold: Duration::from_secs(300),
             shutdown_timeout: Duration::from_secs(5),

--- a/src/context.rs
+++ b/src/context.rs
@@ -273,6 +273,25 @@ impl DiscardStrategy {
     }
 }
 
+/// Replace characters that would break downstream consumers if they ended up
+/// inside a queue name. Primary motivation is the control-plane router which
+/// uses queue_name as an `:name` path segment (anything with `/` would 404),
+/// but space / `?` / `#` / `%` / control chars are also URL-hostile and worth
+/// neutralising. Returns the cleaned string and a flag indicating whether any
+/// substitution happened so callers can warn the operator once.
+pub(crate) fn sanitize_queue_name(raw: &str) -> (String, bool) {
+    let cleaned: String = raw
+        .chars()
+        .map(|c| match c {
+            '/' | '\\' | '?' | '#' | '%' => '-',
+            c if c.is_whitespace() || c.is_control() => '-',
+            c => c,
+        })
+        .collect();
+    let changed = cleaned != raw;
+    (cleaned, changed)
+}
+
 #[derive(Debug)]
 pub struct AppContext {
     pub cwd: std::path::PathBuf,
@@ -556,7 +575,15 @@ impl AppContext {
                         ctx.force_override_queue = if trimmed.is_empty() {
                             None
                         } else {
-                            Some(trimmed.to_string())
+                            let (cleaned, changed) = sanitize_queue_name(trimmed);
+                            if changed {
+                                warn!(
+                                    "force_override_queue='{}' sanitized to '{}' \
+                                     (URL-hostile characters replaced with '-')",
+                                    trimmed, cleaned
+                                );
+                            }
+                            Some(cleaned)
                         };
                     }
                     Err(_) => warn!(
@@ -614,7 +641,18 @@ impl AppContext {
             force_override_queue: std::env::var("QUEBEC_FORCE_OVERRIDE_QUEUE")
                 .ok()
                 .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty()),
+                .filter(|s| !s.is_empty())
+                .map(|raw| {
+                    let (cleaned, changed) = sanitize_queue_name(&raw);
+                    if changed {
+                        warn!(
+                            "QUEBEC_FORCE_OVERRIDE_QUEUE='{}' sanitized to '{}' \
+                             (URL-hostile characters replaced with '-')",
+                            raw, cleaned
+                        );
+                    }
+                    cleaned
+                }),
             process_heartbeat_interval: Duration::from_secs(60),
             process_alive_threshold: Duration::from_secs(300),
             shutdown_timeout: Duration::from_secs(5),

--- a/src/context.rs
+++ b/src/context.rs
@@ -291,6 +291,15 @@ pub struct AppContext {
     /// disable throttling. Mitigates NOTIFY storms on Aurora-style clusters
     /// where every NOTIFY incurs cross-AZ replication cost.
     pub notify_throttle_interval: Duration,
+    /// When set, every enqueue path rewrites `queue_name` to this value,
+    /// ignoring whatever the class / call site / scheduler specified. Use
+    /// for multi-branch development against a shared database: each branch
+    /// runs with its own `QUEBEC_FORCE_OVERRIDE_QUEUE=branch_x` and only
+    /// consumes that queue, so jobs enqueued by one branch are never picked
+    /// up by another. Production deployments should leave this unset — the
+    /// silent rewrite is intentional for the dev use case but surprising
+    /// elsewhere.
+    pub force_override_queue: Option<String>,
     pub process_heartbeat_interval: Duration,
     pub process_alive_threshold: Duration,
     pub shutdown_timeout: Duration,
@@ -536,6 +545,26 @@ impl AppContext {
             if let Some(v) = get_u64("worker_threads") {
                 ctx.worker_threads = v;
             }
+            // force_override_queue: kwargs win over the env var the Default
+            // already read. Empty / whitespace-only strings clear the override
+            // so callers can explicitly opt out from Python even when
+            // QUEBEC_FORCE_OVERRIDE_QUEUE is set in the environment.
+            if let Some(val) = options.get("force_override_queue") {
+                match val.extract::<String>(py) {
+                    Ok(q) => {
+                        let trimmed = q.trim();
+                        ctx.force_override_queue = if trimmed.is_empty() {
+                            None
+                        } else {
+                            Some(trimmed.to_string())
+                        };
+                    }
+                    Err(_) => warn!(
+                        "Config 'force_override_queue': expected String, got {:?}",
+                        val.bind(py).get_type()
+                    ),
+                }
+            }
             // table_name_prefix: only apply if non-empty
             if let Some(val) = options.get("table_name_prefix") {
                 match val.extract::<String>(py) {
@@ -582,6 +611,9 @@ impl AppContext {
             use_skip_locked: true,
             use_listen_notify: true,
             notify_throttle_interval: Duration::from_secs(1),
+            force_override_queue: std::env::var("QUEBEC_FORCE_OVERRIDE_QUEUE")
+                .ok()
+                .filter(|s| !s.trim().is_empty()),
             process_heartbeat_interval: Duration::from_secs(60),
             process_alive_threshold: Duration::from_secs(300),
             shutdown_timeout: Duration::from_secs(5),
@@ -699,6 +731,7 @@ impl AppContext {
             supervisor_pid: AtomicI32::new(0),
             use_listen_notify: self.use_listen_notify,
             notify_throttle_interval: self.notify_throttle_interval,
+            force_override_queue: self.force_override_queue.clone(),
         }
     }
 

--- a/src/control_plane/templates/base.html
+++ b/src/control_plane/templates/base.html
@@ -595,7 +595,18 @@
 </head>
 <body class="bg-white text-black min-h-screen flex flex-col">
   <div class="max-w-screen-2xl mx-auto p-4 md:p-6 w-full flex-grow flex flex-col">
-    <h1 class="text-3xl font-bold mb-6">Control Plane</h1>
+    <div class="flex items-center gap-3 mb-6">
+      <h1 class="text-3xl font-bold">Control Plane</h1>
+      {% if force_override_queue %}
+        <span title="QUEBEC_FORCE_OVERRIDE_QUEUE is active — every enqueue is rewritten to this queue, ignoring class queue config and any `.set(queue=...)` call. Intended for multi-branch dev isolation; do not leave this set in production."
+              class="inline-flex items-center gap-1.5 rounded-md border border-amber-300 bg-amber-50 px-2.5 py-1 text-xs font-medium text-amber-900">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path fill-rule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 0 1 .75.75v4.5a.75.75 0 0 1-1.5 0v-4.5A.75.75 0 0 1 10 5zm0 9a1 1 0 1 0 0-2 1 1 0 0 0 0 2z" clip-rule="evenodd"/>
+          </svg>
+          Forced queue: <span class="font-mono">{{ force_override_queue }}</span>
+        </span>
+      {% endif %}
+    </div>
 
     <div data-controller="nav" data-nav-active-class-value="border-b-2 border-black" class="flex flex-col flex-grow">
       <turbo-frame id="nav-frame">

--- a/src/control_plane/utils.rs
+++ b/src/control_plane/utils.rs
@@ -331,6 +331,10 @@ impl ControlPlane {
         context.insert("db_info", &db_info);
         context.insert("version", env!("CARGO_PKG_VERSION"));
         context.insert("base_path", &self.base_path);
+        // Surface the QUEBEC_FORCE_OVERRIDE_QUEUE setting so the layout can
+        // render a badge — operators on a shared dev DB need to see at a
+        // glance which queue this process is pinned to.
+        context.insert("force_override_queue", &self.ctx.force_override_queue);
 
         // Add navigation stats
         if let Err(e) = self.populate_nav_stats(context).await {

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -176,6 +176,10 @@ where
 
     // Step 1: Create the job first
     // Queue/priority precedence: YAML entry > class attribute > default.
+    // The original queue name is what we serialize into the `arguments`
+    // payload (audit trail); `routed_queue_name` below applies
+    // QUEBEC_FORCE_OVERRIDE_QUEUE for the persisted column and NOTIFY,
+    // matching the single/bulk enqueue paths.
     let defaults = ctx.get_runnable_defaults(&entry.class);
     let queue_name = entry
         .queue
@@ -232,6 +236,12 @@ where
     #[cfg(not(feature = "python"))]
     let concurrency_constraint: Option<crate::context::ConcurrencyConstraint> = None;
 
+    // QUEBEC_FORCE_OVERRIDE_QUEUE — applied after the `arguments` JSON was
+    // built so the payload keeps the original queue_name (audit trail) while
+    // the DB column / NOTIFY / enqueue hooks see the overridden value. Matches
+    // single/bulk; hooks must observe the value that will actually be routed.
+    let routed_queue_name = ctx.force_override_queue.as_deref().unwrap_or(queue_name);
+
     // Call enqueue hooks if overridden (before/around/after)
     #[cfg(feature = "python")]
     let hooks = ctx.get_hook_flags(&entry.class);
@@ -257,7 +267,7 @@ where
                         .map_err(|e| DbErr::Custom(format!("Failed to create instance: {e}")))?;
                     if let Ok(cell) = instance.cast::<crate::types::ActiveJob>() {
                         let mut inner = cell.borrow_mut();
-                        inner.queue_name = queue_name.to_string();
+                        inner.queue_name = routed_queue_name.to_string();
                         inner.arguments = params.to_string();
                         inner.active_job_id = task_key.clone();
                         inner.priority = priority;
@@ -325,7 +335,7 @@ where
             let job = query_builder::jobs::insert_returning(
                 db,
                 &ctx.table_config,
-                queue_name,
+                routed_queue_name,
                 &entry.class,
                 Some(params.to_string()).as_deref(),
                 priority,

--- a/src/types.rs
+++ b/src/types.rs
@@ -816,6 +816,15 @@ impl PyQuebec {
 
         // All parameters have been processed in AppContext.new
         let ctx = Arc::new(_ctx);
+        if let Some(override_q) = ctx.force_override_queue.as_deref() {
+            warn!(
+                "QUEBEC_FORCE_OVERRIDE_QUEUE is active: every enqueue will be \
+                 rewritten to queue '{}', ignoring class queue config and any \
+                 `.set(queue=...)` call. Intended for dev isolation; do not \
+                 leave this set in production.",
+                override_q
+            );
+        }
         let quebec = Arc::new(Quebec::new(ctx.clone()));
         let worker = Arc::new(Worker::new(ctx.clone()));
         let dispatcher = Arc::new(Dispatcher::new(ctx.clone()));
@@ -1779,11 +1788,11 @@ impl PyQuebec {
             }
         }
 
-        // QUEBEC_FORCE_OVERRIDE_QUEUE — last word, wins over class config and
-        // JobBuilder.set(queue=...). Applied after every other queue-resolution
-        // step so the Python-visible `ActiveJob.queue_name` stays consistent
-        // with the value persisted to the DB. The inner `arguments` JSON keeps
-        // the original queue_name as an audit trail.
+        // QUEBEC_FORCE_OVERRIDE_QUEUE — last word, wins over class queue
+        // config and any `.set(queue=...)` call. Applied after every other
+        // queue-resolution step so the Python-visible `ActiveJob.queue_name`
+        // stays consistent with the value persisted to the DB. The inner
+        // `arguments` JSON keeps the original queue_name as an audit trail.
         if let Some(force_q) = self.worker.ctx.force_override_queue.as_deref() {
             obj.queue_name = force_q.to_string();
             debug!("Job queue forced to '{}' by override", obj.queue_name);

--- a/src/types.rs
+++ b/src/types.rs
@@ -1779,6 +1779,16 @@ impl PyQuebec {
             }
         }
 
+        // QUEBEC_FORCE_OVERRIDE_QUEUE — last word, wins over class config and
+        // JobBuilder.set(queue=...). Applied after every other queue-resolution
+        // step so the Python-visible `ActiveJob.queue_name` stays consistent
+        // with the value persisted to the DB. The inner `arguments` JSON keeps
+        // the original queue_name as an audit trail.
+        if let Some(force_q) = self.worker.ctx.force_override_queue.as_deref() {
+            obj.queue_name = force_q.to_string();
+            debug!("Job queue forced to '{}' by override", obj.queue_name);
+        }
+
         // Get hook flags (lightweight read, no GIL/clone)
         let hooks = self.worker.ctx.get_hook_flags(&class_name.to_string());
         let any_enqueue_hook = hooks.before_enqueue || hooks.around_enqueue || hooks.after_enqueue;
@@ -2031,6 +2041,19 @@ impl PyQuebec {
             // Note: perform_all_later does NOT run enqueue callbacks, matching
             // ActiveJob's documented behavior: "Push many jobs onto the queue at
             // once without running enqueue callbacks."
+
+            // QUEBEC_FORCE_OVERRIDE_QUEUE — last word, wins over class config
+            // and per-descriptor options. Applied here (after `arguments`
+            // serialization) so the persisted queue_name column and the
+            // ActiveJob returned to Python use the override, while the inner
+            // `arguments` JSON keeps the original queue_name as an audit
+            // trail — matching the single-enqueue path's behaviour.
+            let queue_name = self
+                .worker
+                .ctx
+                .force_override_queue
+                .clone()
+                .unwrap_or(queue_name);
 
             prepared.push(PreparedJob {
                 class_name,


### PR DESCRIPTION
## Summary

- Add `QUEBEC_FORCE_OVERRIDE_QUEUE` env var that pins **every** enqueue — class `queue_as`, `.set(queue=...)`, recurring schedule entries, bulk `perform_all_later` — to a single queue. Intended for the typical dev case where multiple branches share one database and you want each branch's worker to only see its own jobs.
- Override is applied at every producer entry point (`perform_later`, `perform_all_later`, `scheduler::enqueue_job`) so the Python-visible `ActiveJob.queue_name`, the DB row's `queue_name`, the NOTIFY payload, and any enqueue hooks all see the same routed value. The inner `arguments` JSON keeps the **original** `queue_name` as an audit trail.
- URL-hostile chars in the override value (`/`, `\`, `?`, `#`, `%`, whitespace, control chars) are sanitized — branch names like `feat/foo` are safe to use directly.
- Two visibility surfaces so the override is never silently active: a WARN log at `Quebec` init, and an amber badge in the control plane header (`Forced queue: <name>`) with a tooltip explaining the behavior.

## Test plan

- [ ] `QUEBEC_FORCE_OVERRIDE_QUEUE=branch-a` + enqueue a `FakeJob` with `queue_as="default"` → DB row `queue_name = "branch-a"`, returned `ActiveJob.queue_name = "branch-a"`
- [ ] `FakeJob.set(queue="high").perform_later(...)` with override active → still routed to override queue
- [ ] `perform_all_later` (bulk) → every row routed to override queue, `arguments` JSON retains each job's original `queue_name`
- [ ] Recurring task with `queue: low` in `recurring.yml` → enqueued to override queue, enqueue hooks see routed name
- [ ] Set override to `feat/branch-1` → sanitized to `feat-branch-1` (or similar safe value)
- [ ] Visit control plane → amber "Forced queue: …" badge visible in header with tooltip
- [ ] Check startup logs for the WARN line
- [ ] Unset env var → no badge, no warn, normal queue routing