### PR TITLE
fix(semaphore): allow re-acquire after release with concurrency_limit=1

### DIFF
--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -105,17 +105,21 @@ impl Dispatcher {
                               vec![now.into(), batch_size.into()],
                           )).await?;
 
-                          if expired_keys_result.is_empty() {
-                              trace!("No expired concurrency keys found to unblock");
-                          } else {
-                              info!("Found {} expired concurrency keys to unblock", expired_keys_result.len());
-                          }
-
                           // Collect expired concurrency keys
                           let expired_keys: Vec<String> = expired_keys_result
                               .iter()
                               .filter_map(|row| row.try_get::<String>("", "concurrency_key").ok())
                               .collect();
+
+                          if expired_keys.is_empty() {
+                              trace!("No expired concurrency keys found to unblock");
+                          } else {
+                              info!(
+                                  "Found {} expired concurrency keys to unblock: {:?}",
+                                  expired_keys.len(),
+                                  expired_keys
+                              );
+                          }
 
                           // Pre-filter: batch check semaphores (like Solid Queue's releasable)
                           // Keys without semaphore OR with value > 0 are releasable

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -59,12 +59,14 @@ where
         return Ok(true);
     }
 
-    // Semaphore already exists, try to decrement if value > 0 (attempt_decrement)
-    // But first check the limit == 1 case (check_limit_or_decrement)
-    if concurrency_limit == 1 {
-        return Ok(false); // limit == 1, don't try to decrement
-    }
-
+    // Semaphore already exists, try to decrement if value > 0. The `WHERE
+    // value > 0` predicate naturally covers limit == 1 too: a freed slot has
+    // value = limit (= 1), which satisfies > 0, so decrement-to-0 atomically
+    // re-acquires. The old `if concurrency_limit == 1 { return false; }`
+    // short-circuit here mistook a row's existence for "held" and forced
+    // callers to wait for `expires_at` to elapse before the dispatcher's
+    // delete_expired sweep cleared the row — turning concurrency_duration
+    // into a minimum cooldown rather than a crash-safety TTL.
     let decrement_sql = match db.get_database_backend() {
         DatabaseBackend::Postgres => {
             format!(

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -98,3 +98,66 @@ def test_discard_on_conflict_discards_second_job(qc_with_sqlalchemy, db_assert) 
     assert db_assert.count_blocked_executions() == 0
     # Discarded job should be finished (not failed)
     assert db_assert.count_failed_executions() == 0
+
+
+def test_blocked_job_promoted_immediately_after_release_with_limit_one(
+    qc_with_sqlalchemy, db_assert
+) -> None:
+    """Regression: with concurrency_limit=1, completing job A must release the
+    semaphore in a way that lets the blocked job B be promoted to ready right
+    away — NOT after ``concurrency_duration`` seconds.
+
+    Previously ``acquire_semaphore`` short-circuited to ``false`` whenever the
+    semaphore row existed with ``concurrency_limit == 1``, so the row had to
+    be physically deleted by the dispatcher's expired-key sweep before any
+    new acquire could succeed. That turned ``concurrency_duration`` into a
+    minimum cooldown instead of a crash-safety TTL.
+    """
+    qc = qc_with_sqlalchemy["qc"]
+
+    ConcurrentJob.calls = []
+    qc.register_job(ConcurrentJob)
+
+    # A → ready, B → blocked.
+    ConcurrentJob.perform_later(qc, 1)
+    ConcurrentJob.perform_later(qc, 2)
+    assert db_assert.count_ready_executions() == 1
+    assert db_assert.count_blocked_executions() == 1
+
+    # Drain A. Its release path (`release_next_blocked_job`) must promote B.
+    execution_a = qc.drain_one()
+    execution_a.perform()
+
+    # B is now claimable — without waiting on concurrency_duration.
+    assert db_assert.count_blocked_executions() == 0
+    assert db_assert.count_ready_executions() == 1
+
+    execution_b = qc.drain_one()
+    execution_b.perform()
+    assert ConcurrentJob.calls == [1, 2]
+
+
+def test_discard_mode_can_reenqueue_after_release_with_limit_one(
+    qc_with_sqlalchemy, db_assert
+) -> None:
+    """Regression: with concurrency_limit=1 + Discard mode, a chained
+    ``perform_later`` issued right after the job finishes must land in ready,
+    not be discarded. Previously the freed semaphore row was still readable
+    by the ``limit == 1`` short-circuit in ``acquire_semaphore``, forcing
+    every re-enqueue within ``concurrency_duration`` seconds to be discarded.
+    """
+    qc = qc_with_sqlalchemy["qc"]
+
+    qc.register_job(DiscardOnConflictJob)
+
+    DiscardOnConflictJob.perform_later(qc, 1)
+    execution = qc.drain_one()
+    execution.perform()
+
+    # Job A is finished and the semaphore is released. A fresh perform_later
+    # for the same concurrency_key must acquire and reach ready_executions.
+    DiscardOnConflictJob.perform_later(qc, 2)
+    assert db_assert.count_ready_executions() == 1
+    assert db_assert.count_blocked_executions() == 0
+    # The new job is NOT marked finished (i.e. NOT discarded).
+    assert db_assert.count_jobs() == 2


### PR DESCRIPTION
## Summary

`concurrency_limit = 1` was a near-singleton trap: after a job finished, the freed semaphore slot could not be re-acquired until the `expires_at` lease expired and the dispatcher's `delete_expired` sweep physically dropped the row. In practice this turned `concurrency_duration` into a minimum cooldown between runs.

Observed symptom (real production log, 5-min cron + default 300s duration):

```
15:35:27.163 acquire success → row created, expires_at = 15:40:27
15:35:27.374 job done       → release_semaphore (value 0→1), expires_at bumped to 15:40:27.374
15:35:27.386 chain enqueue  → row exists, limit==1 short-circuit → DISCARDED
15:40:00.059 scheduler tick → row still exists (15:40:00 < 15:40:27) → DISCARDED
~15:40:27.4   dispatcher.delete_expired → row finally removed
15:45:00.057 scheduler tick → INSERT succeeds → acquire success
```

Net: a 5-minute cron task with `concurrency_duration=300` could only run once every **10 minutes**, with half the cron ticks discarded.

## Root cause

`src/semaphore.rs:62-66`:

```rust
// Semaphore already exists, try to decrement if value > 0 (attempt_decrement)
// But first check the limit == 1 case (check_limit_or_decrement)
if concurrency_limit == 1 {
    return Ok(false); // limit == 1, don't try to decrement
}
```

This was ported from Solid Queue's `Semaphore::Proxy#check_limit_or_decrement`, but **Solid Queue only invokes that branch as the race-loser fallback of `attempt_creation`** — i.e. when a concurrent caller has just won the INSERT and the row is guaranteed to have `value = limit - 1 = 0` (occupied for limit=1).

Solid Queue's main "row already exists" path goes through `Semaphore.wait`'s `find_by` branch and runs `attempt_decrement` directly (`UPDATE WHERE value > 0`), which works fine for limit=1: a freed row has value=1, satisfies `> 0`, and decrement brings it back to 0.

Quebec collapsed Solid Queue's two `wait` branches into a single `INSERT-OR-NOTHING + fallback UPDATE`. After INSERT fails, the right move is the same `UPDATE WHERE value > 0` Quebec already has below the removed guard. The early return was just misplaced.

## Fix

Drop the `limit == 1` short-circuit in `src/semaphore.rs`. The downstream `UPDATE ... WHERE value > 0` correctly handles all states for any limit:

| State | Quebec (after fix) | Solid Queue `Semaphore.wait` |
|---|---|---|
| no row | INSERT succeeds → true | `attempt_creation` succeeds → true |
| row exists, value=1 (free) | INSERT fails → UPDATE matches → true | `find_by` → `value > 0` → `attempt_decrement` → true |
| row exists, value=0 (held) | INSERT fails → UPDATE no match → false | `find_by` → `value > 0` false → false |
| race-loser, value=0 (limit=1) | INSERT fails → UPDATE no match → false | `check_limit_or_decrement` → false |
| race-loser, value>0 (limit>1) | INSERT fails → UPDATE matches → true | `check_limit_or_decrement` → `attempt_decrement` → true |

All five paths now match Solid Queue.

## Drive-by

Second commit (`chore(dispatcher): include keys in expired-unblock log`) makes the `Found N expired concurrency keys to unblock` log actually print which keys. With this bug present the log spammed every poll interval because the failed re-acquire left the blocked execution in place to be picked up next tick; the message was unactionable without the keys.

## Test plan

- [x] `cargo clippy --all-targets --all-features` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `uv run pytest tests/test_concurrency.py -v` — 6/6 pass, including 2 new regression tests:
  - `test_blocked_job_promoted_immediately_after_release_with_limit_one` — Block mode: B is in ready_executions and claimable right after A's `release_semaphore`, no need to wait `concurrency_duration`
  - `test_discard_mode_can_reenqueue_after_release_with_limit_one` — Discard mode: chained `perform_later` after job completion lands in ready, not discarded