### PR TITLE
feat(api): expose failed-job retry/discard on the Quebec instance

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -2615,6 +2615,248 @@ impl PyQuebec {
             })
         })
     }
+
+    /// Retry a single failed job by moving it back to the ready queue.
+    ///
+    /// Returns:
+    ///     bool: True if the failed execution was found and retried,
+    ///           False if no failed execution exists for ``job_id``.
+    fn retry_failed(&self, py: Python<'_>, job_id: i64) -> PyResult<bool> {
+        use crate::entities::quebec_failed_executions::Retryable;
+        let table_config = self.ctx.table_config.clone();
+        py.detach(|| {
+            self.rt.block_on(async {
+                let db = self.ctx.get_db().await.map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "Database connection failed: {e}"
+                    ))
+                })?;
+                db.transaction::<_, bool, sea_orm::DbErr>(|txn| {
+                    let table_config = table_config.clone();
+                    Box::pin(async move {
+                        let failed = crate::query_builder::failed_executions::find_by_job_id(
+                            txn,
+                            &table_config,
+                            job_id,
+                        )
+                        .await?;
+                        match failed {
+                            Some(model) => {
+                                model.retry(txn, &table_config).await?;
+                                Ok(true)
+                            }
+                            None => Ok(false),
+                        }
+                    })
+                })
+                .await
+                .map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "Failed to retry job {job_id}: {e}"
+                    ))
+                })
+            })
+        })
+    }
+
+    /// Discard a single failed job: mark it finished and remove the failed
+    /// execution row.
+    ///
+    /// Returns:
+    ///     bool: True if the failed execution was found and discarded,
+    ///           False if no failed execution exists for ``job_id``.
+    fn discard_failed(&self, py: Python<'_>, job_id: i64) -> PyResult<bool> {
+        use crate::entities::quebec_failed_executions::Discardable;
+        let table_config = self.ctx.table_config.clone();
+        py.detach(|| {
+            self.rt.block_on(async {
+                let db = self.ctx.get_db().await.map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "Database connection failed: {e}"
+                    ))
+                })?;
+                db.transaction::<_, bool, sea_orm::DbErr>(|txn| {
+                    let table_config = table_config.clone();
+                    Box::pin(async move {
+                        let failed = crate::query_builder::failed_executions::find_by_job_id(
+                            txn,
+                            &table_config,
+                            job_id,
+                        )
+                        .await?;
+                        match failed {
+                            Some(model) => {
+                                model.discard(txn, &table_config).await?;
+                                Ok(true)
+                            }
+                            None => Ok(false),
+                        }
+                    })
+                })
+                .await
+                .map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "Failed to discard job {job_id}: {e}"
+                    ))
+                })
+            })
+        })
+    }
+
+    /// Bulk retry failed jobs matching the given filters. All filters are
+    /// optional and combined with AND.
+    ///
+    /// Args:
+    ///     class_name: Match exact class name (e.g. ``"MyJob"``).
+    ///     queue_name: Match exact queue name.
+    ///     since: Lower bound on ``failed_executions.created_at``, seconds
+    ///            since epoch.
+    ///     until: Upper bound on ``failed_executions.created_at``, seconds
+    ///            since epoch.
+    ///     error_like: SQL ``LIKE`` pattern against the stored error blob
+    ///            (e.g. ``"%TimeoutError%"``).
+    ///
+    /// Returns:
+    ///     int: Number of failed executions retried.
+    #[pyo3(signature = (class_name=None, queue_name=None, since=None, until=None, error_like=None))]
+    fn retry_all_failed(
+        &self,
+        py: Python<'_>,
+        class_name: Option<String>,
+        queue_name: Option<String>,
+        since: Option<f64>,
+        until: Option<f64>,
+        error_like: Option<String>,
+    ) -> PyResult<u64> {
+        use crate::entities::quebec_failed_executions::{
+            Entity as FailedExecutionEntity, Retryable,
+        };
+        let table_config = self.ctx.table_config.clone();
+        let since = parse_optional_timestamp(since, "since")?;
+        let until = parse_optional_timestamp(until, "until")?;
+        py.detach(|| {
+            self.rt.block_on(async {
+                let db = self.ctx.get_db().await.map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "Database connection failed: {e}"
+                    ))
+                })?;
+                db.transaction::<_, u64, sea_orm::DbErr>(|txn| {
+                    let table_config = table_config.clone();
+                    let class_name = class_name.clone();
+                    let queue_name = queue_name.clone();
+                    let error_like = error_like.clone();
+                    Box::pin(async move {
+                        FailedExecutionEntity
+                            .retry_all(
+                                txn,
+                                &table_config,
+                                class_name.as_deref(),
+                                queue_name.as_deref(),
+                                since,
+                                until,
+                                error_like.as_deref(),
+                            )
+                            .await
+                    })
+                })
+                .await
+                .map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "Failed to retry all failed jobs: {e}"
+                    ))
+                })
+            })
+        })
+    }
+
+    /// Bulk discard failed jobs matching the given filters. Same signature
+    /// as :func:`retry_all_failed`; returns the number of failed executions
+    /// discarded.
+    #[pyo3(signature = (class_name=None, queue_name=None, since=None, until=None, error_like=None))]
+    fn discard_all_failed(
+        &self,
+        py: Python<'_>,
+        class_name: Option<String>,
+        queue_name: Option<String>,
+        since: Option<f64>,
+        until: Option<f64>,
+        error_like: Option<String>,
+    ) -> PyResult<u64> {
+        use crate::entities::quebec_failed_executions::{
+            Discardable, Entity as FailedExecutionEntity,
+        };
+        let table_config = self.ctx.table_config.clone();
+        let since = parse_optional_timestamp(since, "since")?;
+        let until = parse_optional_timestamp(until, "until")?;
+        py.detach(|| {
+            self.rt.block_on(async {
+                let db = self.ctx.get_db().await.map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "Database connection failed: {e}"
+                    ))
+                })?;
+                db.transaction::<_, u64, sea_orm::DbErr>(|txn| {
+                    let table_config = table_config.clone();
+                    let class_name = class_name.clone();
+                    let queue_name = queue_name.clone();
+                    let error_like = error_like.clone();
+                    Box::pin(async move {
+                        FailedExecutionEntity
+                            .discard_all(
+                                txn,
+                                &table_config,
+                                class_name.as_deref(),
+                                queue_name.as_deref(),
+                                since,
+                                until,
+                                error_like.as_deref(),
+                            )
+                            .await
+                    })
+                })
+                .await
+                .map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "Failed to discard all failed jobs: {e}"
+                    ))
+                })
+            })
+        })
+    }
+}
+
+fn parse_optional_timestamp(
+    ts: Option<f64>,
+    field: &str,
+) -> PyResult<Option<chrono::NaiveDateTime>> {
+    let Some(ts) = ts else {
+        return Ok(None);
+    };
+    if ts.is_nan() {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "{field} cannot be NaN"
+        )));
+    }
+    if ts.is_infinite() {
+        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+            "{field} cannot be infinite"
+        )));
+    }
+    // Use floor() so negative fractional timestamps round toward -inf instead
+    // of toward 0 — otherwise -0.5 would land at the epoch instead of half a
+    // second before it, since `as i64` truncates and `as u32` saturates on
+    // negative floats.
+    let floor = ts.floor();
+    let secs = floor as i64;
+    let nsecs = ((ts - floor) * 1_000_000_000.0) as u32;
+    chrono::DateTime::from_timestamp(secs, nsecs)
+        .map(|dt| Some(dt.naive_utc()))
+        .ok_or_else(|| {
+            pyo3::exceptions::PyValueError::new_err(format!(
+                "{field}: timestamp {ts} is out of range"
+            ))
+        })
 }
 
 #[pyclass(name = "ActiveJob", subclass, from_py_object)]

--- a/tests/test_failed_ops.py
+++ b/tests/test_failed_ops.py
@@ -1,0 +1,330 @@
+"""Tests for the failed-job retry/discard Python API on the Quebec instance."""
+
+from __future__ import annotations
+
+import quebec
+from sqlalchemy import text
+
+
+class FailingJob(quebec.ActiveJob):
+    queue_as = "default"
+
+    def perform(self, *args, **kwargs):
+        raise ValueError("boom")
+
+
+class OtherFailingJob(quebec.ActiveJob):
+    queue_as = "default"
+
+    def perform(self, *args, **kwargs):
+        raise RuntimeError("nope")
+
+
+def _enqueue_and_fail(qc, job_cls):
+    """Enqueue a job and run it to completion so it lands in failed_executions."""
+    enqueued = job_cls.perform_later(qc)
+    execution = qc.drain_one()
+    execution.perform()
+    return enqueued
+
+
+def _count(session, prefix, table, where=""):
+    sql = f"SELECT COUNT(*) AS c FROM {prefix}_{table} {where}".strip()
+    return session.execute(text(sql)).scalar()
+
+
+def test_retry_failed_moves_failed_execution_to_ready(qc_with_sqlalchemy) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    qc.register_job(FailingJob)
+    job = _enqueue_and_fail(qc, FailingJob)
+    session.expire_all()
+    assert _count(session, prefix, "failed_executions") == 1
+    assert _count(session, prefix, "ready_executions") == 0
+
+    assert qc.retry_failed(job.id) is True
+
+    session.expire_all()
+    assert _count(session, prefix, "failed_executions") == 0
+    assert (
+        _count(
+            session,
+            prefix,
+            "ready_executions",
+            where=f"WHERE job_id = {job.id}",
+        )
+        == 1
+    )
+
+
+def test_retry_failed_unknown_id_returns_false(qc) -> None:
+    assert qc.retry_failed(999_999) is False
+
+
+def test_discard_failed_marks_finished_and_removes_execution(
+    qc_with_sqlalchemy,
+) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    qc.register_job(FailingJob)
+    job = _enqueue_and_fail(qc, FailingJob)
+    session.expire_all()
+
+    assert qc.discard_failed(job.id) is True
+
+    session.expire_all()
+    assert _count(session, prefix, "failed_executions") == 0
+    finished_at = session.execute(
+        text(f"SELECT finished_at FROM {prefix}_jobs WHERE id = :id"),
+        {"id": job.id},
+    ).scalar()
+    assert finished_at is not None
+
+
+def test_discard_failed_unknown_id_returns_false(qc) -> None:
+    assert qc.discard_failed(999_999) is False
+
+
+def test_retry_all_failed_without_filters_retries_everything(
+    qc_with_sqlalchemy,
+) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    qc.register_job(FailingJob)
+    qc.register_job(OtherFailingJob)
+    _enqueue_and_fail(qc, FailingJob)
+    _enqueue_and_fail(qc, OtherFailingJob)
+    session.expire_all()
+    assert _count(session, prefix, "failed_executions") == 2
+
+    count = qc.retry_all_failed()
+    assert count == 2
+
+    session.expire_all()
+    assert _count(session, prefix, "failed_executions") == 0
+    assert _count(session, prefix, "ready_executions") == 2
+
+
+def test_retry_all_failed_filters_by_class_name(qc_with_sqlalchemy) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    qc.register_job(FailingJob)
+    qc.register_job(OtherFailingJob)
+    _enqueue_and_fail(qc, FailingJob)
+    _enqueue_and_fail(qc, OtherFailingJob)
+    session.expire_all()
+
+    count = qc.retry_all_failed(class_name=FailingJob.__qualname__)
+    assert count == 1
+
+    session.expire_all()
+    # The OtherFailingJob row remains failed; the FailingJob row is back in
+    # ready_executions.
+    assert _count(session, prefix, "failed_executions") == 1
+    assert _count(session, prefix, "ready_executions") == 1
+
+
+def test_discard_all_failed_clears_everything(qc_with_sqlalchemy) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    qc.register_job(FailingJob)
+    _enqueue_and_fail(qc, FailingJob)
+    _enqueue_and_fail(qc, FailingJob)
+    session.expire_all()
+
+    count = qc.discard_all_failed()
+    assert count == 2
+
+    session.expire_all()
+    assert _count(session, prefix, "failed_executions") == 0
+    assert _count(session, prefix, "ready_executions") == 0
+    assert (
+        _count(
+            session,
+            prefix,
+            "jobs",
+            where="WHERE finished_at IS NOT NULL",
+        )
+        == 2
+    )
+
+
+def test_retry_all_failed_rejects_nan_timestamp(qc) -> None:
+    import math
+
+    try:
+        qc.retry_all_failed(since=math.nan)
+    except ValueError as exc:
+        assert "since" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for NaN timestamp")
+
+
+def test_discard_all_failed_filters_by_class_name(qc_with_sqlalchemy) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    qc.register_job(FailingJob)
+    qc.register_job(OtherFailingJob)
+    failing_job = _enqueue_and_fail(qc, FailingJob)
+    _enqueue_and_fail(qc, OtherFailingJob)
+    session.expire_all()
+
+    count = qc.discard_all_failed(class_name=FailingJob.__qualname__)
+    assert count == 1
+
+    session.expire_all()
+    # Only OtherFailingJob's failed_execution remains; FailingJob's row is
+    # gone and the job itself is finished.
+    assert _count(session, prefix, "failed_executions") == 1
+    finished_at = session.execute(
+        text(f"SELECT finished_at FROM {prefix}_jobs WHERE id = :id"),
+        {"id": failing_job.id},
+    ).scalar()
+    assert finished_at is not None
+
+
+def test_retry_all_failed_filters_by_queue_name(qc_with_sqlalchemy) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    class EmailFailingJob(quebec.ActiveJob):
+        queue_as = "emails"
+
+        def perform(self, *args, **kwargs):
+            raise ValueError("boom")
+
+    qc.register_job(FailingJob)
+    qc.register_job(EmailFailingJob)
+    _enqueue_and_fail(qc, FailingJob)
+    _enqueue_and_fail(qc, EmailFailingJob)
+    session.expire_all()
+
+    count = qc.retry_all_failed(queue_name="emails")
+    assert count == 1
+
+    session.expire_all()
+    assert _count(session, prefix, "failed_executions") == 1
+    assert (
+        _count(
+            session,
+            prefix,
+            "ready_executions",
+            where="WHERE queue_name = 'emails'",
+        )
+        == 1
+    )
+
+
+def test_retry_all_failed_filters_by_error_like(qc_with_sqlalchemy) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    qc.register_job(FailingJob)  # raises ValueError
+    qc.register_job(OtherFailingJob)  # raises RuntimeError
+    _enqueue_and_fail(qc, FailingJob)
+    _enqueue_and_fail(qc, OtherFailingJob)
+    session.expire_all()
+
+    # Error blob is JSON; class name appears in the message body.
+    count = qc.retry_all_failed(error_like="%RuntimeError%")
+    assert count == 1
+
+    session.expire_all()
+    # The ValueError-failed row remains, the RuntimeError-failed row is back
+    # in ready_executions.
+    assert _count(session, prefix, "failed_executions") == 1
+    assert _count(session, prefix, "ready_executions") == 1
+
+
+def test_retry_all_failed_filters_by_since_until(qc_with_sqlalchemy) -> None:
+    """``since`` / ``until`` filter on ``failed_executions.created_at``."""
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    qc.register_job(FailingJob)
+    job = _enqueue_and_fail(qc, FailingJob)
+    session.expire_all()
+
+    # Read back the exact created_at the DB stored so we can build a window
+    # around it without flaky clock-skew issues.
+    created_at = session.execute(
+        text(f"SELECT created_at FROM {prefix}_failed_executions WHERE job_id = :id"),
+        {"id": job.id},
+    ).scalar()
+    # SQLite returns ISO 8601; parse to epoch seconds.
+    import datetime
+
+    parsed = datetime.datetime.fromisoformat(str(created_at).replace(" ", "T"))
+    ts = parsed.replace(tzinfo=datetime.timezone.utc).timestamp()
+
+    # Window that strictly precedes the row → no match.
+    assert qc.retry_all_failed(until=ts - 60) == 0
+    session.expire_all()
+    assert _count(session, prefix, "failed_executions") == 1
+
+    # Window that covers the row → matches.
+    assert qc.retry_all_failed(since=ts - 60, until=ts + 60) == 1
+    session.expire_all()
+    assert _count(session, prefix, "failed_executions") == 0
+
+
+def test_parse_timestamp_handles_negative_fractional(qc_with_sqlalchemy) -> None:
+    """Regression: -0.5 must round toward -inf, not toward 0.
+
+    The bug was: ``ts as i64`` truncates toward zero, and ``ts - secs as f64``
+    becomes negative which saturates to 0 when cast to ``u32``. So ``-0.5``
+    landed at the epoch instead of 0.5 s before it.
+
+    A pure end-to-end discriminator: seed a failed_executions row whose
+    ``created_at`` is between the buggy bound (epoch) and the fixed bound
+    (1969-12-31T23:59:59.500). Then ``until=-0.5`` must NOT match the row
+    (fixed) — but it WOULD have matched under the bug (since the row sits
+    before epoch).
+    """
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    # Job + failed_execution at exactly 1969-12-31 23:59:59.750: pre-epoch
+    # but AFTER the fixed -0.5 bound (23:59:59.500). Comparison is on
+    # failed_executions.created_at, which the find_all query bounds via
+    # `>= since` / `<= until`.
+    session.execute(
+        text(
+            f"INSERT INTO {prefix}_jobs "
+            f"(queue_name, class_name, arguments, priority, created_at, updated_at) "
+            f"VALUES ('default', 'X', '[]', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+        )
+    )
+    job_id = session.execute(text("SELECT last_insert_rowid()")).scalar()
+    session.execute(
+        text(
+            f"INSERT INTO {prefix}_failed_executions "
+            f"(job_id, error, created_at) VALUES (:jid, '{{}}', :ts)"
+        ),
+        {"jid": job_id, "ts": "1969-12-31 23:59:59.750"},
+    )
+    session.commit()
+
+    # Buggy parse_optional_timestamp: until=-0.5 → epoch. Row is BEFORE
+    # epoch → row.created_at <= bound → match → returns 1, row deleted.
+    # Fixed: until=-0.5 → 23:59:59.500. Row at 23:59:59.750 is AFTER bound
+    # → no match → returns 0, row stays.
+    assert qc.retry_all_failed(until=-0.5) == 0
+    session.expire_all()
+    assert _count(session, prefix, "failed_executions") == 1


### PR DESCRIPTION
## Summary

Adds four Python methods on the `Quebec` instance for managing failed jobs from application code (mirroring the existing control-plane HTTP actions):

- `retry_failed(job_id)` / `discard_failed(job_id)` — single job, returns `bool`
- `retry_all_failed(class_name, queue_name, since, until, error_like)` / `discard_all_failed(...)` — bulk filtered, returns the count

`since` / `until` are `Optional[float]` seconds-since-epoch. Out-of-range, NaN, or infinite values raise `ValueError`. Fractional negative values round toward `-inf` (the cast path was easy to get subtly wrong — see the regression test).

## Test plan

- [x] `uv run pytest tests/test_failed_ops.py` — 13 new tests cover single + bulk, every filter, unknown-id false return, NaN rejection, negative-fractional timestamp regression
- [x] `cargo clippy --all-targets --all-features`
- [x] `cargo fmt --all -- --check`