### PR TITLE
feat(process): record process revision in heartbeat metadata

### DIFF
--- a/src/control_plane/handlers/workers.rs
+++ b/src/control_plane/handlers/workers.rs
@@ -47,12 +47,18 @@ impl ControlPlane {
                     "alive"
                 };
 
-                let quiet = worker
+                let metadata = worker
                     .metadata
                     .as_deref()
-                    .and_then(|m| serde_json::from_str::<serde_json::Value>(m).ok())
+                    .and_then(|m| serde_json::from_str::<serde_json::Value>(m).ok());
+                let quiet = metadata
+                    .as_ref()
                     .and_then(|v| v.get("quiet").and_then(|q| q.as_bool()))
                     .unwrap_or(false);
+                let revision = metadata
+                    .as_ref()
+                    .and_then(|v| v.get("revision").and_then(|s| s.as_str()))
+                    .map(|s| s.to_string());
 
                 WorkerInfo {
                     id: worker.id,
@@ -64,6 +70,7 @@ impl ControlPlane {
                     seconds_since_heartbeat,
                     status: status.to_string(),
                     quiet,
+                    revision,
                 }
             })
             .collect();

--- a/src/control_plane/models.rs
+++ b/src/control_plane/models.rs
@@ -52,6 +52,7 @@ pub struct WorkerInfo {
     pub seconds_since_heartbeat: i64,
     pub status: String,
     pub quiet: bool,
+    pub revision: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/control_plane/templates/workers.html
+++ b/src/control_plane/templates/workers.html
@@ -38,6 +38,9 @@
           </td>
           <td class="px-6 py-4 whitespace-nowrap">
             <div class="text-sm text-gray-900">{{ worker.pid }}</div>
+            {% if worker.revision %}
+              <div class="text-xs text-gray-500" title="Process revision reported at heartbeat (git SHA when available)">{{ worker.revision }}</div>
+            {% endif %}
           </td>
           <td class="px-6 py-4 whitespace-nowrap">
             <div class="text-sm text-gray-900"><span data-controller="timeago" data-timeago-datetime-value="{{ worker.last_heartbeat_at }}"></span></div>

--- a/src/process.rs
+++ b/src/process.rs
@@ -4,7 +4,8 @@ use crate::error::Result;
 use crate::query_builder;
 use async_trait::async_trait;
 use sea_orm::{DatabaseConnection, DbErr, TransactionTrait};
-use std::sync::Arc;
+use std::process::Command;
+use std::sync::{Arc, OnceLock};
 
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
@@ -12,6 +13,57 @@ use pyo3::prelude::*;
 #[cfg(feature = "python")]
 use tracing::trace;
 use tracing::{info, warn};
+
+/// Short revision identifier of the process at the time the first call
+/// landed. Currently probed once via `git rev-parse --short HEAD` and cached
+/// for the lifetime of the process; returns ``None`` if git is unavailable,
+/// the cwd is not a git repo, or the command fails. Surfaced in the worker's
+/// heartbeat metadata so the control plane can show which revision each
+/// process is running.
+pub fn process_revision() -> Option<&'static str> {
+    static CACHE: OnceLock<Option<String>> = OnceLock::new();
+    CACHE
+        .get_or_init(|| {
+            let output = Command::new("git")
+                .args(["rev-parse", "--short", "HEAD"])
+                .output()
+                .ok()?;
+            if !output.status.success() {
+                return None;
+            }
+            let sha = String::from_utf8(output.stdout).ok()?;
+            let trimmed = sha.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        })
+        .as_deref()
+}
+
+/// Build the JSON metadata blob written to the `processes.metadata` column
+/// each heartbeat. Includes ``revision`` whenever :func:`process_revision`
+/// returns a value, plus ``quiet:true`` when the caller passes ``quiet =
+/// true``. Returns ``None`` when both fields would be absent so the column
+/// stays untouched.
+pub fn build_runtime_metadata(quiet: bool) -> Option<String> {
+    let revision = process_revision();
+    if !quiet && revision.is_none() {
+        return None;
+    }
+    let mut obj = serde_json::Map::new();
+    if quiet {
+        obj.insert("quiet".to_string(), serde_json::Value::Bool(true));
+    }
+    if let Some(s) = revision {
+        obj.insert(
+            "revision".to_string(),
+            serde_json::Value::String(s.to_string()),
+        );
+    }
+    serde_json::to_string(&serde_json::Value::Object(obj)).ok()
+}
 
 #[cfg(feature = "python")]
 pub fn is_running_in_pyo3() -> bool {
@@ -150,11 +202,12 @@ pub trait ProcessTrait: Send + Sync {
         None
     }
 
-    /// Runtime metadata refreshed every heartbeat. Default returns `None`
-    /// (don't touch the metadata column). Override to surface dynamic state
-    /// — e.g. Worker returns `{"quiet":true}` while in quiet mode.
+    /// Runtime metadata refreshed every heartbeat. Default surfaces the
+    /// process's revision (see :func:`process_revision`) when one is
+    /// available; override to merge in role-specific dynamic state — e.g.
+    /// Worker also reports `quiet:true` while in quiet mode.
     fn runtime_metadata(&self) -> Option<String> {
-        None
+        build_runtime_metadata(false)
     }
 
     async fn heartbeat(

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -3151,10 +3151,6 @@ impl ProcessTrait for Worker {
     }
 
     fn runtime_metadata(&self) -> Option<String> {
-        if self.ctx.quiet.is_cancelled() {
-            Some(r#"{"quiet":true}"#.to_string())
-        } else {
-            None
-        }
+        crate::process::build_runtime_metadata(self.ctx.quiet.is_cancelled())
     }
 }


### PR DESCRIPTION
## Summary

Each process now records a short revision identifier in `processes.metadata` on every heartbeat, so the control plane can show which build each worker/dispatcher/scheduler is running. Currently probed via `git rev-parse --short HEAD` (cached for the lifetime of the process) — the JSON field is named `revision` so we're free to source it from somewhere else later (Docker digest, CI build SHA, etc.) without a schema change.

- `process::process_revision()` — cached `OnceLock<Option<String>>`, returns `None` outside a git repo
- `process::build_runtime_metadata(quiet)` — merges `revision` and `quiet` into one JSON blob; returns `None` when both fields are absent (keeps the metadata column untouched in non-VCS environments)
- Default `ProcessTrait::runtime_metadata()` now returns `build_runtime_metadata(false)`; `Worker` overrides to pass its `quiet` flag through
- Workers control-plane page reads `revision` from metadata and renders it below the PID as small gray text

## Test plan

- [x] `cargo clippy --all-targets --all-features`
- [x] `cargo fmt --all -- --check`
- [x] `uv run pytest tests/test_supervisor.py tests/test_lifecycle.py` — 29 tests pass, covering process registration, heartbeat updates, and lifecycle hooks
- [ ] Manually verify the workers page shows the short SHA under each PID (control plane is template-rendered; covered by build success but not by the existing test suite)