### PR TITLE
fix(worker): store pruned-process error as structured JSON

### DIFF
--- a/src/worker.rs
+++ b/src/worker.rs
@@ -2207,9 +2207,14 @@ impl Worker {
             let process_id = process.id;
             let process_pid = process.pid;
             let process_hostname = process.hostname.clone();
-            let error_msg = format!(
-                "Worker process {process_id} (pid={process_pid}, host={process_hostname:?}) stopped responding"
-            );
+            let error_msg = serde_json::json!({
+                "exception_class": "ProcessPrunedError",
+                "message": format!(
+                    "Worker process {process_id} (pid={process_pid}, host={process_hostname:?}) stopped responding"
+                ),
+                "backtrace": Vec::<String>::new(),
+            })
+            .to_string();
 
             let ctx = self.ctx.clone();
             let tc = table_config.clone();


### PR DESCRIPTION
## Summary

When the supervisor prunes a stale worker (`heartbeat` past threshold), the claimed jobs are moved to `failed_executions` with a synthetic error message. Previously that message was written as a **plain string** to the `error` column, which is inconsistent with every other failure path — Python exceptions write a JSON object `{exception_class, message, backtrace}` (see `worker.rs:1462`), and Solid Queue's `ProcessPrunedError` writes the same JSON shape.

This patch wraps the synthetic message in the same JSON shape so:
- the control plane's `parse_error_fields` can extract `ProcessPrunedError` as the class label, rendering the same nicely-formatted UI as Python exceptions
- the `error` column stays a single shape across both fail paths (Python exception vs prune)
- it aligns with Solid Queue's behaviour (where `Processes::ProcessPrunedError` is serialized via the standard `{exception_class, message, backtrace}` path)

## Test plan

- [x] `cargo clippy --all-targets --all-features` — clean
- [x] Manual: existing pruned-job UI text rendering verified end-to-end (pre-upgrade rows with plain-string error still render via the JSON-parse fallback in `parse_error_fields`)