### PR TITLE
feat(api): expose blocked/scheduled/recurring ops on the Quebec instance

### DIFF
--- a/src/query_builder.rs
+++ b/src/query_builder.rs
@@ -1850,6 +1850,57 @@ pub mod blocked_executions {
         execute_select(db, query).await
     }
 
+    /// Find a blocked execution by job_id (unique column).
+    pub async fn find_by_job_id<C>(
+        db: &C,
+        table_config: &TableConfig,
+        job_id: i64,
+    ) -> Result<Option<quebec_blocked_executions::Model>, DbErr>
+    where
+        C: ConnectionTrait,
+    {
+        let table = Alias::new(&table_config.blocked_executions);
+        let query = Query::select()
+            .column(Asterisk)
+            .from(table)
+            .and_where(Expr::col(col("job_id")).eq(job_id))
+            .to_owned();
+
+        execute_select_one(db, query).await
+    }
+
+    /// Find all blocked executions matching the optional class_name /
+    /// queue_name filters (same predicates as [`delete_all`]).
+    pub async fn find_all_filtered<C>(
+        db: &C,
+        table_config: &TableConfig,
+        class_name: Option<&str>,
+        queue_name: Option<&str>,
+    ) -> Result<Vec<quebec_blocked_executions::Model>, DbErr>
+    where
+        C: ConnectionTrait,
+    {
+        let table = Alias::new(&table_config.blocked_executions);
+        let jobs_table = Alias::new(&table_config.jobs);
+        let mut select = Query::select();
+        select.column((table.clone(), Asterisk));
+        select.from(table.clone());
+        if class_name.is_some() {
+            select.inner_join(
+                jobs_table.clone(),
+                Expr::col((table.clone(), col("job_id"))).equals((jobs_table.clone(), col("id"))),
+            );
+            if let Some(cn) = class_name {
+                select.and_where(Expr::col((jobs_table, col("class_name"))).eq(cn));
+            }
+        }
+        if let Some(qn) = queue_name {
+            select.and_where(Expr::col((table, col("queue_name"))).eq(qn));
+        }
+
+        execute_select(db, select).await
+    }
+
     /// Delete a blocked execution by job_id
     pub async fn delete_by_job_id<C>(
         db: &C,

--- a/src/types.rs
+++ b/src/types.rs
@@ -2615,6 +2615,330 @@ impl PyQuebec {
             })
         })
     }
+
+    /// Promote a single blocked job back to the ready queue.
+    ///
+    /// Inserts a ready_execution mirroring the blocked row's queue and
+    /// priority, then removes the blocked_execution. This **bypasses the
+    /// concurrency semaphore** — call sites are typically admin recovery
+    /// paths where the user is explicitly overriding the lock; the
+    /// dispatcher's auto-unblock path (`expires_at` sweep) is the one that
+    /// respects the semaphore.
+    ///
+    /// Returns:
+    ///     bool: True if a blocked execution existed and was promoted to
+    ///           ready, False if no blocked execution exists for ``job_id``.
+    fn unblock(&self, py: Python<'_>, job_id: i64) -> PyResult<bool> {
+        let table_config = self.ctx.table_config.clone();
+        py.detach(|| {
+            self.rt.block_on(async {
+                let db = self.ctx.get_db().await.map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "Database connection failed: {e}"
+                    ))
+                })?;
+                db.transaction::<_, bool, sea_orm::DbErr>(|txn| {
+                    let table_config = table_config.clone();
+                    Box::pin(async move {
+                        let blocked = crate::query_builder::blocked_executions::find_by_job_id(
+                            txn,
+                            &table_config,
+                            job_id,
+                        )
+                        .await?;
+                        let Some(blocked) = blocked else {
+                            return Ok(false);
+                        };
+                        crate::query_builder::ready_executions::insert(
+                            txn,
+                            &table_config,
+                            blocked.job_id,
+                            &blocked.queue_name,
+                            blocked.priority,
+                        )
+                        .await?;
+                        crate::query_builder::blocked_executions::delete_by_job_id(
+                            txn,
+                            &table_config,
+                            job_id,
+                        )
+                        .await?;
+                        Ok(true)
+                    })
+                })
+                .await
+                .map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "Failed to unblock job {job_id}: {e}"
+                    ))
+                })
+            })
+        })
+    }
+
+    /// Cancel a blocked job: remove both the blocked_execution and the job
+    /// row entirely.
+    ///
+    /// Mirrors the control-plane ``POST /blocked-jobs/:id/cancel`` action.
+    ///
+    /// Returns:
+    ///     bool: True if a blocked execution existed and was cancelled,
+    ///           False if no blocked execution exists for ``job_id``.
+    fn cancel_blocked(&self, py: Python<'_>, job_id: i64) -> PyResult<bool> {
+        let table_config = self.ctx.table_config.clone();
+        py.detach(|| {
+            self.rt.block_on(async {
+                let db = self.ctx.get_db().await.map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "Database connection failed: {e}"
+                    ))
+                })?;
+                db.transaction::<_, bool, sea_orm::DbErr>(|txn| {
+                    let table_config = table_config.clone();
+                    Box::pin(async move {
+                        let rows = crate::query_builder::blocked_executions::delete_by_job_id(
+                            txn,
+                            &table_config,
+                            job_id,
+                        )
+                        .await?;
+                        if rows == 0 {
+                            return Ok(false);
+                        }
+                        crate::query_builder::jobs::delete_by_id(txn, &table_config, job_id)
+                            .await?;
+                        Ok(true)
+                    })
+                })
+                .await
+                .map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "Failed to cancel blocked job {job_id}: {e}"
+                    ))
+                })
+            })
+        })
+    }
+
+    /// Bulk promote matching blocked jobs back to the ready queue. All
+    /// filters are optional and combined with AND. Like :func:`unblock`,
+    /// this **bypasses the concurrency semaphore**.
+    ///
+    /// Args:
+    ///     class_name: Match exact class name (e.g. ``"MyJob"``).
+    ///     queue_name: Match exact queue name.
+    ///
+    /// Returns:
+    ///     int: Number of blocked executions promoted to ready.
+    #[pyo3(signature = (class_name=None, queue_name=None))]
+    fn unblock_all(
+        &self,
+        py: Python<'_>,
+        class_name: Option<String>,
+        queue_name: Option<String>,
+    ) -> PyResult<u64> {
+        let table_config = self.ctx.table_config.clone();
+        py.detach(|| {
+            self.rt.block_on(async {
+                let db = self.ctx.get_db().await.map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "Database connection failed: {e}"
+                    ))
+                })?;
+                db.transaction::<_, u64, sea_orm::DbErr>(|txn| {
+                    let table_config = table_config.clone();
+                    let class_name = class_name.clone();
+                    let queue_name = queue_name.clone();
+                    Box::pin(async move {
+                        let rows = crate::query_builder::blocked_executions::find_all_filtered(
+                            txn,
+                            &table_config,
+                            class_name.as_deref(),
+                            queue_name.as_deref(),
+                        )
+                        .await?;
+                        if rows.is_empty() {
+                            return Ok(0);
+                        }
+                        let ready_rows: Vec<(i64, &str, i32)> = rows
+                            .iter()
+                            .map(|m| (m.job_id, m.queue_name.as_str(), m.priority))
+                            .collect();
+                        crate::query_builder::ready_executions::insert_all(
+                            txn,
+                            &table_config,
+                            &ready_rows,
+                        )
+                        .await?;
+                        let mut deleted: u64 = 0;
+                        for blocked in &rows {
+                            deleted += crate::query_builder::blocked_executions::delete_by_id(
+                                txn,
+                                &table_config,
+                                blocked.id,
+                            )
+                            .await?;
+                        }
+                        Ok(deleted)
+                    })
+                })
+                .await
+                .map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "Failed to unblock all blocked jobs: {e}"
+                    ))
+                })
+            })
+        })
+    }
+
+    /// Cancel a scheduled job: mark it finished and remove the
+    /// scheduled_execution row.
+    ///
+    /// Mirrors the control-plane ``POST /scheduled-jobs/:id/cancel`` action.
+    ///
+    /// Returns:
+    ///     bool: True if a scheduled execution existed and was cancelled,
+    ///           False if no scheduled execution exists for ``job_id``.
+    fn cancel_scheduled(&self, py: Python<'_>, job_id: i64) -> PyResult<bool> {
+        let table_config = self.ctx.table_config.clone();
+        py.detach(|| {
+            self.rt.block_on(async {
+                let db = self.ctx.get_db().await.map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "Database connection failed: {e}"
+                    ))
+                })?;
+                db.transaction::<_, bool, sea_orm::DbErr>(|txn| {
+                    let table_config = table_config.clone();
+                    Box::pin(async move {
+                        let rows = crate::query_builder::scheduled_executions::delete_by_job_id(
+                            txn,
+                            &table_config,
+                            job_id,
+                        )
+                        .await?;
+                        if rows == 0 {
+                            return Ok(false);
+                        }
+                        crate::query_builder::jobs::mark_finished(txn, &table_config, job_id)
+                            .await?;
+                        Ok(true)
+                    })
+                })
+                .await
+                .map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "Failed to cancel scheduled job {job_id}: {e}"
+                    ))
+                })
+            })
+        })
+    }
+
+    /// Enqueue a recurring task immediately, bypassing its cron schedule.
+    ///
+    /// Mirrors the control-plane ``POST /recurring-jobs/:id/run-now`` action,
+    /// but takes the task ``key`` (the schedule's user-facing name) instead
+    /// of the internal row id. Each call uses ``now()`` for the recurring
+    /// run's ``scheduled_at``, so back-to-back calls each enqueue a fresh
+    /// job.
+    ///
+    /// Returns:
+    ///     bool: True if the task was found and a job was enqueued, False if
+    ///           no recurring task exists with that key. (Also False in the
+    ///           rare case where another scheduler claims the same
+    ///           ``(task_key, scheduled_at)`` slot first.)
+    fn run_recurring_now(&self, py: Python<'_>, key: String) -> PyResult<bool> {
+        use crate::context::ScheduledEntry;
+        use crate::scheduler::enqueue_job;
+        use sea_orm::{ConnectionTrait, Statement, Value as DbValue};
+
+        let ctx = self.ctx.clone();
+        let table_config = self.ctx.table_config.clone();
+        py.detach(|| {
+            self.rt.block_on(async {
+                let db = ctx.get_db().await.map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "Database connection failed: {e}"
+                    ))
+                })?;
+                let db_ref = db.as_ref();
+                let backend = db_ref.get_database_backend();
+                let p1 = match backend {
+                    DbBackend::Postgres => "$1",
+                    DbBackend::MySql | DbBackend::Sqlite => "?",
+                };
+
+                let sql = format!(
+                    "SELECT class_name, queue_name, priority, arguments FROM {} WHERE key = {}",
+                    table_config.recurring_tasks, p1
+                );
+                let row = db_ref
+                    .query_one(Statement::from_sql_and_values(
+                        backend,
+                        &sql,
+                        [DbValue::from(key.clone())],
+                    ))
+                    .await
+                    .map_err(|e| {
+                        pyo3::exceptions::PyRuntimeError::new_err(format!(
+                            "Failed to look up recurring task {key}: {e}"
+                        ))
+                    })?;
+
+                let Some(row) = row else {
+                    return Ok(false);
+                };
+
+                let class_name: String = row.try_get("", "class_name").unwrap_or_default();
+                let queue_name: Option<String> = row.try_get("", "queue_name").ok();
+                let priority: Option<i32> = row.try_get("", "priority").ok();
+                let arguments: Option<String> = row.try_get("", "arguments").ok();
+
+                let args = arguments
+                    .as_ref()
+                    .and_then(|s| serde_json::from_str::<Vec<serde_json::Value>>(s).ok())
+                    .map(|v| {
+                        v.into_iter()
+                            .map(|j| serde_yaml::to_value(&j).unwrap_or(serde_yaml::Value::Null))
+                            .collect()
+                    });
+
+                let entry = ScheduledEntry {
+                    key: Some(key.clone()),
+                    class: class_name,
+                    queue: queue_name,
+                    priority,
+                    args,
+                    schedule: String::new(),
+                };
+
+                let now = chrono::Utc::now().naive_utc();
+                let enqueued_queue = db_ref
+                    .transaction::<_, Option<String>, sea_orm::DbErr>(|txn| {
+                        let entry = entry.clone();
+                        let ctx = ctx.clone();
+                        Box::pin(async move { enqueue_job(&ctx, txn, entry, now).await })
+                    })
+                    .await
+                    .map_err(|e| {
+                        pyo3::exceptions::PyRuntimeError::new_err(format!(
+                            "Failed to enqueue recurring task {key}: {e}"
+                        ))
+                    })?;
+
+                if let Some(ref queue) = enqueued_queue {
+                    if crate::notify::should_send_notify(&ctx, queue) {
+                        let _ = crate::notify::NotifyManager::send_notify(&ctx.name, db_ref, queue)
+                            .await;
+                    }
+                }
+
+                Ok(enqueued_queue.is_some())
+            })
+        })
+    }
 }
 
 #[pyclass(name = "ActiveJob", subclass, from_py_object)]

--- a/tests/test_execution_ops.py
+++ b/tests/test_execution_ops.py
@@ -1,0 +1,315 @@
+"""Tests for the blocked/scheduled/recurring Python API on the Quebec instance."""
+
+from __future__ import annotations
+
+import quebec
+from sqlalchemy import text
+
+
+def _count(session, prefix, table, where=""):
+    sql = f"SELECT COUNT(*) AS c FROM {prefix}_{table} {where}".strip()
+    return session.execute(text(sql)).scalar()
+
+
+class ExclusiveJob(quebec.ActiveJob):
+    queue_as = "default"
+    concurrency_limit = 1
+
+    @staticmethod
+    def concurrency_key(*args, **kwargs) -> str:
+        return "exclusive-resource"
+
+    def perform(self, *args, **kwargs):
+        pass
+
+
+class OtherExclusiveJob(quebec.ActiveJob):
+    queue_as = "default"
+    concurrency_limit = 1
+
+    @staticmethod
+    def concurrency_key(*args, **kwargs) -> str:
+        return "other-exclusive"
+
+    def perform(self, *args, **kwargs):
+        pass
+
+
+def _enqueue_blocked_pair(qc, job_cls):
+    """Enqueue two of the same concurrency-keyed job; second lands in blocked."""
+    first = job_cls.perform_later(qc)
+    second = job_cls.perform_later(qc)
+    return first, second
+
+
+def test_unblock_promotes_blocked_execution_to_ready(qc_with_sqlalchemy) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    qc.register_job(ExclusiveJob)
+    _first, blocked = _enqueue_blocked_pair(qc, ExclusiveJob)
+    session.expire_all()
+    assert _count(session, prefix, "blocked_executions") == 1
+
+    assert qc.unblock(blocked.id) is True
+
+    session.expire_all()
+    # blocked_execution gone; job row stays and is now in ready_executions
+    # with the same queue/priority — i.e. actually unblocked, not orphaned.
+    assert _count(session, prefix, "blocked_executions") == 0
+    assert _count(session, prefix, "jobs", where=f"WHERE id = {blocked.id}") == 1
+    assert (
+        _count(
+            session,
+            prefix,
+            "ready_executions",
+            where=f"WHERE job_id = {blocked.id}",
+        )
+        == 1
+    )
+
+
+def test_unblock_unknown_id_returns_false(qc) -> None:
+    assert qc.unblock(999_999) is False
+
+
+def test_cancel_blocked_removes_blocked_execution_and_job(qc_with_sqlalchemy) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    qc.register_job(ExclusiveJob)
+    _first, blocked = _enqueue_blocked_pair(qc, ExclusiveJob)
+    session.expire_all()
+
+    assert qc.cancel_blocked(blocked.id) is True
+
+    session.expire_all()
+    assert _count(session, prefix, "blocked_executions") == 0
+    assert _count(session, prefix, "jobs", where=f"WHERE id = {blocked.id}") == 0
+
+
+def test_cancel_blocked_unknown_id_returns_false(qc) -> None:
+    assert qc.cancel_blocked(999_999) is False
+
+
+def test_unblock_all_without_filters_promotes_everything(qc_with_sqlalchemy) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    qc.register_job(ExclusiveJob)
+    qc.register_job(OtherExclusiveJob)
+    _enqueue_blocked_pair(qc, ExclusiveJob)
+    _enqueue_blocked_pair(qc, OtherExclusiveJob)
+    session.expire_all()
+    assert _count(session, prefix, "blocked_executions") == 2
+
+    count = qc.unblock_all()
+    assert count == 2
+
+    session.expire_all()
+    assert _count(session, prefix, "blocked_executions") == 0
+    # Each promoted blocked row produced a fresh ready_executions row.
+    # The first job per concurrency key already had a ready row from the
+    # initial enqueue, so the table now holds 2 (initial) + 2 (promoted) = 4.
+    assert _count(session, prefix, "ready_executions") == 4
+
+
+def test_unblock_all_filters_by_class_name(qc_with_sqlalchemy) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    qc.register_job(ExclusiveJob)
+    qc.register_job(OtherExclusiveJob)
+    _enqueue_blocked_pair(qc, ExclusiveJob)
+    _enqueue_blocked_pair(qc, OtherExclusiveJob)
+    session.expire_all()
+
+    count = qc.unblock_all(class_name=ExclusiveJob.__qualname__)
+    assert count == 1
+
+    session.expire_all()
+    # OtherExclusiveJob's blocked row remains
+    assert _count(session, prefix, "blocked_executions") == 1
+    # The promoted ExclusiveJob row now sits in ready_executions alongside
+    # the initial ready row for the first ExclusiveJob enqueue.
+    assert (
+        _count(
+            session,
+            prefix,
+            "ready_executions",
+            where="WHERE queue_name = 'default'",
+        )
+        == 3
+    )
+
+
+def test_unblock_all_filters_by_queue_name(qc_with_sqlalchemy) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    class EmailExclusiveJob(quebec.ActiveJob):
+        queue_as = "emails"
+        concurrency_limit = 1
+
+        @staticmethod
+        def concurrency_key(*args, **kwargs) -> str:
+            return "email-exclusive"
+
+        def perform(self, *args, **kwargs):
+            pass
+
+    qc.register_job(ExclusiveJob)
+    qc.register_job(EmailExclusiveJob)
+    _enqueue_blocked_pair(qc, ExclusiveJob)
+    _enqueue_blocked_pair(qc, EmailExclusiveJob)
+    session.expire_all()
+    assert _count(session, prefix, "blocked_executions") == 2
+
+    count = qc.unblock_all(queue_name="emails")
+    assert count == 1
+
+    session.expire_all()
+    # default-queue row remains
+    assert (
+        _count(
+            session,
+            prefix,
+            "blocked_executions",
+            where="WHERE queue_name = 'default'",
+        )
+        == 1
+    )
+
+
+class DelayableJob(quebec.BaseClass):
+    queue_as = "default"
+
+    def perform(self, *args, **kwargs):
+        pass
+
+
+def test_cancel_scheduled_marks_finished_and_removes_execution(
+    qc_with_sqlalchemy,
+) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    qc.register_job(DelayableJob)
+    job = DelayableJob.set(wait=3600).perform_later(qc)
+    session.expire_all()
+    assert _count(session, prefix, "scheduled_executions") == 1
+
+    assert qc.cancel_scheduled(job.id) is True
+
+    session.expire_all()
+    assert _count(session, prefix, "scheduled_executions") == 0
+    finished_at = session.execute(
+        text(f"SELECT finished_at FROM {prefix}_jobs WHERE id = :id"),
+        {"id": job.id},
+    ).scalar()
+    assert finished_at is not None
+
+
+def test_cancel_scheduled_unknown_id_returns_false(qc) -> None:
+    assert qc.cancel_scheduled(999_999) is False
+
+
+class RecurringDummyJob(quebec.ActiveJob):
+    queue_as = "default"
+
+    def perform(self, *args, **kwargs):
+        pass
+
+
+def _insert_recurring_task(session, prefix, key: str, class_name: str) -> None:
+    """Insert a recurring_tasks row directly so we don't have to spin up the scheduler."""
+    session.execute(
+        text(
+            f"INSERT INTO {prefix}_recurring_tasks "
+            f"(key, schedule, class_name, queue_name, priority, static, "
+            f"arguments, created_at, updated_at) VALUES "
+            f"(:key, :schedule, :class_name, :queue_name, :priority, :static, "
+            f":arguments, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+        ),
+        {
+            "key": key,
+            "schedule": "every minute",
+            "class_name": class_name,
+            "queue_name": "default",
+            "priority": 0,
+            "static": True,
+            "arguments": "[]",
+        },
+    )
+    session.commit()
+
+
+def test_run_recurring_now_enqueues_job(qc_with_sqlalchemy) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    qc.register_job(RecurringDummyJob)
+    _insert_recurring_task(
+        session, prefix, key="daily-cleanup", class_name=RecurringDummyJob.__qualname__
+    )
+
+    assert qc.run_recurring_now("daily-cleanup") is True
+
+    session.expire_all()
+    # One job created plus one recurring_executions row recording the run.
+    assert (
+        _count(
+            session,
+            prefix,
+            "jobs",
+            where=f"WHERE class_name = '{RecurringDummyJob.__qualname__}'",
+        )
+        == 1
+    )
+    assert (
+        _count(
+            session,
+            prefix,
+            "recurring_executions",
+            where="WHERE task_key = 'daily-cleanup'",
+        )
+        == 1
+    )
+
+
+def test_run_recurring_now_unknown_key_returns_false(qc) -> None:
+    assert qc.run_recurring_now("does-not-exist") is False
+
+
+def test_run_recurring_now_consecutive_calls_both_enqueue(qc_with_sqlalchemy) -> None:
+    """Each manual run uses ``now()`` for ``scheduled_at`` so it gets its own
+    recurring_executions row — back-to-back calls each enqueue a fresh job."""
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    qc.register_job(RecurringDummyJob)
+    _insert_recurring_task(
+        session, prefix, key="manual-runs", class_name=RecurringDummyJob.__qualname__
+    )
+
+    assert qc.run_recurring_now("manual-runs") is True
+    assert qc.run_recurring_now("manual-runs") is True
+
+    session.expire_all()
+    assert (
+        _count(
+            session,
+            prefix,
+            "recurring_executions",
+            where="WHERE task_key = 'manual-runs'",
+        )
+        == 2
+    )


### PR DESCRIPTION
## Summary

Rounds out the Python-side mirror of the control-plane mutating actions. After #62 (queue pause/resume) and #63 (failed retry/discard), the remaining gaps were blocked jobs, scheduled jobs, and recurring tasks:

- `unblock(job_id)` / `unblock_all(class_name=None, queue_name=None)` — promote blocked job(s) back to `ready_executions`. **Bypasses the concurrency semaphore** — this is an admin override path; the dispatcher's `expires_at` sweep is the one that respects the semaphore.
- `cancel_blocked(job_id)` — remove both the blocked_execution and the job row entirely.
- `cancel_scheduled(job_id)` — mark the job finished and drop its scheduled_execution row.
- `run_recurring_now(key)` — enqueue a recurring task immediately, addressed by its user-facing `key` (rather than the internal `recurring_tasks.id` the HTTP route uses).

Notes:
- `unblock` / `unblock_all` diverge from the existing HTTP handler (`POST /blocked-jobs/:id/unblock`), which currently only deletes the blocked_execution row and leaves the job orphaned — the Python API does the right thing (insert ready, then delete blocked). The HTTP handler can be aligned in a follow-up.
- Added two new query-builder helpers — `blocked_executions::find_by_job_id` and `find_all_filtered` — to support the promote-then-delete shape.
- `run_recurring_now`'s SQL placeholder is backend-dispatched (`$1` for Postgres, `?` for SQLite/MySQL) to match the convention already in `src/dispatcher.rs:93-95`.

## Test plan

- [x] `cargo clippy --all-targets --all-features`
- [x] `cargo fmt --all -- --check`
- [x] `uv run pytest tests/test_execution_ops.py -v` — 12 tests cover happy path + unknown-id false return + filtered bulk + scheduled cancel + recurring run-now (unknown key + back-to-back calls)
- [x] `uv run ruff check tests/test_execution_ops.py`