### PR TITLE
feat(control-plane): live per-queue counts in /stats turbo-stream

### DIFF
--- a/src/control_plane/handlers/queues.rs
+++ b/src/control_plane/handlers/queues.rs
@@ -13,7 +13,7 @@ use std::time::Instant;
 use tracing::{debug, error};
 
 use crate::control_plane::{
-    models::{Pagination, QueueInfo},
+    models::{queue_slug, Pagination, QueueInfo},
     ControlPlane,
 };
 use crate::query_builder;
@@ -42,39 +42,11 @@ impl ControlPlane {
             .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
         let table_config = &state.ctx.table_config;
-        let ready_table = Alias::new(&table_config.ready_executions);
 
         // Count only ready executions per queue (matching Solid Queue's Queue#size)
-        let query = SeaQuery::select()
-            .column(Alias::new("queue_name"))
-            .expr_as(
-                Expr::col(Alias::new("queue_name")).count(),
-                Alias::new("count"),
-            )
-            .from(ready_table)
-            .group_by_col(Alias::new("queue_name"))
-            .to_owned();
-
-        let (sql, values) = match db.get_database_backend() {
-            DbBackend::Postgres => query.build(PostgresQueryBuilder),
-            DbBackend::Sqlite => query.build(SqliteQueryBuilder),
-            DbBackend::MySql => query.build(MysqlQueryBuilder),
-        };
-
-        let stmt = Statement::from_sql_and_values(db.get_database_backend(), &sql, values);
-
-        // Get queue counts with unfinished jobs
-        let queue_counts_map: HashMap<String, i64> = db
-            .query_all(stmt)
+        let queue_counts_map = query_builder::ready_executions::count_by_queue(db, table_config)
             .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-            .into_iter()
-            .map(|row| {
-                let queue_name: String = row.try_get("", "queue_name").unwrap_or_default();
-                let count: i64 = row.try_get("", "count").unwrap_or_default();
-                (queue_name, count)
-            })
-            .collect();
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
         // Ensure all queues are included in results, even if they have no unfinished jobs
         let queue_counts: Vec<(String, i64)> = all_queue_names
@@ -102,13 +74,14 @@ impl ControlPlane {
         let queue_infos: Vec<QueueInfo> = queue_counts
             .into_iter()
             .map(|(name, count)| QueueInfo {
-                name: name.clone(),
-                jobs_count: count,
+                slug: queue_slug(&name),
                 status: if paused_queue_names.contains(&name) {
                     "paused".to_string()
                 } else {
                     "active".to_string()
                 },
+                name,
+                jobs_count: count,
             })
             .filter(|queue| {
                 // Apply status filter if provided

--- a/src/control_plane/models.rs
+++ b/src/control_plane/models.rs
@@ -10,21 +10,35 @@ pub struct QueueInfo {
     pub status: String,
 }
 
-/// Sanitize a queue name into an HTML-id-safe slug. Used to anchor
-/// per-queue turbo-stream targets (`queue-count-{slug}`, `queue-status-{slug}`).
-/// Collisions are theoretically possible if two queue names differ only in
-/// disallowed characters; current quebec callers use alphanumeric+underscore
-/// names so this is a non-issue in practice.
+/// Encode a queue name into an HTML-id-safe slug with **no collisions**.
+/// Used to anchor per-queue turbo-stream targets (`queue-count-{slug}`,
+/// `queue-status-{slug}`).
+///
+/// Standard URL percent-encoding semantics, byte-by-byte: `[A-Za-z0-9_-]`
+/// pass through unchanged, everything else becomes `%HH` (uppercase hex of
+/// the UTF-8 byte). Guarantees a one-to-one mapping — a naive "replace
+/// with `_`" strategy would collapse `a.b`, `a/b`, `a b` onto the same DOM
+/// element and silently freeze all but the first one's live counter.
+///
+/// `%` in an HTML `id` attribute is legal; turbo-stream `target=` looks the
+/// element up via `document.getElementById`, which doesn't need CSS-style
+/// escaping.
+///
+/// Examples:
+///   * `"auto"`           → `"auto"`
+///   * `"a.b"`            → `"a%2Eb"`
+///   * `"a/b"`            → `"a%2Fb"`
+///   * `"中"`             → `"%E4%B8%AD"`
 pub fn queue_slug(name: &str) -> String {
-    name.chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect()
+    let mut out = String::with_capacity(name.len());
+    for b in name.bytes() {
+        if b.is_ascii_alphanumeric() || b == b'-' || b == b'_' {
+            out.push(b as char);
+        } else {
+            out.push_str(&format!("%{:02X}", b));
+        }
+    }
+    out
 }
 
 #[derive(Debug, Serialize)]

--- a/src/control_plane/models.rs
+++ b/src/control_plane/models.rs
@@ -3,8 +3,28 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Serialize)]
 pub struct QueueInfo {
     pub name: String,
+    /// HTML-id-safe version of `name` used as the anchor for turbo-stream
+    /// updates. Non `[A-Za-z0-9_-]` characters are replaced with `_`.
+    pub slug: String,
     pub jobs_count: i64,
     pub status: String,
+}
+
+/// Sanitize a queue name into an HTML-id-safe slug. Used to anchor
+/// per-queue turbo-stream targets (`queue-count-{slug}`, `queue-status-{slug}`).
+/// Collisions are theoretically possible if two queue names differ only in
+/// disallowed characters; current quebec callers use alphanumeric+underscore
+/// names so this is a non-issue in practice.
+pub fn queue_slug(name: &str) -> String {
+    name.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
 }
 
 #[derive(Debug, Serialize)]

--- a/src/control_plane/templates/base.html
+++ b/src/control_plane/templates/base.html
@@ -529,14 +529,21 @@
             this.fetchSnapshot()
             this.startPolling()
           } else {
-            // SSE's first tick fires immediately on connect — no explicit
-            // snapshot needed, and skipping it avoids a render race where
-            // a stale fetch response could overwrite fresher SSE data.
+            // SSE's first tick fires immediately on connect — but proxies or
+            // a slow first DB roundtrip can still delay it. Pull a snapshot
+            // now and let SSE overwrite once it catches up.
+            this.fetchSnapshot()
             this.startSSE()
           }
         }
         document.addEventListener("visibilitychange", this._onVisibility)
-        if (!document.hidden) this.startSSE()
+        if (!document.hidden) {
+          // Eager snapshot on first paint: even though the page is SSR'd
+          // with current counts, the data may have drifted between server
+          // render and browser parse. SSE/polling will refresh again shortly.
+          this.fetchSnapshot()
+          this.startSSE()
+        }
       }
 
       async fetchSnapshot() {
@@ -564,6 +571,9 @@
           if (!received) {
             this.stopSSE()
             this._usePolling = true
+            // setInterval waits a full interval before its first callback,
+            // so fetch immediately to avoid a multi-second blank window.
+            this.fetchSnapshot()
             this.startPolling()
           }
         }
@@ -619,22 +629,22 @@
           </a>
 
           <a href="{{ base_path }}/failed-jobs" data-nav-target="navItem" data-action="click->nav#navigate" class="shrink-0 whitespace-nowrap px-4 h-8 font-medium text-gray-600 hover:text-black border-b-2 border-transparent hover:border-black">
-            Failed jobs <span id="failed-jobs-count" class="px-1 py-0.5 text-xs rounded-full bg-gray-200 text-gray-800">0</span>
+            Failed jobs <span id="failed-jobs-count" class="px-1 py-0.5 text-xs rounded-full bg-gray-200 text-gray-800">{{ nav_failed_jobs | default(value=0) }}</span>
           </a>
           <a href="{{ base_path }}/in-progress-jobs" data-nav-target="navItem" data-action="click->nav#navigate" class="shrink-0 whitespace-nowrap px-4 h-8 font-medium text-gray-600 hover:text-black border-b-2 border-transparent hover:border-black">
-            In Progress jobs <span id="in-progress-jobs-count" class="px-1 py-0.5 text-xs rounded-full bg-gray-200 text-gray-800">0</span>
+            In Progress jobs <span id="in-progress-jobs-count" class="px-1 py-0.5 text-xs rounded-full bg-gray-200 text-gray-800">{{ nav_in_progress_jobs | default(value=0) }}</span>
           </a>
           <a href="{{ base_path }}/blocked-jobs" data-nav-target="navItem" data-action="click->nav#navigate" class="shrink-0 whitespace-nowrap px-4 h-8 font-medium text-gray-600 hover:text-black border-b-2 border-transparent hover:border-black">
-            Blocked jobs <span id="blocked-jobs-count" class="px-1 py-0.5 text-xs rounded-full bg-gray-200 text-gray-800">0</span>
+            Blocked jobs <span id="blocked-jobs-count" class="px-1 py-0.5 text-xs rounded-full bg-gray-200 text-gray-800">{{ nav_blocked_jobs | default(value=0) }}</span>
           </a>
           <a href="{{ base_path }}/scheduled-jobs" data-nav-target="navItem" data-action="click->nav#navigate" class="shrink-0 whitespace-nowrap px-4 h-8 font-medium text-gray-600 hover:text-black border-b-2 border-transparent hover:border-black">
-            Scheduled jobs <span id="scheduled-jobs-count" class="px-1 py-0.5 text-xs rounded-full bg-gray-200 text-gray-800">0</span>
+            Scheduled jobs <span id="scheduled-jobs-count" class="px-1 py-0.5 text-xs rounded-full bg-gray-200 text-gray-800">{{ nav_scheduled_jobs | default(value=0) }}</span>
           </a>
           <a href="{{ base_path }}/recurring-jobs" data-nav-target="navItem" data-action="click->nav#navigate" class="shrink-0 whitespace-nowrap px-4 h-8 font-medium text-gray-600 hover:text-black border-b-2 border-transparent hover:border-black">
             Recurring jobs
           </a>
           <a href="{{ base_path }}/finished-jobs" data-nav-target="navItem" data-action="click->nav#navigate" class="shrink-0 whitespace-nowrap px-4 h-8 font-medium text-gray-600 hover:text-black border-b-2 border-transparent hover:border-black">
-            Finished jobs <span id="finished-jobs-count" class="px-1 py-0.5 text-xs rounded-full bg-gray-200 text-gray-800">0</span>
+            Finished jobs <span id="finished-jobs-count" class="px-1 py-0.5 text-xs rounded-full bg-gray-200 text-gray-800">{{ finished_jobs_count | default(value=0) }}</span>
           </a>
 
           <a href="{{ base_path }}/workers" data-nav-target="navItem" data-action="click->nav#navigate" class="shrink-0 whitespace-nowrap px-4 h-8 font-medium text-gray-600 hover:text-black border-b-2 border-transparent hover:border-black">

--- a/src/control_plane/templates/queues.html
+++ b/src/control_plane/templates/queues.html
@@ -63,10 +63,10 @@
         <td class="px-6 py-4 whitespace-nowrap">
           <a href="{{ base_path }}/queues/{{ queue.name }}" data-turbo-action="advance" class="text-sm font-medium text-gray-900 hover:underline">{{ queue.name }}</a>
         </td>
-        <td class="px-6 py-4 whitespace-nowrap">
+        <td class="px-6 py-4 whitespace-nowrap" id="queue-count-{{ queue.slug }}">
           <div class="text-sm text-gray-900">{{ queue.jobs_count }}</div>
         </td>
-        <td class="px-6 py-4 whitespace-nowrap">
+        <td class="px-6 py-4 whitespace-nowrap" id="queue-status-{{ queue.slug }}">
           <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full {% if queue.status == 'active' %}bg-green-100 text-green-800{% else %}bg-yellow-100 text-yellow-800{% endif %}">
             {{ queue.status | title }}
           </span>

--- a/src/control_plane/templates/stats.html
+++ b/src/control_plane/templates/stats.html
@@ -28,3 +28,22 @@
     <span class="px-1 py-0.5 text-xs rounded-full bg-gray-200 text-gray-800">{{ finished_jobs_count }}</span>
   </template>
 </turbo-stream>
+
+{# Per-queue live counters. Anchored to id="queue-count-{slug}" and
+   id="queue-status-{slug}" in queues.html. The queues page is the only one
+   that renders these anchors; on other pages the targets simply don't exist
+   and Turbo silently no-ops, so this loop is cheap to ship unconditionally. #}
+{% for q in queue_counts %}
+<turbo-stream action="update" target="queue-count-{{ q.slug }}">
+  <template>
+    <div class="text-sm text-gray-900">{{ q.jobs_count }}</div>
+  </template>
+</turbo-stream>
+<turbo-stream action="update" target="queue-status-{{ q.slug }}">
+  <template>
+    <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full {% if q.status == 'active' %}bg-green-100 text-green-800{% else %}bg-yellow-100 text-yellow-800{% endif %}">
+      {{ q.status | title }}
+    </span>
+  </template>
+</turbo-stream>
+{% endfor %}

--- a/src/control_plane/utils.rs
+++ b/src/control_plane/utils.rs
@@ -8,6 +8,7 @@ use tera::Context;
 use tracing::{debug, error, info};
 use url::Url;
 
+use crate::control_plane::models::{queue_slug, QueueInfo};
 use crate::query_builder;
 
 use super::{templates, ControlPlane};
@@ -130,6 +131,32 @@ impl ControlPlane {
         let finished_count =
             query_builder::jobs::count_finished(db, table_config, None, None).await? as i64;
         context.insert("finished_jobs_count", &finished_count);
+
+        // Per-queue ready-execution counts + paused-state snapshot, so the
+        // /stats turbo-stream can update each row of the queues table in sync
+        // with the top nav counters. Two extra queries (one GROUP BY on the
+        // ready table, one full table read of pauses) — both cheap because the
+        // working sets are small by design.
+        let queue_counts_map =
+            query_builder::ready_executions::count_by_queue(db, table_config).await?;
+        let paused_queue_names =
+            query_builder::pauses::find_all_queue_names(db, table_config).await?;
+        let all_queue_names = query_builder::jobs::get_queue_names(db, table_config).await?;
+
+        let queue_counts: Vec<QueueInfo> = all_queue_names
+            .into_iter()
+            .map(|name| QueueInfo {
+                slug: queue_slug(&name),
+                jobs_count: *queue_counts_map.get(&name).unwrap_or(&0),
+                status: if paused_queue_names.contains(&name) {
+                    "paused".to_string()
+                } else {
+                    "active".to_string()
+                },
+                name,
+            })
+            .collect();
+        context.insert("queue_counts", &queue_counts);
 
         Ok(())
     }

--- a/src/query_builder.rs
+++ b/src/query_builder.rs
@@ -1275,6 +1275,44 @@ pub mod ready_executions {
         execute_count(db, query).await
     }
 
+    /// Count ready executions grouped by queue name. Returns a map of
+    /// queue_name -> count for every queue that currently has at least one
+    /// ready execution. Queues with zero ready jobs are not present in the
+    /// result — callers that need a complete enumeration must merge against
+    /// their own list of known queue names.
+    pub async fn count_by_queue<C>(
+        db: &C,
+        table_config: &TableConfig,
+    ) -> Result<std::collections::HashMap<String, i64>, DbErr>
+    where
+        C: ConnectionTrait,
+    {
+        let table = Alias::new(&table_config.ready_executions);
+        let query = Query::select()
+            .column(col("queue_name"))
+            .expr_as(Expr::col(col("queue_name")).count(), Alias::new("count"))
+            .from(table)
+            .group_by_col(col("queue_name"))
+            .to_owned();
+
+        let (sql, values) = match db.get_database_backend() {
+            DbBackend::Postgres => query.build(PostgresQueryBuilder),
+            DbBackend::Sqlite => query.build(SqliteQueryBuilder),
+            DbBackend::MySql => query.build(MysqlQueryBuilder),
+        };
+
+        let stmt = Statement::from_sql_and_values(db.get_database_backend(), &sql, values);
+        let rows = db.query_all(stmt).await?;
+
+        let mut out = std::collections::HashMap::with_capacity(rows.len());
+        for row in rows {
+            let name: String = row.try_get("", "queue_name").unwrap_or_default();
+            let count: i64 = row.try_get("", "count").unwrap_or_default();
+            out.insert(name, count);
+        }
+        Ok(out)
+    }
+
     /// Get the oldest ready execution's created_at for pending latency calculation
     pub async fn oldest_created_at<C>(
         db: &C,


### PR DESCRIPTION
## Summary

Make the per-queue **Jobs Count** and **Status** cells on the Queues page refresh through the same `/stats` SSE turbo-stream that already drives the top nav counters (Failed / In Progress / Blocked / Scheduled / Finished). Before this PR half the numbers on screen would tick while the other half sat still until full page reload — UX-inconsistent.

## How

- `query_builder::ready_executions::count_by_queue` — new helper, one `GROUP BY queue_name` over `solid_queue_ready_executions`, returns `HashMap<String, i64>`. Uses the existing `idx_solid_queue_ready_executions_queue_priority` index
- `populate_nav_stats` calls the helper + pauses + `jobs::get_queue_names` and exposes `queue_counts: Vec<QueueInfo>` in the template context
- `templates/stats.html` loops `queue_counts` and emits one `<turbo-stream>` per queue, targeting `#queue-count-{slug}` and `#queue-status-{slug}`
- `templates/queues.html` adds those `id=` anchors on the matching `<td>` cells
- `handlers/queues.rs` refactored to use the same `count_by_queue` helper so the two surfaces never disagree

`QueueInfo` gains a `slug` field — non `[A-Za-z0-9_-]` chars in the queue name are replaced with `_` so the resulting `id=` is HTML-safe. Quebec queue names are alphanumeric+underscore in practice; the slug rule rarely changes anything visible.

Pages other than `/queues` simply lack the anchor IDs — Turbo silently no-ops on missing targets, so emitting the extra turbo-streams unconditionally is safe.

## Cost

Per `/stats` tick (default 3s SSE interval):

- +1 `GROUP BY queue_name` index-only scan over `ready_executions`
- +1 full table read of `pauses` (tiny table)
- +1 `DISTINCT queue_name` scan via `jobs::get_queue_names` (already cached pattern elsewhere)

Working sets are bounded by worker throughput (ready table) and config (pauses), so total overhead is well under 5% of the existing 7-`COUNT` /stats baseline.

## Test plan

- [x] `cargo check`, `cargo clippy --all-targets --all-features`, `cargo fmt --check`
- [ ] Manual: open `/queues`, observe top nav counters and per-queue rows refreshing every 3 s in lockstep
- [ ] Manual: pause a queue from another tab, watch the status badge flip on the open `/queues` tab without page reload
- [ ] Manual: visit another page (e.g. `/overview`) while /stats is firing — verify no errors in browser console from the extra turbo-streams