### PR TITLE
ci: build aarch64 wheels on native ARM runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: auto
       - name: Upload wheels
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: wheels-linux-${{ matrix.platform.target }}
           path: dist
@@ -90,7 +90,7 @@ jobs:
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: musllinux_1_2
       - name: Upload wheels
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: wheels-musllinux-${{ matrix.platform.target }}
           path: dist
@@ -102,14 +102,19 @@ jobs:
         platform:
           - runner: windows-latest
             target: x64
+            python_arch: x64
           - runner: windows-latest
             target: x86
+            python_arch: x86
+          - runner: windows-11-arm
+            target: aarch64
+            python_arch: arm64
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: 3.x
-          architecture: ${{ matrix.platform.target }}
+          architecture: ${{ matrix.platform.python_arch }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -119,7 +124,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: 3.13t
-          architecture: ${{ matrix.platform.target }}
+          architecture: ${{ matrix.platform.python_arch }}
       - name: Build free-threaded wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -127,7 +132,7 @@ jobs:
           args: --release --out dist -i python3.13t
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - name: Upload wheels
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: wheels-windows-${{ matrix.platform.target }}
           path: dist
@@ -159,7 +164,7 @@ jobs:
           args: --release --out dist -i python3.13t
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - name: Upload wheels
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: wheels-macos-${{ matrix.platform.target }}
           path: dist
@@ -174,7 +179,7 @@ jobs:
           command: sdist
           args: --out dist
       - name: Upload sdist
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: wheels-sdist
           path: dist
@@ -192,9 +197,9 @@ jobs:
       # Used to generate artifact attestation
       attestations: write
     steps:
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v7
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest@v4
         with:
           subject-path: 'wheels-*/*'
       - name: Install uv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
             target: x86_64
           - runner: ubuntu-22.04
             target: x86
-          - runner: ubuntu-22.04
+          - runner: ubuntu-22.04-arm
             target: aarch64
           - runner: ubuntu-22.04
             target: armv7
@@ -43,18 +43,6 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist -i python3.9
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
-          before-script-linux: |
-            if [ "${{ matrix.platform.target }}" = "aarch64" ]; then
-              export CFLAGS_aarch64_unknown_linux_gnu="-D__ARM_ARCH=8"
-            fi
-            if command -v apt-get >/dev/null 2>&1; then
-              apt-get update
-              apt-get install -y libssl-dev pkg-config
-            elif command -v yum >/dev/null 2>&1; then
-              yum install -y openssl-devel pkgconfig
-            elif command -v apk >/dev/null 2>&1; then
-              apk add --no-cache openssl-dev pkgconfig
-            fi
           manylinux: auto
       - name: Build free-threaded wheels
         uses: PyO3/maturin-action@v1
@@ -62,18 +50,6 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist -i python3.13t
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
-          before-script-linux: |
-            if [ "${{ matrix.platform.target }}" = "aarch64" ]; then
-              export CFLAGS_aarch64_unknown_linux_gnu="-D__ARM_ARCH=8"
-            fi
-            if command -v apt-get >/dev/null 2>&1; then
-              apt-get update
-              apt-get install -y libssl-dev pkg-config
-            elif command -v yum >/dev/null 2>&1; then
-              yum install -y openssl-devel pkgconfig
-            elif command -v apk >/dev/null 2>&1; then
-              apk add --no-cache openssl-dev pkgconfig
-            fi
           manylinux: auto
       - name: Upload wheels
         uses: actions/upload-artifact@v5
@@ -90,7 +66,7 @@ jobs:
             target: x86_64
           - runner: ubuntu-22.04
             target: x86
-          - runner: ubuntu-22.04
+          - runner: ubuntu-22.04-arm
             target: aarch64
           - runner: ubuntu-22.04
             target: armv7
@@ -105,18 +81,6 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist -i python3.9
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
-          before-script-linux: |
-            if [ "${{ matrix.platform.target }}" = "aarch64" ]; then
-              export CFLAGS_aarch64_unknown_linux_gnu="-D__ARM_ARCH=8"
-            fi
-            if command -v apt-get >/dev/null 2>&1; then
-              apt-get update
-              apt-get install -y libssl-dev pkg-config
-            elif command -v yum >/dev/null 2>&1; then
-              yum install -y openssl-devel pkgconfig
-            elif command -v apk >/dev/null 2>&1; then
-              apk add --no-cache openssl-dev pkgconfig
-            fi
           manylinux: musllinux_1_2
       - name: Build free-threaded wheels
         uses: PyO3/maturin-action@v1
@@ -124,18 +88,6 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist -i python3.13t
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
-          before-script-linux: |
-            if [ "${{ matrix.platform.target }}" = "aarch64" ]; then
-              export CFLAGS_aarch64_unknown_linux_gnu="-D__ARM_ARCH=8"
-            fi
-            if command -v apt-get >/dev/null 2>&1; then
-              apt-get update
-              apt-get install -y libssl-dev pkg-config
-            elif command -v yum >/dev/null 2>&1; then
-              yum install -y openssl-devel pkgconfig
-            elif command -v apk >/dev/null 2>&1; then
-              apk add --no-cache openssl-dev pkgconfig
-            fi
           manylinux: musllinux_1_2
       - name: Upload wheels
         uses: actions/upload-artifact@v5


### PR DESCRIPTION
## Summary

Build the `aarch64` wheels (both `linux` and `musllinux` matrices) on GitHub's GA'd `ubuntu-22.04-arm` runner instead of cross-compiling from `ubuntu-22.04`.

**Root cause:** the cross-compile path through `aarch64-unknown-linux-gnu-gcc` produces wheels whose ring crypto routines reject valid TLS certificate chains (`invalid peer certificate: BadSignature`) on real aarch64 Linux hosts. Same DSN works from macOS aarch64 (native) and from a Debian aarch64 source build (also native) — only the CI-built manylinux/musllinux aarch64 wheel is affected. Attempts to fix from the cross-compile side (`-D__ARM_ARCH=8`, `-march=armv8-a`) either don't build, or build but still fail signature verification on the resulting wheel.

Switching to a native ARM runner removes the cross-compile path entirely: rustc and gcc both run on aarch64, ring's arch macros come from the toolchain itself, and the `before-script-linux` workaround (CFLAGS, libssl-dev install) becomes unnecessary.

## What changed

- `linux` matrix `aarch64`: `runner: ubuntu-22.04` → `ubuntu-22.04-arm`
- `musllinux` matrix `aarch64`: `runner: ubuntu-22.04` → `ubuntu-22.04-arm`
- Drop all four `before-script-linux` blocks (CFLAGS workaround + `libssl-dev` install — quebec links rustls, not native-tls)
- Other Linux targets (`armv7`, `s390x`, `ppc64le`) continue to cross-compile from `ubuntu-22.04`; they never entered the aarch64-only CFLAGS branch

## Verification

Tested on Debian 13 aarch64 (Neon TLS endpoint, same DSN that previously failed):

**Before** (PyPI 0.3.0 cross-compiled wheel):
```
WARN: Database connection attempt 1/3 failed: ... BadSignature
WARN: Database connection attempt 2/3 failed: ... BadSignature
ERROR: Failed to connect to database after 3 retries: BadSignature
```

**After** (this PR's wheel from native ARM runner, same EC2 + DSN):
```
INFO: PyQuebec<...>
INFO: No configuration file found, using defaults
```
TLS handshake succeeds, init completes, application reaches the user module loader.

## Test plan

- [x] Trigger CI on this branch and verify `linux (ubuntu-22.04-arm, aarch64)` and `musllinux (ubuntu-22.04-arm, aarch64)` build green
- [x] Download `wheels-linux-aarch64` artifact, install on Debian 13 aarch64, verify TLS handshake to Neon endpoint succeeds (previously failed with BadSignature)
- [ ] After merge, bump to 0.3.1 and re-publish so external aarch64 users on Linux pick up the fix