### PR TITLE
fix(worker): align concurrency_key handling with Solid Queue

### DIFF
--- a/src/worker.rs
+++ b/src/worker.rs
@@ -198,15 +198,21 @@ impl Runnable {
             // Call the concurrency_key method with the job arguments
             let result = concurrency_key_attr.call(py_args.bind(py), Some(&py_kwargs.bind(py)))?;
 
-            // Check if the result is None or empty string - if so, no concurrency control
-            if result.is_none() {
-                return Ok(None);
-            }
-
-            let raw_key = result.extract::<String>()?;
-            if raw_key.is_empty() {
-                return Ok(None);
-            }
+            // Mirror Solid Queue's `[group, key].compact.join("/")` semantics:
+            // when the user's `concurrency_key` returns None or empty string,
+            // fall back to a group-only key instead of silently dropping
+            // concurrency control. `warn!` so users who forgot `return` (Python
+            // default-returns None) discover the misconfiguration via logs.
+            let raw_key = if result.is_none() {
+                None
+            } else {
+                let s = result.extract::<String>()?;
+                if s.is_empty() {
+                    None
+                } else {
+                    Some(s)
+                }
+            };
 
             // Get concurrency_group (defaults to class name)
             let concurrency_group = if instance.hasattr("concurrency_group")? {
@@ -215,8 +221,20 @@ impl Runnable {
                 self.class_name.clone()
             };
 
-            // Build final concurrency_key as "group/key"
-            let key = format!("{concurrency_group}/{raw_key}");
+            // Build final concurrency_key — "group/key" when key is non-empty,
+            // otherwise group-only (matches Solid Queue's behaviour).
+            let key = match &raw_key {
+                Some(k) => format!("{concurrency_group}/{k}"),
+                None => {
+                    warn!(
+                        class = self.class_name,
+                        "concurrency_key returned None or empty string; falling back to \
+                         group-only key '{concurrency_group}'. Implement the method to \
+                         return a non-empty per-instance string for proper isolation."
+                    );
+                    concurrency_group.clone()
+                }
+            };
 
             // Return explicit limit or default to 1 (per Solid Queue spec)
             let limit = self.concurrency_limit.unwrap_or(1);
@@ -1787,6 +1805,25 @@ impl Worker {
                     .unwrap_or(false))
             })()
             .unwrap_or(false);
+
+            // Solid Queue's `limits_concurrency key:` is a mandatory keyword;
+            // matching that intent: if the user set concurrency_limit or
+            // concurrency_duration but the class exposes no concurrency_key,
+            // refuse to register rather than silently dropping the controls.
+            // concurrency_on_conflict is intentionally NOT part of the trigger
+            // because its default (Block) can't be distinguished from "user
+            // explicitly chose Block".
+            if !has_concurrency_control
+                && (concurrency_limit.is_some() || concurrency_duration.is_some())
+            {
+                return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                    "{class_name}: concurrency_limit/duration is set but \
+                     `concurrency_key` is missing — concurrency control would silently \
+                     not apply. Define `def concurrency_key(self, *args, **kwargs) -> str:` \
+                     (returning a non-empty key) or remove the concurrency_limit / \
+                     concurrency_duration attributes."
+                )));
+            }
 
             let module_path = bound
                 .getattr("__module__")

--- a/tests/test_concurrency_strict.py
+++ b/tests/test_concurrency_strict.py
@@ -1,0 +1,182 @@
+"""Tests for the SQ-aligned strict concurrency_key checks.
+
+Pre-fix behaviour silently dropped concurrency control when:
+- the class set `concurrency_limit` / `concurrency_duration` but never defined
+  `concurrency_key` (register-time fall-through), or
+- `concurrency_key()` returned `None` / empty string (runtime fall-through).
+
+Post-fix:
+- register-time: the first case raises `ValueError`, matching SQ's
+  `limits_concurrency key:` keyword being mandatory.
+- runtime: None/empty falls back to a group-only key (`concurrency_group`)
+  instead of NULL, mirroring SQ's `[group, key].compact.join("/")`. A warn!
+  is emitted so users who forgot `return` discover the issue via logs.
+"""
+
+from __future__ import annotations
+
+import pytest
+import quebec
+from sqlalchemy import text
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Layer 1 — register-time strict check
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_register_raises_when_limit_set_without_concurrency_key(qc_with_sqlalchemy):
+    """concurrency_limit set + no concurrency_key method → ValueError on register."""
+    qc = qc_with_sqlalchemy["qc"]
+
+    class MisconfiguredLimitJob(quebec.BaseClass):
+        concurrency_limit = 3
+
+        def perform(self, *args, **kwargs) -> None:
+            pass
+
+    with pytest.raises(ValueError, match="concurrency_key"):
+        qc.register_job(MisconfiguredLimitJob)
+
+
+def test_register_raises_when_duration_set_without_concurrency_key(qc_with_sqlalchemy):
+    """concurrency_duration set + no concurrency_key method → ValueError on register."""
+    qc = qc_with_sqlalchemy["qc"]
+
+    class MisconfiguredDurationJob(quebec.BaseClass):
+        concurrency_duration = 60
+
+        def perform(self, *args, **kwargs) -> None:
+            pass
+
+    with pytest.raises(ValueError, match="concurrency_key"):
+        qc.register_job(MisconfiguredDurationJob)
+
+
+def test_register_accepts_class_with_no_concurrency_attrs(qc_with_sqlalchemy):
+    """Class without any concurrency_* attribute is unaffected by the strict check."""
+    qc = qc_with_sqlalchemy["qc"]
+
+    class PlainJob(quebec.BaseClass):
+        def perform(self, *args, **kwargs) -> None:
+            pass
+
+    qc.register_job(PlainJob)  # must not raise
+
+
+def test_register_accepts_only_concurrency_on_conflict_set(qc_with_sqlalchemy):
+    """concurrency_on_conflict defaults to Block, so setting it alone shouldn't trip
+    the strict check — only limit/duration count as 'user configured concurrency'."""
+    qc = qc_with_sqlalchemy["qc"]
+
+    class OnConflictOnlyJob(quebec.BaseClass):
+        concurrency_on_conflict = quebec.ConcurrencyConflict.discard()
+
+        def perform(self, *args, **kwargs) -> None:
+            pass
+
+    qc.register_job(OnConflictOnlyJob)  # must not raise
+
+
+def test_register_accepts_full_concurrency_config(qc_with_sqlalchemy):
+    """concurrency_limit + concurrency_key method → registers cleanly."""
+    qc = qc_with_sqlalchemy["qc"]
+
+    class ProperJob(quebec.BaseClass):
+        concurrency_limit = 2
+
+        @staticmethod
+        def concurrency_key(*args, **kwargs) -> str:
+            return "resource-x"
+
+        def perform(self, *args, **kwargs) -> None:
+            pass
+
+    qc.register_job(ProperJob)  # must not raise
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Layer 2 — runtime fallback to group-only key (no silent NULL)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_concurrency_key_returning_none_falls_back_to_group(qc_with_sqlalchemy):
+    """Forgot `return` (Python defaults to None) → key falls back to group, NOT NULL."""
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    class ForgotReturnJob(quebec.BaseClass):
+        concurrency_limit = 1
+
+        @staticmethod
+        def concurrency_key(*args, **kwargs):
+            # No return → Python returns None
+            return None
+
+        def perform(self, *args, **kwargs) -> None:
+            pass
+
+    qc.register_job(ForgotReturnJob)
+    ForgotReturnJob.perform_later(qc, "x")
+
+    row = session.execute(
+        text(f"SELECT concurrency_key FROM {prefix}_jobs ORDER BY id DESC LIMIT 1")
+    ).fetchone()
+    # Fallback key is just the group (class name by default), no "/key" suffix.
+    assert row.concurrency_key is not None
+    assert row.concurrency_key.endswith("ForgotReturnJob")
+    assert "/" not in row.concurrency_key
+
+
+def test_concurrency_key_returning_empty_string_falls_back_to_group(qc_with_sqlalchemy):
+    """Empty-string key → same fallback as None."""
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    class EmptyKeyJob(quebec.BaseClass):
+        concurrency_limit = 1
+
+        @staticmethod
+        def concurrency_key(*args, **kwargs) -> str:
+            return ""
+
+        def perform(self, *args, **kwargs) -> None:
+            pass
+
+    qc.register_job(EmptyKeyJob)
+    EmptyKeyJob.perform_later(qc, "x")
+
+    row = session.execute(
+        text(f"SELECT concurrency_key FROM {prefix}_jobs ORDER BY id DESC LIMIT 1")
+    ).fetchone()
+    assert row.concurrency_key is not None
+    assert row.concurrency_key.endswith("EmptyKeyJob")
+    assert "/" not in row.concurrency_key
+
+
+def test_concurrency_key_normal_path_unchanged(qc_with_sqlalchemy):
+    """Non-empty key → "group/key" composition unchanged (regression guard)."""
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    class NormalJob(quebec.BaseClass):
+        concurrency_limit = 1
+
+        @staticmethod
+        def concurrency_key(*args, **kwargs) -> str:
+            return "tenant-42"
+
+        def perform(self, *args, **kwargs) -> None:
+            pass
+
+    qc.register_job(NormalJob)
+    NormalJob.perform_later(qc, "x")
+
+    row = session.execute(
+        text(f"SELECT concurrency_key FROM {prefix}_jobs ORDER BY id DESC LIMIT 1")
+    ).fetchone()
+    assert row.concurrency_key is not None
+    assert row.concurrency_key.endswith("NormalJob/tenant-42")


### PR DESCRIPTION
## Summary

Two silent fall-throughs made concurrency control disappear with no log or warning:

- **register-time**: class sets `concurrency_limit` / `concurrency_duration` but defines no `concurrency_key` method → `has_concurrency_control = false` → enqueue path writes NULL.
- **runtime**: `concurrency_key()` returns `None` (typical Python "forgot `return`") or empty string → helper short-circuits to `Ok(None)` → still NULL.

This change aligns Quebec with Solid Queue:

- **Layer 1 — register raises**: if \`concurrency_limit\` or \`concurrency_duration\` is set but no \`concurrency_key\` exists, registration now raises \`ValueError\` with an actionable message. Mirrors SQ's mandatory \`limits_concurrency(key:, ...)\` keyword.
- **Layer 2 — runtime fallback**: when the key resolves to \`None\` / empty, fall back to a group-only key instead of NULL. Mirrors SQ's \`[group, key].compact.join("/")\`. A \`warn!\` is emitted so Python users who forgot \`return\` find the misconfiguration in logs.

\`concurrency_on_conflict\` is intentionally **not** part of the layer-1 trigger condition — it defaults to \`Block\` (\`ConcurrencyConflict::default()\`), so its value can't distinguish "user wanted Block" from "user didn't touch it".

## Follow-up

\`CONCURRENCY_CONTROL.md\` still contains a "条件性并发控制" example that uses \`return None\` to opt out per-call. That example is now stale — None falls back to the group-only key rather than disabling concurrency control. A docs-only follow-up will rewrite it.

## Test plan

- [x] new \`tests/test_concurrency_strict.py\` — 8/8 passing (layer-1 raises for limit-only / duration-only, layer-2 fallback for None / empty, regression on normal path, plus accept paths for no-config and on_conflict-only)
- [x] existing \`tests/test_concurrency.py\` — 4/4 unchanged
- [x] \`cargo clippy --all-targets --all-features\` — clean