### PR TITLE
feat(api): expose queue pause/resume on the Quebec instance

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -2615,6 +2615,194 @@ impl PyQuebec {
             })
         })
     }
+
+    /// Pause a queue so workers stop claiming jobs from it. Dispatched/ready
+    /// rows continue to be produced by the dispatcher; they just won't be
+    /// picked up by workers while the queue is paused. Idempotent.
+    ///
+    /// Returns:
+    ///     bool: True if a new pause record was inserted, False if the queue was already paused.
+    fn pause_queue(&self, py: Python<'_>, queue_name: &str) -> PyResult<bool> {
+        let table_config = self.ctx.table_config.clone();
+        let queue_name = queue_name.to_string();
+        py.detach(|| {
+            self.rt.block_on(async {
+                let db = self.ctx.get_db().await.map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "Database connection failed: {e}"
+                    ))
+                })?;
+                let inserted_id = crate::query_builder::pauses::insert(
+                    db.as_ref(),
+                    &table_config,
+                    &queue_name,
+                    chrono::Utc::now().naive_utc(),
+                )
+                .await
+                .map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to pause queue: {e}"))
+                })?;
+                Ok(inserted_id != 0)
+            })
+        })
+    }
+
+    /// Resume a paused queue.
+    ///
+    /// Returns:
+    ///     bool: True if a pause record was removed, False if the queue was not paused.
+    fn resume_queue(&self, py: Python<'_>, queue_name: &str) -> PyResult<bool> {
+        let table_config = self.ctx.table_config.clone();
+        let queue_name = queue_name.to_string();
+        py.detach(|| {
+            self.rt.block_on(async {
+                let db = self.ctx.get_db().await.map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "Database connection failed: {e}"
+                    ))
+                })?;
+                let deleted = crate::query_builder::pauses::delete_by_queue_name(
+                    db.as_ref(),
+                    &table_config,
+                    &queue_name,
+                )
+                .await
+                .map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "Failed to resume queue: {e}"
+                    ))
+                })?;
+                Ok(deleted > 0)
+            })
+        })
+    }
+
+    /// Check whether a specific queue is currently paused.
+    fn queue_paused(&self, py: Python<'_>, queue_name: &str) -> PyResult<bool> {
+        let table_config = self.ctx.table_config.clone();
+        let queue_name = queue_name.to_string();
+        py.detach(|| {
+            self.rt.block_on(async {
+                let db = self.ctx.get_db().await.map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "Database connection failed: {e}"
+                    ))
+                })?;
+                let found = crate::query_builder::pauses::find_by_queue_name(
+                    db.as_ref(),
+                    &table_config,
+                    &queue_name,
+                )
+                .await
+                .map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "Failed to check pause state: {e}"
+                    ))
+                })?;
+                Ok(found.is_some())
+            })
+        })
+    }
+
+    /// Return the list of currently paused queue names (sorted).
+    fn paused_queues(&self, py: Python<'_>) -> PyResult<Vec<String>> {
+        let table_config = self.ctx.table_config.clone();
+        py.detach(|| {
+            self.rt.block_on(async {
+                let db = self.ctx.get_db().await.map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "Database connection failed: {e}"
+                    ))
+                })?;
+                let mut names =
+                    crate::query_builder::pauses::find_all_queue_names(db.as_ref(), &table_config)
+                        .await
+                        .map_err(|e| {
+                            pyo3::exceptions::PyRuntimeError::new_err(format!(
+                                "Failed to list paused queues: {e}"
+                            ))
+                        })?;
+                names.sort();
+                Ok(names)
+            })
+        })
+    }
+
+    /// Pause every queue that has at least one job. Already-paused queues are skipped.
+    ///
+    /// Returns:
+    ///     int: Number of queues that were newly paused.
+    fn pause_all(&self, py: Python<'_>) -> PyResult<u64> {
+        let table_config = self.ctx.table_config.clone();
+        py.detach(|| {
+            self.rt.block_on(async {
+                let db = self.ctx.get_db().await.map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "Database connection failed: {e}"
+                    ))
+                })?;
+                let queue_names =
+                    crate::query_builder::jobs::get_queue_names(db.as_ref(), &table_config)
+                        .await
+                        .map_err(|e| {
+                            pyo3::exceptions::PyRuntimeError::new_err(format!(
+                                "Failed to enumerate queues: {e}"
+                            ))
+                        })?;
+                let already_paused =
+                    crate::query_builder::pauses::find_all_queue_names(db.as_ref(), &table_config)
+                        .await
+                        .map_err(|e| {
+                            pyo3::exceptions::PyRuntimeError::new_err(format!(
+                                "Failed to list paused queues: {e}"
+                            ))
+                        })?;
+                let now = chrono::Utc::now().naive_utc();
+                let mut paused: u64 = 0;
+                for name in &queue_names {
+                    if already_paused.contains(name) {
+                        continue;
+                    }
+                    let inserted =
+                        crate::query_builder::pauses::insert(db.as_ref(), &table_config, name, now)
+                            .await
+                            .map_err(|e| {
+                                pyo3::exceptions::PyRuntimeError::new_err(format!(
+                                    "Failed to pause queue {name}: {e}"
+                                ))
+                            })?;
+                    if inserted != 0 {
+                        paused += 1;
+                    }
+                }
+                Ok(paused)
+            })
+        })
+    }
+
+    /// Resume every paused queue.
+    ///
+    /// Returns:
+    ///     int: Number of pause records deleted.
+    fn resume_all(&self, py: Python<'_>) -> PyResult<u64> {
+        let table_config = self.ctx.table_config.clone();
+        py.detach(|| {
+            self.rt.block_on(async {
+                let db = self.ctx.get_db().await.map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "Database connection failed: {e}"
+                    ))
+                })?;
+                crate::query_builder::pauses::delete_all(db.as_ref(), &table_config)
+                    .await
+                    .map_err(|e| {
+                        pyo3::exceptions::PyRuntimeError::new_err(format!(
+                            "Failed to resume all queues: {e}"
+                        ))
+                    })
+            })
+        })
+    }
 }
 
 #[pyclass(name = "ActiveJob", subclass, from_py_object)]

--- a/tests/test_queue_pause.py
+++ b/tests/test_queue_pause.py
@@ -1,0 +1,71 @@
+"""Tests for the queue pause/resume Python API on the Quebec instance."""
+
+from __future__ import annotations
+
+from sqlalchemy import text
+
+
+def test_pause_queue_inserts_row_and_resume_deletes_it(qc_with_sqlalchemy) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    assert qc.queue_paused("emails") is False
+    assert qc.paused_queues() == []
+
+    assert qc.pause_queue("emails") is True
+
+    assert qc.queue_paused("emails") is True
+    paused = session.execute(
+        text(f"SELECT queue_name FROM {prefix}_pauses ORDER BY queue_name")
+    ).fetchall()
+    assert [row.queue_name for row in paused] == ["emails"]
+    assert qc.paused_queues() == ["emails"]
+
+    assert qc.resume_queue("emails") is True
+
+    assert qc.queue_paused("emails") is False
+    assert qc.paused_queues() == []
+
+
+def test_pause_queue_is_idempotent(qc) -> None:
+    assert qc.pause_queue("emails") is True
+    assert qc.pause_queue("emails") is False
+    assert qc.queue_paused("emails") is True
+
+
+def test_resume_queue_returns_false_when_not_paused(qc) -> None:
+    assert qc.resume_queue("emails") is False
+    assert qc.queue_paused("emails") is False
+
+
+def test_pause_all_skips_already_paused_and_resume_all_clears(
+    qc_with_sqlalchemy,
+) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    # pause_all enumerates queues from the jobs table — seed two queues
+    # directly via SQLAlchemy to keep the test free of Quebec's enqueue path.
+    for queue in ("emails", "reports"):
+        session.execute(
+            text(
+                f"INSERT INTO {prefix}_jobs "
+                f"(queue_name, class_name, arguments, priority, created_at, updated_at) "
+                f"VALUES (:queue, 'Job', '[]', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+            ),
+            {"queue": queue},
+        )
+    session.commit()
+
+    # Pre-pause one queue manually to confirm pause_all skips it.
+    assert qc.pause_queue("emails") is True
+
+    newly_paused = qc.pause_all()
+    assert newly_paused == 1
+    assert sorted(qc.paused_queues()) == ["emails", "reports"]
+
+    resumed = qc.resume_all()
+    assert resumed == 2
+    assert qc.paused_queues() == []


### PR DESCRIPTION
## Summary

The queue pause/resume logic already exists in `query_builder::pauses` and is wired up to the HTTP control plane, but `PyQuebec` doesn't expose it. This forces Python users to either drive pauses through the web UI or write raw SQL against `solid_queue_pauses` — neither is great for app-level automation (think: pause a queue from an `on_start` callback while a migration runs, or in a one-off ops script).

This PR wraps the existing layer as Python methods on the Quebec instance.

## Methods added

- `pause_queue(name) / resume_queue(name)` — idempotent, return whether the state actually changed
- `queue_paused(name) / paused_queues()` — introspection
- `pause_all()` — pauses every queue that has at least one job and isn't already paused (mirrors `pause_all_queues` in the control plane handler)
- `resume_all()` — clears every pause record

`pause_queue`'s docstring credits the worker for the skip behavior (not the dispatcher), since `dispatcher.rs` never consults the pauses table — the worker reads `pauses` when claiming ready executions and skips paused queue names. Without that caveat, callers might expect pausing a queue to also stop the dispatcher from producing ready rows for it.

## Follow-up scope (intentionally separate PRs)

- Queue introspection (`queue_size`, etc.) — separate concern from pause state
- Failed-jobs ops (`retry_failed`, `discard_failed`, `retry_all_failed`)
- Blocked-jobs ops (`unblock_job`, `cancel_blocked_job`)
- Orphan-recovery helper for `on_start` callbacks (`retry_orphaned`)

## Test plan

- [ ] `cargo check` / `cargo clippy --all-targets` / `cargo fmt --check`
- [ ] `uv run pytest tests/test_queue_pause.py -v` — 4 new tests pass
- [ ] Full pytest suite — 113 tests pass; ran 12 consecutive iterations to confirm no new flakes after isolating which fixture interactions stress SQLite under load