### PR TITLE
feat(control-plane): show exception_executions map in execution history

### DIFF
--- a/src/control_plane/handlers/job_details.rs
+++ b/src/control_plane/handlers/job_details.rs
@@ -343,8 +343,24 @@ impl ControlPlane {
             // Format arguments for display
             job_details.arguments = Self::parse_arguments(&job_details.arguments);
 
+            // Surface arguments.exception_executions (class → retry count) so the
+            // template can list it. ActiveJob doesn't persist message/backtrace
+            // for retried exceptions; this map is the only signal that survives.
+            let exception_executions: Option<serde_json::Map<String, serde_json::Value>> =
+                serde_json::from_str::<serde_json::Value>(&job_details.arguments)
+                    .ok()
+                    .and_then(|v| {
+                        v.get("exception_executions")
+                            .and_then(|m| m.as_object())
+                            .cloned()
+                    })
+                    .filter(|m| !m.is_empty());
+
             let mut context = tera::Context::new();
             context.insert("job", &job_details);
+            if let Some(map) = &exception_executions {
+                context.insert("exception_executions", map);
+            }
             context.insert(
                 "active_page",
                 match status.as_str() {

--- a/src/control_plane/templates/job-details.html
+++ b/src/control_plane/templates/job-details.html
@@ -197,8 +197,18 @@
             {% endif %}
           </div>
           {% endfor %}
-          {% else %}
+          {% elif not exception_executions %}
           <div class="p-4 text-sm text-gray-500">No execution history available.</div>
+          {% endif %}
+          {% if exception_executions %}
+          <div class="p-4">
+            <div class="text-xs font-medium text-gray-700 mb-2">exception_executions</div>
+            <div class="space-y-1 text-sm">
+              {% for class_name, count in exception_executions %}
+              <div><span class="font-mono text-gray-900">{{ class_name }}</span>: {{ count }}</div>
+              {% endfor %}
+            </div>
+          </div>
           {% endif %}
         </div>
       </div>


### PR DESCRIPTION
## Summary

`arguments.exception_executions` already records the per-exception retry counts (class → count) — it's the only signal that survives when an ActiveJob retries successfully and there's no row in `failed_executions`. Today the job details page just renders "No execution history available." even when this map has entries, leaving operators no way to see _that_ a job retried.

This patch surfaces the map directly in the Execution History panel:

- handler parses `arguments` JSON, picks out `exception_executions` (only when it's a non-empty object), and inserts it into the Tera context
- template adds a `{% for class_name, count in exception_executions %}` block listing entries
- when there's no per-attempt card and no map → still show the original "No execution history available." text

ActiveJob's `retry_on` path never persists the exception's message or backtrace, so this stays best-effort — class name and count only. The follow-up `feat/retain-exception-history` branch extends this with full message/backtrace history under a separate opt-in flag.

## Test plan

- [x] `cargo clippy --all-targets --all-features` — clean
- [x] Manual: job with executions=2 / `{"[ArgumentError]": 1, "[OperationalError]": 1}` now shows both entries in the Execution History panel
- [x] Job without the map (Solid Queue-shaped arguments) renders unchanged ("No execution history available.")