### PR TITLE
feat(control-plane): live worker rows on /workers via stats turbo-stream

### DIFF
--- a/src/control_plane/handlers/events.rs
+++ b/src/control_plane/handlers/events.rs
@@ -25,12 +25,15 @@ impl ControlPlane {
                     }
                 }
 
+                // Nav stats are added implicitly by render_template. Stream
+                // extras (workers, ...) are this loop's explicit
+                // responsibility: failure here skips a tick rather than
+                // blowing up unrelated page renders elsewhere.
                 let mut context = tera::Context::new();
-                if let Err(e) = state.populate_nav_stats(&mut context).await {
-                    debug!("SSE stats error: {}", e);
+                if let Err(e) = state.populate_stream_extras(&mut context).await {
+                    debug!("SSE stream extras error: {}", e);
                     continue;
                 }
-
                 match state.render_template("stats.html", &mut context).await {
                     Ok(html) => {
                         yield Ok(Event::default().event("message").data(html));

--- a/src/control_plane/handlers/workers.rs
+++ b/src/control_plane/handlers/workers.rs
@@ -11,42 +11,32 @@ use crate::control_plane::{models::WorkerInfo, ControlPlane};
 use crate::query_builder;
 
 impl ControlPlane {
-    pub async fn workers(
-        State(state): State<Arc<ControlPlane>>,
-    ) -> Result<Html<String>, (StatusCode, String)> {
+    /// Query and assemble the live worker list. Shared between the full
+    /// `/workers` page render and the `/stats` turbo-stream that drives
+    /// live refresh (SSE in standalone mode, polling fallback under ASGI).
+    pub(crate) async fn fetch_workers_info(&self) -> Result<Vec<WorkerInfo>, sea_orm::DbErr> {
         let start = Instant::now();
-        let db = state
-            .ctx
-            .get_db()
-            .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        let db = self.ctx.get_db().await?;
         let db = db.as_ref();
-        let table_config = &state.ctx.table_config;
+        let table_config = &self.ctx.table_config;
         debug!("Database connection obtained in {:?}", start.elapsed());
 
-        // Query all worker processes using query_builder
-        let workers = query_builder::processes::find_all_by_heartbeat(db, table_config)
-            .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        let workers = query_builder::processes::find_all_by_heartbeat(db, table_config).await?;
 
-        // Calculate time since last heartbeat for each worker
-        let workers_info: Vec<WorkerInfo> = workers
+        let threshold_seconds = self.ctx.process_alive_threshold.as_secs() as i64;
+        let now = chrono::Utc::now().naive_utc();
+
+        Ok(workers
             .into_iter()
             .map(|worker| {
                 let last_heartbeat = worker.last_heartbeat_at;
-                let now = chrono::Utc::now().naive_utc();
-                // Calculate time difference (seconds)
-                let duration = now.signed_duration_since(last_heartbeat);
-                let seconds_since_heartbeat = duration.num_seconds();
-
-                // Use process_alive_threshold from context to determine worker status
-                let threshold_seconds = state.ctx.process_alive_threshold.as_secs() as i64;
+                let seconds_since_heartbeat =
+                    now.signed_duration_since(last_heartbeat).num_seconds();
                 let status = if seconds_since_heartbeat > threshold_seconds {
                     "dead"
                 } else {
                     "alive"
                 };
-
                 let quiet = worker
                     .metadata
                     .as_deref()
@@ -66,7 +56,20 @@ impl ControlPlane {
                     quiet,
                 }
             })
-            .collect();
+            .collect())
+    }
+
+    pub async fn workers(
+        State(state): State<Arc<ControlPlane>>,
+    ) -> Result<Html<String>, (StatusCode, String)> {
+        // Page-context: /workers owns its core data. Querying it here (rather
+        // than via populate_nav_stats) keeps the page robust against nav-stats
+        // failures and surfaces a 5xx from this handler — not from deep inside
+        // render_template — if the processes query itself fails.
+        let workers_info = state
+            .fetch_workers_info()
+            .await
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
         let mut context = tera::Context::new();
         context.insert("workers", &workers_info);
@@ -83,9 +86,12 @@ impl ControlPlane {
     ) -> Result<impl IntoResponse, (StatusCode, String)> {
         let mut context = tera::Context::new();
 
-        // Use populate_nav_stats method to fill statistics
+        // Stream-context: extras beyond nav stats (workers, ...). Nav stats
+        // are populated implicitly by render_template; here we add the
+        // resource-level live data that stats.html broadcasts as a
+        // turbo-stream.
         state
-            .populate_nav_stats(&mut context)
+            .populate_stream_extras(&mut context)
             .await
             .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 

--- a/src/control_plane/templates/stats.html
+++ b/src/control_plane/templates/stats.html
@@ -28,3 +28,11 @@
     <span class="px-1 py-0.5 text-xs rounded-full bg-gray-200 text-gray-800">{{ finished_jobs_count }}</span>
   </template>
 </turbo-stream>
+
+{# Live worker rows. Anchored at <tbody id="workers-tbody"> on /workers;
+   no-op on every other page (Turbo silently skips missing targets). #}
+<turbo-stream action="update" target="workers-tbody">
+  <template>
+    {% include "workers_frame.html" %}
+  </template>
+</turbo-stream>

--- a/src/control_plane/templates/workers.html
+++ b/src/control_plane/templates/workers.html
@@ -21,51 +21,8 @@
           <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
         </tr>
       </thead>
-      <tbody class="bg-white divide-y divide-gray-200">
-        {% for worker in workers %}
-        <tr>
-          <td class="px-6 py-4 whitespace-nowrap">
-            <div class="text-sm text-gray-900">{{ worker.id }}</div>
-          </td>
-          <td class="px-6 py-4 whitespace-nowrap">
-            <div class="text-sm text-gray-900">{{ worker.name }}</div>
-          </td>
-          <td class="px-6 py-4 whitespace-nowrap">
-            <div class="text-sm text-gray-900">{{ worker.kind }}</div>
-          </td>
-          <td class="px-6 py-4 whitespace-nowrap">
-            <div class="text-sm text-gray-900">{{ worker.hostname | default(value="unknown") }}</div>
-          </td>
-          <td class="px-6 py-4 whitespace-nowrap">
-            <div class="text-sm text-gray-900">{{ worker.pid }}</div>
-          </td>
-          <td class="px-6 py-4 whitespace-nowrap">
-            <div class="text-sm text-gray-900"><span data-controller="timeago" data-timeago-datetime-value="{{ worker.last_heartbeat_at }}"></span></div>
-          </td>
-          <td class="px-6 py-4 whitespace-nowrap">
-            {% if worker.status == "alive" %}
-              <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
-                Active
-              </span>
-            {% else %}
-              <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-red-100 text-red-800">
-                Dead
-              </span>
-            {% endif %}
-            {% if worker.quiet %}
-              <span class="ml-1 px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800" title="Worker is in quiet mode: no longer claiming new jobs, draining in-flight work">
-                Quiet
-              </span>
-            {% endif %}
-          </td>
-        </tr>
-        {% endfor %}
-
-        {% if workers | length == 0 %}
-        <tr>
-          <td colspan="7" class="px-4 py-3 text-sm text-center text-gray-500">No workers found</td>
-        </tr>
-        {% endif %}
+      <tbody id="workers-tbody" class="bg-white divide-y divide-gray-200">
+        {% include "workers_frame.html" %}
       </tbody>
     </table>
   </div>

--- a/src/control_plane/templates/workers_frame.html
+++ b/src/control_plane/templates/workers_frame.html
@@ -1,0 +1,44 @@
+{% for worker in workers %}
+<tr>
+  <td class="px-6 py-4 whitespace-nowrap">
+    <div class="text-sm text-gray-900">{{ worker.id }}</div>
+  </td>
+  <td class="px-6 py-4 whitespace-nowrap">
+    <div class="text-sm text-gray-900">{{ worker.name }}</div>
+  </td>
+  <td class="px-6 py-4 whitespace-nowrap">
+    <div class="text-sm text-gray-900">{{ worker.kind }}</div>
+  </td>
+  <td class="px-6 py-4 whitespace-nowrap">
+    <div class="text-sm text-gray-900">{{ worker.hostname | default(value="unknown") }}</div>
+  </td>
+  <td class="px-6 py-4 whitespace-nowrap">
+    <div class="text-sm text-gray-900">{{ worker.pid }}</div>
+  </td>
+  <td class="px-6 py-4 whitespace-nowrap">
+    <div class="text-sm text-gray-900"><span data-controller="timeago" data-timeago-datetime-value="{{ worker.last_heartbeat_at }}"></span></div>
+  </td>
+  <td class="px-6 py-4 whitespace-nowrap">
+    {% if worker.status == "alive" %}
+      <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
+        Active
+      </span>
+    {% else %}
+      <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-red-100 text-red-800">
+        Dead
+      </span>
+    {% endif %}
+    {% if worker.quiet %}
+      <span class="ml-1 px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800" title="Worker is in quiet mode: no longer claiming new jobs, draining in-flight work">
+        Quiet
+      </span>
+    {% endif %}
+  </td>
+</tr>
+{% endfor %}
+
+{% if workers | length == 0 %}
+<tr>
+  <td colspan="7" class="px-4 py-3 text-sm text-center text-gray-500">No workers found</td>
+</tr>
+{% endif %}

--- a/src/control_plane/utils.rs
+++ b/src/control_plane/utils.rs
@@ -134,6 +134,22 @@ impl ControlPlane {
         Ok(())
     }
 
+    /// Stream-level extras: live resource data that the /stats turbo-stream
+    /// broadcasts on top of `populate_nav_stats`. Explicitly invoked only by
+    /// the `/stats` handler and the `/events` SSE loop — page handlers that
+    /// just need their own resource (e.g. /workers) should query it
+    /// themselves, so that a failure in this broader live-data computation
+    /// doesn't take down individual page renders.
+    ///
+    /// Keeping this separate also means errors here surface in a single
+    /// place (the stream loop / poll handler), not deep inside
+    /// `render_template`.
+    pub async fn populate_stream_extras(&self, context: &mut Context) -> Result<(), DbErr> {
+        let workers_info = self.fetch_workers_info().await?;
+        context.insert("workers", &workers_info);
+        Ok(())
+    }
+
     /// Check if a queue is paused using query_builder
     pub async fn is_queue_paused(&self, queue_name: &str) -> Result<bool, DbErr> {
         let db = self.ctx.get_db().await?;


### PR DESCRIPTION
## Summary

- Workers table rows refresh in lockstep with the nav-chip counters by reusing the existing `/stats` turbo-stream channel (SSE in standalone mode, polling fallback under ASGI). No new endpoints, controllers, or SSE connections.
- Control-plane context preparation is split into three explicit layers so individual page failures stay isolated:
  - **Layout context** (`populate_nav_stats`): nav-chip data injected implicitly by `render_template`. Failure degrades the chip but cannot break a page.
  - **Page context**: each handler owns its core resource — `/workers` calls `fetch_workers_info()` itself, so a workers-query failure surfaces as a 5xx on that page only.
  - **Stream context** (`populate_stream_extras`): the extras the `/stats` turbo-stream broadcasts on top of nav stats (currently workers; queue counts etc. land here later). Called explicitly by `/stats` and `/events`; failure skips a tick rather than breaking unrelated pages.
- New `workers_frame.html` partial holds the table-rows markup; `workers.html` includes it for SSR, `stats.html` updates it via `<turbo-stream action="update" target="workers-tbody">`. Turbo silently skips the missing anchor on every page that doesn't have it.
- Each `/stats` poll / SSE tick now runs one nav-COUNT batch + one processes query (not the doubled set the prior iteration produced).

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features`
- [ ] Browser smoke: standalone control plane — open `/workers`, kill a worker, watch the row drop within the next SSE tick.
- [ ] Browser smoke: ASGI mount — open `/<prefix>/workers`, confirm polling fallback updates the rows.
- [ ] Verify `/workers` still renders even when `populate_nav_stats` fails (e.g. simulate a count query error).