### PR TITLE
feat(control-plane): time range + error filters for bulk retry/discard

### DIFF
--- a/src/control_plane/handlers/failed_jobs.rs
+++ b/src/control_plane/handlers/failed_jobs.rs
@@ -88,12 +88,17 @@ impl ControlPlane {
         // Get total count of failed jobs for pagination calculation
         let start = Instant::now();
 
-        // Execute count query using query_builder (with same filters)
+        // Execute count query using query_builder (with same filters).
+        // The since/until/error_like filters are only used by the bulk
+        // retry/discard endpoints — the list view ignores them.
         let total_count: u64 = query_builder::failed_executions::count_all(
             db,
             table_config,
             pagination.class_name.as_deref(),
             pagination.queue_name.as_deref(),
+            None,
+            None,
+            None,
         )
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
@@ -245,6 +250,11 @@ impl ControlPlane {
         Query(pagination): Query<Pagination>,
         headers: HeaderMap,
     ) -> Response {
+        let (since, until) = match parse_time_bounds(&pagination) {
+            Ok(v) => v,
+            Err(msg) => return (StatusCode::BAD_REQUEST, msg).into_response(),
+        };
+
         let db = match state.ctx.get_db().await {
             Ok(db) => db,
             Err(_) => return Self::error_response(),
@@ -254,6 +264,7 @@ impl ControlPlane {
         let redirect = Self::referer_without_page_or(&headers, "/failed-jobs");
         let class_name = pagination.class_name.clone();
         let queue_name = pagination.queue_name.clone();
+        let error_like = pagination.error_like.clone();
 
         match db
             .transaction::<_, u64, DbErr>(|txn| {
@@ -264,6 +275,9 @@ impl ControlPlane {
                             &table_config,
                             class_name.as_deref(),
                             queue_name.as_deref(),
+                            since,
+                            until,
+                            error_like.as_deref(),
                         )
                         .await?;
                     Ok(count)
@@ -288,6 +302,11 @@ impl ControlPlane {
         Query(pagination): Query<Pagination>,
         headers: HeaderMap,
     ) -> Response {
+        let (since, until) = match parse_time_bounds(&pagination) {
+            Ok(v) => v,
+            Err(msg) => return (StatusCode::BAD_REQUEST, msg).into_response(),
+        };
+
         let db = match state.ctx.get_db().await {
             Ok(db) => db,
             Err(_) => return Self::error_response(),
@@ -297,6 +316,7 @@ impl ControlPlane {
         let redirect = Self::referer_without_page_or(&headers, "/failed-jobs");
         let class_name = pagination.class_name.clone();
         let queue_name = pagination.queue_name.clone();
+        let error_like = pagination.error_like.clone();
 
         match db
             .transaction::<_, u64, DbErr>(|txn| {
@@ -307,6 +327,9 @@ impl ControlPlane {
                             &table_config,
                             class_name.as_deref(),
                             queue_name.as_deref(),
+                            since,
+                            until,
+                            error_like.as_deref(),
                         )
                         .await?;
                     Ok(count)
@@ -324,4 +347,36 @@ impl ControlPlane {
             }
         }
     }
+}
+
+/// Parse the optional `since` / `until` query strings into `NaiveDateTime`.
+/// Accepted formats: RFC 3339 with timezone (`2026-05-17T12:00:00Z`),
+/// naive ISO (`2026-05-17T12:00:00`), or `YYYY-MM-DD HH:MM:SS`. RFC 3339
+/// values are normalized to UTC before being stripped of the offset, matching
+/// how `created_at` is stored in the DB.
+fn parse_time_bounds(
+    pagination: &Pagination,
+) -> Result<(Option<chrono::NaiveDateTime>, Option<chrono::NaiveDateTime>), String> {
+    let parse = |raw: &str| -> Result<chrono::NaiveDateTime, String> {
+        if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(raw) {
+            return Ok(dt.naive_utc());
+        }
+        chrono::NaiveDateTime::parse_from_str(raw, "%Y-%m-%dT%H:%M:%S")
+            .or_else(|_| chrono::NaiveDateTime::parse_from_str(raw, "%Y-%m-%d %H:%M:%S"))
+            .map_err(|e| format!("invalid timestamp '{raw}': {e}"))
+    };
+
+    let since = pagination
+        .since
+        .as_deref()
+        .map(parse)
+        .transpose()
+        .map_err(|e| format!("since: {e}"))?;
+    let until = pagination
+        .until
+        .as_deref()
+        .map(parse)
+        .transpose()
+        .map_err(|e| format!("until: {e}"))?;
+    Ok((since, until))
 }

--- a/src/control_plane/handlers/health.rs
+++ b/src/control_plane/handlers/health.rs
@@ -101,9 +101,17 @@ impl ControlPlane {
         let blocked = query_builder::blocked_executions::count_all(db, table_config, None, None)
             .await
             .map_err(map_err)?;
-        let failed = query_builder::failed_executions::count_all(db, table_config, None, None)
-            .await
-            .map_err(map_err)?;
+        let failed = query_builder::failed_executions::count_all(
+            db,
+            table_config,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .map_err(map_err)?;
 
         // Status determination
         // "unavailable" only when workers exist but all are dead, or no processes at all

--- a/src/control_plane/models.rs
+++ b/src/control_plane/models.rs
@@ -27,6 +27,17 @@ pub struct Pagination {
     pub class_name: Option<String>,
     pub queue_name: Option<String>,
     pub status: Option<String>,
+    /// Lower bound on `failed_executions.created_at`. Accepted as a
+    /// chrono-parseable ISO 8601 / RFC 3339-ish string; handlers reject
+    /// unparseable input with 400. Currently only honoured by the
+    /// /failed-jobs/all/retry and /failed-jobs/all/delete endpoints.
+    pub since: Option<String>,
+    /// Upper bound on `failed_executions.created_at`. See `since`.
+    pub until: Option<String>,
+    /// SQL `LIKE` pattern matched against the stored error message
+    /// (e.g. `Process+crashed%`). Currently only honoured by the
+    /// /failed-jobs/all/retry and /failed-jobs/all/delete endpoints.
+    pub error_like: Option<String>,
 }
 
 fn default_page() -> u64 {

--- a/src/control_plane/utils.rs
+++ b/src/control_plane/utils.rs
@@ -102,8 +102,16 @@ impl ControlPlane {
                 as i64;
 
         // Count failed jobs
-        let failed_count =
-            query_builder::failed_executions::count_all(db, table_config, None, None).await? as i64;
+        let failed_count = query_builder::failed_executions::count_all(
+            db,
+            table_config,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await? as i64;
 
         // Count blocked jobs
         let blocked_count =

--- a/src/entities/quebec_failed_executions.rs
+++ b/src/entities/quebec_failed_executions.rs
@@ -16,13 +16,18 @@ pub trait Retryable {
     ) -> Result<(), DbErr>;
 
     /// Retry all failed jobs by moving them from failed_executions to ready_executions.
-    /// When `class_name` or `queue_name` is provided, only matching jobs are retried.
+    /// Optional filters: `class_name`, `queue_name`, `since`/`until` (failed_executions.created_at
+    /// range), and `error_like` (SQL LIKE pattern against the stored error message).
+    #[allow(clippy::too_many_arguments)]
     async fn retry_all(
         &self,
         txn: &DatabaseTransaction,
         table_config: &TableConfig,
         class_name: Option<&str>,
         queue_name: Option<&str>,
+        since: Option<chrono::NaiveDateTime>,
+        until: Option<chrono::NaiveDateTime>,
+        error_like: Option<&str>,
     ) -> Result<u64, DbErr>;
 }
 
@@ -36,13 +41,18 @@ pub trait Discardable {
     ) -> Result<(), DbErr>;
 
     /// Discard all failed jobs by removing them from failed_executions and marking the jobs as finished.
-    /// When `class_name` or `queue_name` is provided, only matching jobs are discarded.
+    /// Optional filters: `class_name`, `queue_name`, `since`/`until` (failed_executions.created_at
+    /// range), and `error_like` (SQL LIKE pattern against the stored error message).
+    #[allow(clippy::too_many_arguments)]
     async fn discard_all(
         &self,
         txn: &DatabaseTransaction,
         table_config: &TableConfig,
         class_name: Option<&str>,
         queue_name: Option<&str>,
+        since: Option<chrono::NaiveDateTime>,
+        until: Option<chrono::NaiveDateTime>,
+        error_like: Option<&str>,
     ) -> Result<u64, DbErr>;
 }
 
@@ -119,11 +129,21 @@ impl Retryable for Model {
         table_config: &TableConfig,
         class_name: Option<&str>,
         queue_name: Option<&str>,
+        since: Option<chrono::NaiveDateTime>,
+        until: Option<chrono::NaiveDateTime>,
+        error_like: Option<&str>,
     ) -> Result<u64, DbErr> {
         // 1. Get all failed job records
-        let failed_executions =
-            query_builder::failed_executions::find_all(txn, table_config, class_name, queue_name)
-                .await?;
+        let failed_executions = query_builder::failed_executions::find_all(
+            txn,
+            table_config,
+            class_name,
+            queue_name,
+            since,
+            until,
+            error_like,
+        )
+        .await?;
 
         if failed_executions.is_empty() {
             return Ok(0);
@@ -192,11 +212,21 @@ impl Discardable for Model {
         table_config: &TableConfig,
         class_name: Option<&str>,
         queue_name: Option<&str>,
+        since: Option<chrono::NaiveDateTime>,
+        until: Option<chrono::NaiveDateTime>,
+        error_like: Option<&str>,
     ) -> Result<u64, DbErr> {
         // 1. Get all failed job records
-        let failed_executions =
-            query_builder::failed_executions::find_all(txn, table_config, class_name, queue_name)
-                .await?;
+        let failed_executions = query_builder::failed_executions::find_all(
+            txn,
+            table_config,
+            class_name,
+            queue_name,
+            since,
+            until,
+            error_like,
+        )
+        .await?;
 
         if failed_executions.is_empty() {
             return Ok(0);
@@ -240,11 +270,21 @@ impl Retryable for Entity {
         table_config: &TableConfig,
         class_name: Option<&str>,
         queue_name: Option<&str>,
+        since: Option<chrono::NaiveDateTime>,
+        until: Option<chrono::NaiveDateTime>,
+        error_like: Option<&str>,
     ) -> Result<u64, DbErr> {
         // 1. Get all failed job records
-        let failed_executions =
-            query_builder::failed_executions::find_all(txn, table_config, class_name, queue_name)
-                .await?;
+        let failed_executions = query_builder::failed_executions::find_all(
+            txn,
+            table_config,
+            class_name,
+            queue_name,
+            since,
+            until,
+            error_like,
+        )
+        .await?;
 
         if failed_executions.is_empty() {
             return Ok(0);
@@ -298,11 +338,21 @@ impl Discardable for Entity {
         table_config: &TableConfig,
         class_name: Option<&str>,
         queue_name: Option<&str>,
+        since: Option<chrono::NaiveDateTime>,
+        until: Option<chrono::NaiveDateTime>,
+        error_like: Option<&str>,
     ) -> Result<u64, DbErr> {
         // 1. Get all failed job records
-        let failed_executions =
-            query_builder::failed_executions::find_all(txn, table_config, class_name, queue_name)
-                .await?;
+        let failed_executions = query_builder::failed_executions::find_all(
+            txn,
+            table_config,
+            class_name,
+            queue_name,
+            since,
+            until,
+            error_like,
+        )
+        .await?;
 
         if failed_executions.is_empty() {
             return Ok(0);

--- a/src/query_builder.rs
+++ b/src/query_builder.rs
@@ -2106,12 +2106,17 @@ pub mod failed_executions {
         }
     }
 
-    /// Find all failed executions, optionally filtered by class_name/queue_name
+    /// Find all failed executions, optionally filtered by class_name, queue_name,
+    /// creation time range (since/until), and error message pattern.
+    #[allow(clippy::too_many_arguments)]
     pub async fn find_all<C>(
         db: &C,
         table_config: &TableConfig,
         class_name: Option<&str>,
         queue_name: Option<&str>,
+        since: Option<chrono::NaiveDateTime>,
+        until: Option<chrono::NaiveDateTime>,
+        error_like: Option<&str>,
     ) -> Result<Vec<quebec_failed_executions::Model>, DbErr>
     where
         C: ConnectionTrait,
@@ -2132,7 +2137,8 @@ pub mod failed_executions {
         if need_join {
             query.inner_join(
                 jobs_table.clone(),
-                Expr::col((fe_table, col("job_id"))).equals((jobs_table.clone(), col("id"))),
+                Expr::col((fe_table.clone(), col("job_id")))
+                    .equals((jobs_table.clone(), col("id"))),
             );
             if let Some(cn) = class_name {
                 query.and_where(Expr::col((jobs_table.clone(), col("class_name"))).eq(cn));
@@ -2140,6 +2146,16 @@ pub mod failed_executions {
             if let Some(qn) = queue_name {
                 query.and_where(Expr::col((jobs_table, col("queue_name"))).eq(qn));
             }
+        }
+
+        if let Some(ts) = since {
+            query.and_where(Expr::col((fe_table.clone(), col("created_at"))).gte(ts));
+        }
+        if let Some(ts) = until {
+            query.and_where(Expr::col((fe_table.clone(), col("created_at"))).lte(ts));
+        }
+        if let Some(pat) = error_like {
+            query.and_where(Expr::col((fe_table, col("error"))).like(pat));
         }
 
         execute_select(db, query.to_owned()).await
@@ -2203,12 +2219,17 @@ pub mod failed_executions {
         execute_delete(db, query).await
     }
 
-    /// Count failed executions, optionally filtered by class_name/queue_name
+    /// Count failed executions, optionally filtered by class_name, queue_name,
+    /// creation time range (since/until), and error message pattern.
+    #[allow(clippy::too_many_arguments)]
     pub async fn count_all<C>(
         db: &C,
         table_config: &TableConfig,
         class_name: Option<&str>,
         queue_name: Option<&str>,
+        since: Option<chrono::NaiveDateTime>,
+        until: Option<chrono::NaiveDateTime>,
+        error_like: Option<&str>,
     ) -> Result<u64, DbErr>
     where
         C: ConnectionTrait,
@@ -2224,7 +2245,8 @@ pub mod failed_executions {
         if need_join {
             query.inner_join(
                 jobs_table.clone(),
-                Expr::col((fe_table, col("job_id"))).equals((jobs_table.clone(), col("id"))),
+                Expr::col((fe_table.clone(), col("job_id")))
+                    .equals((jobs_table.clone(), col("id"))),
             );
             if let Some(cn) = class_name {
                 query.and_where(Expr::col((jobs_table.clone(), col("class_name"))).eq(cn));
@@ -2232,6 +2254,16 @@ pub mod failed_executions {
             if let Some(qn) = queue_name {
                 query.and_where(Expr::col((jobs_table, col("queue_name"))).eq(qn));
             }
+        }
+
+        if let Some(ts) = since {
+            query.and_where(Expr::col((fe_table.clone(), col("created_at"))).gte(ts));
+        }
+        if let Some(ts) = until {
+            query.and_where(Expr::col((fe_table.clone(), col("created_at"))).lte(ts));
+        }
+        if let Some(pat) = error_like {
+            query.and_where(Expr::col((fe_table, col("error"))).like(pat));
         }
 
         let query = query.to_owned();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -40,7 +40,7 @@ mod schema {
             0
         );
         assert_eq!(
-            query_builder::failed_executions::count_all(&db, &tc, None, None)
+            query_builder::failed_executions::count_all(&db, &tc, None, None, None, None, None)
                 .await
                 .unwrap(),
             0
@@ -637,7 +637,7 @@ mod failed_executions {
         assert_eq!(found.error.as_deref(), Some("something broke"));
 
         assert_eq!(
-            query_builder::failed_executions::count_all(&db, &tc, None, None)
+            query_builder::failed_executions::count_all(&db, &tc, None, None, None, None, None)
                 .await
                 .unwrap(),
             1
@@ -647,7 +647,7 @@ mod failed_executions {
             .await
             .unwrap();
         assert_eq!(
-            query_builder::failed_executions::count_all(&db, &tc, None, None)
+            query_builder::failed_executions::count_all(&db, &tc, None, None, None, None, None)
                 .await
                 .unwrap(),
             0
@@ -1115,7 +1115,7 @@ mod lifecycle {
         // executions count is stored in arguments JSON
         assert_eq!(quebec::utils::get_executions(job.arguments.as_deref()), 1);
         assert_eq!(
-            query_builder::failed_executions::count_all(&db, &tc, None, None)
+            query_builder::failed_executions::count_all(&db, &tc, None, None, None, None, None)
                 .await
                 .unwrap(),
             0


### PR DESCRIPTION
## Summary

Extend `POST /failed-jobs/all/retry` and `POST /failed-jobs/all/delete` with three new optional query-string filters:

- `since` — lower bound on `failed_executions.created_at`
- `until` — upper bound on `failed_executions.created_at`
- `error_like` — SQL `LIKE` pattern matched against the stored error message (e.g. `Process+crashed%`)

These compose with the existing `class_name` and `queue_name` filters. Primary use case: after a worker restart, retry only the recent batch of failures attributable to the crash (`since=<restart-time>&error_like=Process+crashed%25`), without disturbing other queued or in-progress jobs.

## Example

```
# Retry everything that failed in the last hour with a Process-crashed error
POST /failed-jobs/all/retry?since=2026-05-17T12:00:00Z&error_like=Process+crashed%25

# Retry the time window when an upstream API was down, scoped to one class
POST /failed-jobs/all/retry?since=2026-05-17T10:00:00Z&until=2026-05-17T11:00:00Z&class_name=PaymentJob
```

Accepted timestamp formats: RFC 3339 (`2026-05-17T12:00:00Z`), naive ISO (`2026-05-17T12:00:00`), or `YYYY-MM-DD HH:MM:SS`. Unparseable input returns 400.

## Scope

- `query_builder::failed_executions::find_all` / `count_all` gain `since` / `until` / `error_like` parameters
- `Retryable::retry_all` and `Discardable::discard_all` trait methods (and their Model/Entity impls) forward the new filters
- `Pagination` struct picks up the three optional fields (no changes to `GET /failed-jobs` rendering — list view and `/health` count pass `None` and behave as before)
- Per-job `POST /failed-jobs/:id/retry` and `POST /failed-jobs/:id/delete` are untouched

## Test plan

- [x] `cargo check`, `cargo clippy --all-targets --all-features`, `cargo fmt --check` all clean
- [ ] Manually `curl -X POST '…/failed-jobs/all/retry?since=<ts>&error_like=Process+crashed%25'` against a DB with stale failed executions, verify only matching rows are moved to ready
- [ ] Verify 400 response when `since=not-a-date`
- [ ] Verify existing `?class_name=X&queue_name=Q` behavior unchanged when new filters are omitted