### PR TITLE
fix(shutdown): track spawned handles so worker on_stop drains before exit

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -1013,9 +1013,21 @@ impl PyQuebec {
             .set_proc_title("worker", Some(&self.ctx.worker_threads.to_string()));
 
         let worker = self.worker.clone();
-        let _ = self.rt.spawn(async move {
+        // Track the handle in self.handles so graceful_shutdown's block_on
+        // actually waits for run_main_loop's `quit.cancelled()` branch to
+        // finish — otherwise release_all_claimed_executions + on_stop race
+        // against process::exit and the process row leaks.
+        let handle = self.rt.spawn(async move {
             let _ = worker.run_main_loop().await;
         });
+        self.handles
+            .lock()
+            .map_err(|_| {
+                PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                    "Failed to acquire lock for handles",
+                )
+            })?
+            .push(handle);
 
         Ok(())
     }
@@ -1024,9 +1036,17 @@ impl PyQuebec {
         self.ctx.set_proc_title("dispatcher", None);
 
         let dispatcher = self.dispatcher.clone();
-        let _ = self.rt.spawn(async move {
+        let handle = self.rt.spawn(async move {
             let _ = dispatcher.run().await;
         });
+        self.handles
+            .lock()
+            .map_err(|_| {
+                PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                    "Failed to acquire lock for handles",
+                )
+            })?
+            .push(handle);
 
         Ok(())
     }
@@ -1035,9 +1055,17 @@ impl PyQuebec {
         self.ctx.set_proc_title("scheduler", None);
 
         let scheduler = self.scheduler.clone();
-        let _ = self.rt.spawn(async move {
+        let handle = self.rt.spawn(async move {
             let _ = scheduler.run().await;
         });
+        self.handles
+            .lock()
+            .map_err(|_| {
+                PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                    "Failed to acquire lock for handles",
+                )
+            })?
+            .push(handle);
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

- `spawn_job_claim_poller` / `spawn_dispatcher` / `spawn_scheduler` discarded their `JoinHandle`, so `graceful_shutdown()`'s `block_on` only awaited `bind_queue`'s `queue.join()` plus the control-plane handle. Once those returned, `std::process::exit(0)` ran while the main loops' `quit.cancelled()` cleanup was still in flight.
- Worker's cleanup is multi-step (Python stop_handlers → `release_all_claimed_executions` → `on_stop`), so it routinely lost the race against `exit(0)` and left its row in `solid_queue_processes`. The bug reproduces reliably under `SIGUSR1` → `SIGTERM` (quiet then terminate): `queue.join()` returns instantly because in-flight jobs are already drained, so there is no slack for the worker's deregister path to complete.
- Dispatcher's single-DELETE `on_stop` usually won the race, which is why only worker rows leaked.

## Fix

Push the spawned handle for each of the three poller fns into `self.handles`. `block_on` now waits for each component's `quit.cancelled()` branch (including `on_stop`'s row delete) before `process::exit`. The existing `shutdown_timeout` still bounds total wait time and falls back to force-quit.

## Test plan

- [ ] `cargo check` / `cargo clippy --all-targets` / `cargo fmt --check`
- [ ] Manual: start a worker, `kill -USR1 <pid>` to enter quiet, then `kill -TERM <pid>`; verify `SELECT * FROM solid_queue_processes WHERE kind='Worker'` returns no row for that pid afterwards.
- [ ] Manual: same dance for dispatcher/scheduler — should still be clean (was the un-broken case).