### PR TITLE
feat(experimental): per-queue global concurrency limit

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -3,9 +3,7 @@ use croner::Cron;
 use english_to_cron::str_cron_syntax;
 use sea_orm::{ConnectOptions, Database, DatabaseConnection, DbErr};
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "python")]
-use std::collections::HashMap;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
@@ -345,6 +343,11 @@ pub struct AppContext {
     #[cfg(feature = "python")]
     pub runnables: Arc<RwLock<HashMap<String, crate::worker::Runnable>>>, // Store job class runnables
     pub concurrency_enabled: Arc<RwLock<HashSet<String>>>, // Store job classes with concurrency control enabled
+    /// EXPERIMENTAL: per-queue concurrency limits enforced at worker
+    /// claim time by acquiring a `queue:<name>` semaphore. Naming and
+    /// semantics may change. Use to isolate misbehaving queues during
+    /// remediation. Queues not present here are unlimited.
+    pub experimental_queue_concurrency: HashMap<String, i32>,
     pub runtime_handle: Option<Handle>,
     pub table_config: TableConfig, // Dynamic table name configuration
     /// Optional notifier for idle worker threads - when set, signals main loop to poll for new jobs
@@ -564,6 +567,39 @@ impl AppContext {
             if let Some(v) = get_u64("worker_threads") {
                 ctx.worker_threads = v;
             }
+            // EXPERIMENTAL: per-queue concurrency overrides via a Python dict
+            // {queue_name: limit}. Invalid entries are skipped with a warning;
+            // the whole field is opt-in so leaving it unset preserves prior
+            // behaviour.
+            if let Some(val) = options.get("experimental_queue_concurrency") {
+                match val.extract::<HashMap<String, i32>>(py) {
+                    Ok(map) => {
+                        let mut accepted: HashMap<String, i32> = HashMap::new();
+                        for (k, v) in map {
+                            let trimmed = k.trim();
+                            if trimmed.is_empty() {
+                                warn!("experimental_queue_concurrency: skipping empty queue name");
+                                continue;
+                            }
+                            if v <= 0 {
+                                warn!(
+                                    "experimental_queue_concurrency['{}']={} ignored \
+                                     (limit must be > 0; use no entry to mean unlimited)",
+                                    trimmed, v
+                                );
+                                continue;
+                            }
+                            accepted.insert(trimmed.to_string(), v);
+                        }
+                        ctx.experimental_queue_concurrency = accepted;
+                    }
+                    Err(_) => warn!(
+                        "Config 'experimental_queue_concurrency': expected dict[str, int], \
+                         got {:?}",
+                        val.bind(py).get_type()
+                    ),
+                }
+            }
             // force_override_queue: kwargs win over the env var the Default
             // already read. Empty / whitespace-only strings clear the override
             // so callers can explicitly opt out from Python even when
@@ -675,6 +711,7 @@ impl AppContext {
             #[cfg(feature = "python")]
             runnables: Arc::new(RwLock::new(HashMap::new())),
             concurrency_enabled: Arc::new(RwLock::new(HashSet::new())),
+            experimental_queue_concurrency: HashMap::new(),
             runtime_handle: None,
             table_config: TableConfig::default(),
             idle_notify: Arc::new(RwLock::new(None)),
@@ -763,6 +800,7 @@ impl AppContext {
             #[cfg(feature = "python")]
             runnables: self.runnables.clone(),
             concurrency_enabled: self.concurrency_enabled.clone(),
+            experimental_queue_concurrency: self.experimental_queue_concurrency.clone(),
             runtime_handle: Some(runtime_handle),
             table_config: self.table_config.clone(),
             idle_notify: Arc::new(RwLock::new(None)),

--- a/src/control_plane/handlers/queues.rs
+++ b/src/control_plane/handlers/queues.rs
@@ -80,6 +80,7 @@ impl ControlPlane {
                 } else {
                     "active".to_string()
                 },
+                concurrency_limit: state.ctx.experimental_queue_concurrency.get(&name).copied(),
                 name,
                 jobs_count: count,
             })

--- a/src/control_plane/models.rs
+++ b/src/control_plane/models.rs
@@ -8,6 +8,12 @@ pub struct QueueInfo {
     pub slug: String,
     pub jobs_count: i64,
     pub status: String,
+    /// EXPERIMENTAL queue-level concurrency limit (from
+    /// `experimental_queue_concurrency`). `None` means no global cap is in
+    /// effect for this queue. Surfaced in the queues page so operators can
+    /// see at a glance which queues are currently throttled and to what
+    /// level.
+    pub concurrency_limit: Option<i32>,
 }
 
 /// Encode a queue name into an HTML-id-safe slug with **no collisions**.

--- a/src/control_plane/templates/queues.html
+++ b/src/control_plane/templates/queues.html
@@ -62,6 +62,15 @@
       <tr>
         <td class="px-6 py-4 whitespace-nowrap">
           <a href="{{ base_path }}/queues/{{ queue.name }}" data-turbo-action="advance" class="text-sm font-medium text-gray-900 hover:underline">{{ queue.name }}</a>
+          {% if queue.concurrency_limit %}
+            <span class="ml-1.5 inline-flex items-center gap-1 rounded-full border border-gray-200 px-2 py-0.5 text-xs font-mono text-gray-600" title="Experimental: global concurrency limit for this queue (experimental_queue_concurrency)">
+              <svg class="h-3 w-3" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
+                <path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
+              </svg>
+              limit {{ queue.concurrency_limit }}
+            </span>
+          {% endif %}
         </td>
         <td class="px-6 py-4 whitespace-nowrap" id="queue-count-{{ queue.slug }}">
           <div class="text-sm text-gray-900">{{ queue.jobs_count }}</div>

--- a/src/control_plane/utils.rs
+++ b/src/control_plane/utils.rs
@@ -161,6 +161,7 @@ impl ControlPlane {
                 } else {
                     "active".to_string()
                 },
+                concurrency_limit: self.ctx.experimental_queue_concurrency.get(&name).copied(),
                 name,
             })
             .collect();

--- a/src/types.rs
+++ b/src/types.rs
@@ -921,6 +921,52 @@ impl PyQuebec {
         })
     }
 
+    /// Drain up to ``batch_size`` ready jobs via the same batch-claim path
+    /// the real worker uses internally. Exposes ``Worker::claim_jobs`` so
+    /// tests can verify ``experimental_queue_concurrency`` partitioning
+    /// behaviour deterministically. Returns the freshly-claimed Execution
+    /// list (jobs are now in ``claimed_executions``; perform them via
+    /// :meth:`Execution.perform` or release them via worker shutdown).
+    fn drain_batch(&self, py: Python<'_>, batch_size: u64) -> PyResult<Vec<Execution>> {
+        let worker = self.worker.clone();
+        let ctx = self.ctx.clone();
+
+        py.detach(|| {
+            self.rt.block_on(async move {
+                let claimed = worker.claim_jobs(batch_size).await.map_err(|e| {
+                    PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
+                        "claim_jobs failed: {e}"
+                    ))
+                })?;
+
+                let db = ctx.get_db().await.map_err(|e| {
+                    PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string())
+                })?;
+                let mut out: Vec<Execution> = Vec::with_capacity(claimed.len());
+                for c in claimed {
+                    let job = crate::query_builder::jobs::find_by_id(
+                        db.as_ref(),
+                        &ctx.table_config,
+                        c.job_id,
+                    )
+                    .await
+                    .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?
+                    .ok_or_else(|| {
+                        PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Job record not found")
+                    })?;
+                    let runnable = Python::attach(|_py| ctx.get_runnable(&job.class_name))
+                        .map_err(|e| {
+                            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
+                                "Job handler not found: {e}"
+                            ))
+                        })?;
+                    out.push(Execution::new(ctx.clone(), c, job, runnable));
+                }
+                Ok(out)
+            })
+        })
+    }
+
     async fn post_job(&self) -> crate::error::Result<()> {
         let _ = self.rt.spawn(async move {
             tokio::time::sleep(Duration::from_secs(5)).await;

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1171,6 +1171,10 @@ impl Execution {
             .runnable
             .concurrency_duration
             .map(|s| chrono::Duration::seconds(s as i64));
+        // EXPERIMENTAL queue-level concurrency: release is delegated to
+        // `Worker::release_queue_slot` which looks up the limit from `ctx`
+        // at call time.
+        let queue_name = job.queue_name.clone();
         let table_config_orig = self.ctx.table_config.clone();
         let ctx = self.ctx.clone();
 
@@ -1206,9 +1210,11 @@ impl Execution {
             let concurrency_key = concurrency_key.clone();
             let ctx = ctx.clone();
             let claimed = claimed.clone();
+            let queue_name = queue_name.clone();
 
             transaction_result = db
                 .transaction::<_, bool, DbErr>(|txn| {
+                    let queue_name = queue_name.clone();
                     Box::pin(async move {
                         if let Some((scheduled_at, ref arguments)) = retry_job_data {
                             Self::schedule_retry_job(
@@ -1294,6 +1300,13 @@ impl Execution {
                                     .ok();
                             }
                         }
+
+                        // EXPERIMENTAL: release queue-level semaphore
+                        // acquired at claim time. No release_next_blocked
+                        // counterpart because queue-throttled jobs stay in
+                        // ready, not blocked — the next worker poll picks
+                        // them up.
+                        Worker::release_queue_slot(&ctx, txn, &table_config, &queue_name).await?;
 
                         Ok(failed)
                     })
@@ -1909,10 +1922,15 @@ impl Worker {
         let queue_selector = self.ctx.worker_queues.clone();
         let use_skip_locked = self.ctx.use_skip_locked;
         let process_id = *self.process_id.lock().await;
+        // EXPERIMENTAL: queue-level concurrency overrides — acquired here at
+        // claim time via `try_acquire_queue_slot`, released by
+        // `after_executed` (or the cleanup paths) via `release_queue_slot`.
+        let ctx = self.ctx.clone();
 
         let job = db
             .transaction::<_, quebec_claimed_executions::Model, DbErr>(|txn| {
                 let table_config = table_config.clone();
+                let ctx = ctx.clone();
                 Box::pin(async move {
                     let paused_queues =
                         query_builder::pauses::find_all_queue_names(txn, &table_config).await?;
@@ -1925,24 +1943,59 @@ impl Worker {
                         .as_ref()
                         .map_or_else(|| vec![(false, "*".to_string())], |q| q.ordered_patterns());
 
-                    // Helper macro to avoid duplicating find + claim logic
+                    // Helper macro to avoid duplicating find + claim logic.
+                    // When `experimental_queue_concurrency` is empty (the
+                    // common case), skip the per-record acquire path
+                    // entirely so feature-off workers pay zero overhead
+                    // beyond a single `is_empty()` check per claim.
+                    let queue_concurrency_enabled = !ctx.experimental_queue_concurrency.is_empty();
+
+                    // For queues listed in `experimental_queue_concurrency`,
+                    // attempt the `queue:<name>` semaphore between find and
+                    // claim via `try_acquire_queue_slot`; if the slot is
+                    // full, add the queue to a local exclude list and re-find
+                    // so the next candidate (potentially from a different
+                    // queue) gets a chance. Without this retry, a single
+                    // throttled candidate from the wildcard pattern would
+                    // block claims from every other queue in this poll.
                     macro_rules! try_claim_one {
                         ($filter:expr, $exclude:expr) => {{
-                            let record = query_builder::ready_executions::find_one_for_update(
-                                txn,
-                                &table_config,
-                                $filter,
-                                $exclude,
-                                use_skip_locked,
-                            )
-                            .await?;
-                            if let Some(ref execution) = record {
+                            let mut local_throttled: Vec<String> = Vec::new();
+                            loop {
+                                let mut effective_exclude: Vec<String> =
+                                    $exclude.iter().cloned().collect();
+                                effective_exclude.extend(local_throttled.iter().cloned());
+                                let record = query_builder::ready_executions::find_one_for_update(
+                                    txn,
+                                    &table_config,
+                                    $filter,
+                                    &effective_exclude,
+                                    use_skip_locked,
+                                )
+                                .await?;
+                                let Some(ref execution) = record else { break };
+
+                                if queue_concurrency_enabled {
+                                    let acquired = Self::try_acquire_queue_slot(
+                                        &ctx,
+                                        txn,
+                                        &table_config,
+                                        &execution.queue_name,
+                                    )
+                                    .await?;
+                                    if !acquired {
+                                        local_throttled.push(execution.queue_name.clone());
+                                        continue;
+                                    }
+                                }
+
                                 if let Some(claimed) =
                                     Self::claim_execution(txn, &table_config, execution, process_id)
                                         .await?
                                 {
                                     return Ok(claimed);
                                 }
+                                break;
                             }
                         }};
                     }
@@ -1993,10 +2046,13 @@ impl Worker {
         let table_config = self.ctx.table_config.clone();
         let queue_selector = self.ctx.worker_queues.clone();
         let process_id = *self.process_id.lock().await;
+        // EXPERIMENTAL: shared `ctx` for per-record queue-level acquire below.
+        let ctx = self.ctx.clone();
 
         let jobs = db
             .transaction::<_, Vec<quebec_claimed_executions::Model>, DbErr>(|txn| {
                 let table_config = table_config.clone();
+                let ctx = ctx.clone();
                 Box::pin(async move {
                     // Get list of paused queues
                     let paused_queues =
@@ -2015,52 +2071,131 @@ impl Worker {
                         .as_ref()
                         .map_or_else(|| vec![(false, "*".to_string())], |q| q.ordered_patterns()); // Default to all
 
-                    // Helper macro to claim jobs from a queue (batch insert + batch delete)
+                    // When `experimental_queue_concurrency` is empty (the
+                    // common case), `claim_from_queue!` skips the per-record
+                    // acquire path entirely so feature-off workers pay zero
+                    // overhead beyond a single `is_empty()` check per claim.
+                    let queue_concurrency_enabled = !ctx.experimental_queue_concurrency.is_empty();
+
+                    // Helper macro to claim jobs from a queue (batch insert + batch delete).
+                    // EXPERIMENTAL: when `experimental_queue_concurrency` is
+                    // configured, each candidate goes through
+                    // `try_acquire_queue_slot` before being added to the
+                    // batch. Throttled candidates stay in ready_executions
+                    // so the next poll re-attempts them; the queue's
+                    // throttled state is cached locally inside this batch
+                    // to avoid redundant acquire calls when many candidates
+                    // share the same queue.
                     macro_rules! claim_from_queue {
                         ($filter:expr, $exclude:expr) => {{
-                            let records = query_builder::ready_executions::find_many_for_update(
-                                txn,
-                                &table_config,
-                                $filter,
-                                $exclude,
-                                use_skip_locked,
-                                remaining,
-                            )
-                            .await?;
+                            // Loop in the same transaction: when the first
+                            // find returns rows that are all from throttled
+                            // queues, add them to `local_throttled` and
+                            // re-find so unrelated queues' rows can still
+                            // be claimed this poll. Without this, a single
+                            // throttled queue sitting at the head of the
+                            // priority order (e.g. `default` with limit=1
+                            // already held) would block claims from every
+                            // other queue until the next poll tick.
+                            let mut local_throttled = std::collections::HashSet::<String>::new();
+                            loop {
+                                if remaining == 0 {
+                                    break;
+                                }
+                                let mut effective_exclude: Vec<String> =
+                                    $exclude.iter().cloned().collect();
+                                effective_exclude.extend(local_throttled.iter().cloned());
+                                let requested = remaining;
+                                let records =
+                                    query_builder::ready_executions::find_many_for_update(
+                                        txn,
+                                        &table_config,
+                                        $filter,
+                                        &effective_exclude,
+                                        use_skip_locked,
+                                        requested,
+                                    )
+                                    .await?;
+                                if records.is_empty() {
+                                    break;
+                                }
+                                // If DB returned fewer than we asked for,
+                                // there are no more matching rows beyond
+                                // this batch — stop after processing.
+                                let exhausted = (records.len() as u64) < requested;
 
-                            if !records.is_empty() {
-                                let now = chrono::Utc::now().naive_utc();
-                                let insert_data: Vec<(i64, Option<i64>, chrono::NaiveDateTime)> =
-                                    records
+                                let mut accepted: Vec<&quebec_ready_executions::Model> = Vec::new();
+                                if !queue_concurrency_enabled {
+                                    // Feature disabled: accept every found
+                                    // record verbatim — no per-record
+                                    // HashMap lookup, no async helper call.
+                                    accepted.extend(records.iter());
+                                } else {
+                                    for record in &records {
+                                        if local_throttled.contains(&record.queue_name) {
+                                            continue;
+                                        }
+                                        let acquired = Self::try_acquire_queue_slot(
+                                            &ctx,
+                                            txn,
+                                            &table_config,
+                                            &record.queue_name,
+                                        )
+                                        .await?;
+                                        if !acquired {
+                                            local_throttled.insert(record.queue_name.clone());
+                                            continue;
+                                        }
+                                        accepted.push(record);
+                                    }
+                                }
+
+                                if !accepted.is_empty() {
+                                    let now = chrono::Utc::now().naive_utc();
+                                    let insert_data: Vec<(
+                                        i64,
+                                        Option<i64>,
+                                        chrono::NaiveDateTime,
+                                    )> = accepted
                                         .iter()
                                         .map(|r| (r.job_id, process_id, now))
                                         .collect();
-                                let ready_ids: Vec<i64> = records.iter().map(|r| r.id).collect();
-                                let job_ids: Vec<i64> = records.iter().map(|r| r.job_id).collect();
+                                    let ready_ids: Vec<i64> =
+                                        accepted.iter().map(|r| r.id).collect();
+                                    let job_ids: Vec<i64> =
+                                        accepted.iter().map(|r| r.job_id).collect();
 
-                                // Batch insert claimed (RETURNING *) + batch delete ready
-                                let mut claimed =
-                                    query_builder::claimed_executions::insert_all_returning(
+                                    // Batch insert claimed (RETURNING *) + batch delete ready
+                                    let mut claimed =
+                                        query_builder::claimed_executions::insert_all_returning(
+                                            txn,
+                                            &table_config,
+                                            &insert_data,
+                                        )
+                                        .await?;
+                                    query_builder::ready_executions::delete_by_ids(
                                         txn,
                                         &table_config,
-                                        &insert_data,
+                                        &ready_ids,
                                     )
                                     .await?;
-                                query_builder::ready_executions::delete_by_ids(
-                                    txn,
-                                    &table_config,
-                                    &ready_ids,
-                                )
-                                .await?;
 
-                                // Reorder to match original priority/job_id selection order
-                                let order_map: std::collections::HashMap<i64, usize> =
-                                    job_ids.iter().enumerate().map(|(i, &id)| (id, i)).collect();
-                                claimed.sort_by_key(|c| {
-                                    order_map.get(&c.job_id).copied().unwrap_or(usize::MAX)
-                                });
-                                claimed_jobs.extend(claimed);
-                                remaining = remaining.saturating_sub(records.len() as u64);
+                                    // Reorder to match original priority/job_id selection order
+                                    let order_map: std::collections::HashMap<i64, usize> = job_ids
+                                        .iter()
+                                        .enumerate()
+                                        .map(|(i, &id)| (id, i))
+                                        .collect();
+                                    claimed.sort_by_key(|c| {
+                                        order_map.get(&c.job_id).copied().unwrap_or(usize::MAX)
+                                    });
+                                    claimed_jobs.extend(claimed);
+                                    remaining = remaining.saturating_sub(accepted.len() as u64);
+                                }
+
+                                if exhausted {
+                                    break;
+                                }
                             }
                         }};
                     }
@@ -2381,18 +2516,22 @@ impl Worker {
 
         for execution in claimed {
             let table_config = table_config.clone();
+            let ctx = self.ctx.clone();
             let job_id = execution.job_id;
             let execution_id = execution.id;
 
             db.transaction::<_, (), DbErr>(|txn| {
+                let ctx = ctx.clone();
                 Box::pin(async move {
                     if let Some(job) =
                         query_builder::jobs::find_by_id(txn, &table_config, job_id).await?
                     {
-                        // Bypass concurrency limits: the job already holds a semaphore
-                        // slot from when it was dispatched. Put it back to ready directly
-                        // so the dispatcher can re-claim it without re-acquiring the slot.
-                        // Matches Solid Queue's dispatch_bypassing_concurrency_limits.
+                        // Bypass class-level concurrency limits: the job
+                        // already holds the class-level semaphore slot from
+                        // when it was dispatched. Put it back to ready
+                        // directly so the dispatcher can re-claim it
+                        // without re-acquiring. Matches Solid Queue's
+                        // `dispatch_bypassing_concurrency_limits`.
                         query_builder::ready_executions::insert(
                             txn,
                             &table_config,
@@ -2401,6 +2540,11 @@ impl Worker {
                             job.priority,
                         )
                         .await?;
+                        // EXPERIMENTAL queue-level slot was acquired at
+                        // claim time and must be released here — the next
+                        // worker that re-claims this job will re-acquire.
+                        Worker::release_queue_slot(&ctx, txn, &table_config, &job.queue_name)
+                            .await?;
                     } else {
                         warn!(
                             "Job {} not found, dropping claimed execution {}",
@@ -2441,10 +2585,12 @@ impl Worker {
         let mut released = 0usize;
         for row in claimed {
             let table_config = table_config.clone();
+            let ctx = ctx.clone();
             let job_id = row.job_id;
             let execution_id = row.id;
             if let Err(e) = db
                 .transaction::<_, (), DbErr>(|txn| {
+                    let ctx = ctx.clone();
                     Box::pin(async move {
                         if let Some(job) =
                             query_builder::jobs::find_by_id(txn, &table_config, job_id).await?
@@ -2457,6 +2603,10 @@ impl Worker {
                                 job.priority,
                             )
                             .await?;
+                            // EXPERIMENTAL queue-level slot release on
+                            // requeue (see `release_all_claimed_executions`).
+                            Worker::release_queue_slot(&ctx, txn, &table_config, &job.queue_name)
+                                .await?;
                         }
                         query_builder::claimed_executions::delete_by_id(
                             txn,
@@ -2580,6 +2730,11 @@ impl Worker {
         let Some(job) = query_builder::jobs::find_by_id(db, table_config, job_id).await? else {
             return Ok(());
         };
+
+        // EXPERIMENTAL: release queue-level slot first so it's freed even
+        // when the job has no class-level concurrency_key.
+        Self::release_queue_slot(ctx, db, table_config, &job.queue_name).await?;
+
         let Some(key) = job.concurrency_key.as_ref().filter(|k| !k.is_empty()) else {
             return Ok(());
         };
@@ -2605,6 +2760,76 @@ impl Worker {
                 .ok();
         }
 
+        Ok(())
+    }
+
+    /// EXPERIMENTAL: attempt to acquire the `queue:<name>` semaphore at
+    /// claim time. Returns `Ok(true)` when the queue has no override or
+    /// the slot was acquired; `Ok(false)` when the queue is throttled and
+    /// no slot is currently free.
+    ///
+    /// Zero-overhead fast path when the override map is empty: a single
+    /// `is_empty()` check returns immediately, skipping the per-queue
+    /// HashMap lookup, hash, and async work.
+    pub(crate) async fn try_acquire_queue_slot<C>(
+        ctx: &Arc<AppContext>,
+        db: &C,
+        table_config: &TableConfig,
+        queue_name: &str,
+    ) -> std::result::Result<bool, DbErr>
+    where
+        C: ConnectionTrait,
+    {
+        if ctx.experimental_queue_concurrency.is_empty() {
+            return Ok(true);
+        }
+        let Some(&limit) = ctx.experimental_queue_concurrency.get(queue_name) else {
+            return Ok(true);
+        };
+        let duration = chrono::Duration::from_std(ctx.default_concurrency_control_period).ok();
+        crate::semaphore::acquire_semaphore(
+            db,
+            table_config,
+            format!("queue:{}", queue_name),
+            limit,
+            duration,
+        )
+        .await
+    }
+
+    /// EXPERIMENTAL: release the `queue:<name>` semaphore. No-op when the
+    /// queue isn't in the override map. Called from every code path that
+    /// removes a row from `claimed_executions` (normal completion, requeue
+    /// on graceful shutdown, dispatch failure batch release, orphan
+    /// recovery) so the slot doesn't leak until the TTL sweep.
+    ///
+    /// Zero-overhead fast path when the override map is empty: a single
+    /// `is_empty()` check returns immediately.
+    pub(crate) async fn release_queue_slot<C>(
+        ctx: &Arc<AppContext>,
+        db: &C,
+        table_config: &TableConfig,
+        queue_name: &str,
+    ) -> std::result::Result<(), DbErr>
+    where
+        C: ConnectionTrait,
+    {
+        if ctx.experimental_queue_concurrency.is_empty() {
+            return Ok(());
+        }
+        let Some(&limit) = ctx.experimental_queue_concurrency.get(queue_name) else {
+            return Ok(());
+        };
+        let duration = chrono::Duration::from_std(ctx.default_concurrency_control_period).ok();
+        let _ = release_semaphore(
+            db,
+            table_config,
+            format!("queue:{}", queue_name),
+            limit,
+            duration,
+        )
+        .await
+        .inspect_err(|e| warn!("Failed to release queue:{} semaphore: {:?}", queue_name, e));
         Ok(())
     }
 

--- a/tests/test_experimental_queue_concurrency.py
+++ b/tests/test_experimental_queue_concurrency.py
@@ -1,0 +1,277 @@
+"""Tests for the experimental per-queue concurrency limit.
+
+The override is enforced at worker claim time: when the queue is listed in
+``experimental_queue_concurrency`` and the ``queue:<name>`` semaphore slot
+is full, the candidate job stays in ``ready_executions`` and the next
+worker poll picks it up again.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import quebec
+
+
+class PlainJob(quebec.BaseClass):
+    queue_as = "default"
+    calls: list[int] = []
+
+    def perform(self, value: int) -> None:
+        type(self).calls.append(value)
+
+
+class OtherJob(quebec.BaseClass):
+    queue_as = "other"
+    calls: list[int] = []
+
+    def perform(self, value: int) -> None:
+        type(self).calls.append(value)
+
+
+def _qc(db_url, prefix, **overrides):
+    instance = quebec.Quebec(db_url, table_name_prefix=prefix, **overrides)
+    assert instance.create_tables() is True
+    return instance
+
+
+def test_queue_limit_blocks_concurrent_claim(db_url, test_prefix) -> None:
+    """With ``experimental_queue_concurrency={"default": 1}``, claiming a
+    job from "default" holds the slot. A second claim attempt against the
+    same queue must fail until the first job releases.
+    """
+    qc = _qc(db_url, test_prefix, experimental_queue_concurrency={"default": 1})
+    try:
+        PlainJob.calls = []
+        qc.register_job(PlainJob)
+
+        PlainJob.perform_later(qc, 1)
+        PlainJob.perform_later(qc, 2)
+
+        # First drain acquires queue:default → succeeds.
+        e1 = qc.drain_one()
+
+        # While e1 is still pending perform(), queue:default is full.
+        # Second drain must fail to claim.
+        with pytest.raises(Exception, match="No ready job to claim"):
+            qc.drain_one()
+
+        # After e1 runs, queue slot frees → next drain works.
+        e1.perform()
+        e2 = qc.drain_one()
+        e2.perform()
+        assert PlainJob.calls == [1, 2]
+    finally:
+        qc.close()
+
+
+def test_queue_limit_does_not_affect_other_queues(db_url, test_prefix) -> None:
+    """A throttled queue must not block claims from other queues. Worker
+    falls through to the next queue when one is throttled.
+    """
+    qc = _qc(db_url, test_prefix, experimental_queue_concurrency={"default": 1})
+    try:
+        PlainJob.calls = []
+        OtherJob.calls = []
+        qc.register_job(PlainJob)
+        qc.register_job(OtherJob)
+
+        PlainJob.perform_later(qc, 1)
+        PlainJob.perform_later(qc, 2)
+        OtherJob.perform_later(qc, 99)
+
+        # First drain takes the default slot (alphabetical/insertion order
+        # not guaranteed, but ready_executions FIFO by id → PlainJob 1 first).
+        e1 = qc.drain_one()
+        assert e1 is not None
+
+        # Default is full now. Next drain should still find OtherJob in
+        # "other" queue, unaffected by the default-queue throttle.
+        e2 = qc.drain_one()
+        e2.perform()
+
+        # Default still throttled — third drain must fail.
+        with pytest.raises(Exception, match="No ready job to claim"):
+            qc.drain_one()
+
+        # Release default.
+        e1.perform()
+
+        # Now PlainJob 2 can be drained.
+        e3 = qc.drain_one()
+        e3.perform()
+
+        assert PlainJob.calls == [1, 2]
+        assert OtherJob.calls == [99]
+    finally:
+        qc.close()
+
+
+def test_no_override_keeps_existing_behavior(db_url, test_prefix) -> None:
+    """Without ``experimental_queue_concurrency`` set, concurrent claims on
+    the same queue still succeed (no queue-level throttling at all).
+    """
+    qc = _qc(db_url, test_prefix)
+    try:
+        PlainJob.calls = []
+        qc.register_job(PlainJob)
+
+        PlainJob.perform_later(qc, 1)
+        PlainJob.perform_later(qc, 2)
+
+        # Both can be claimed back-to-back, no queue throttle in play.
+        e1 = qc.drain_one()
+        e2 = qc.drain_one()
+
+        e1.perform()
+        e2.perform()
+        assert sorted(PlainJob.calls) == [1, 2]
+    finally:
+        qc.close()
+
+
+def test_batch_claim_respects_queue_limit(db_url, test_prefix) -> None:
+    """Regression for P1 in the review: the production worker uses the
+    batch ``claim_jobs`` path, not the single-job ``claim_job``. Tests that
+    only exercise ``drain_one`` (which calls ``claim_job``) miss the batch
+    bypass. This test directly drives ``claim_jobs`` via the
+    ``drain_batch`` API and asserts that a queue limit of 1 lets exactly
+    one row leave ready_executions even when many are available.
+    """
+    qc = _qc(db_url, test_prefix, experimental_queue_concurrency={"default": 1})
+    try:
+        PlainJob.calls = []
+        qc.register_job(PlainJob)
+
+        # Five jobs all on "default" — limit=1 must allow only 1 to claim.
+        for i in range(5):
+            PlainJob.perform_later(qc, i)
+
+        claimed = qc.drain_batch(10)
+        assert len(claimed) == 1, (
+            f"queue:default limit=1 was bypassed by claim_jobs; "
+            f"got {len(claimed)} claimed"
+        )
+    finally:
+        qc.close()
+
+
+def test_batch_claim_no_head_of_line_block(db_url, test_prefix) -> None:
+    """Regression: a throttled queue at the head of the priority order
+    must not block claims from other queues in the same poll, even when
+    ``batch_size`` is smaller than the count of throttled rows ahead.
+
+    Scenario: enqueue [default-1, default-2, other-1] (FIFO id order),
+    ``experimental_queue_concurrency={"default": 1}``, ``batch_size=2``.
+    Old behaviour: find_many returns [default-1, default-2]; default-1
+    claims the slot, default-2 throttled, other-1 left in ready — to wait
+    for next poll. Fixed behaviour: claim_jobs re-finds with `default` in
+    the exclude list within the same transaction → other-1 also gets
+    claimed.
+    """
+    qc = _qc(db_url, test_prefix, experimental_queue_concurrency={"default": 1})
+    try:
+        PlainJob.calls = []
+        OtherJob.calls = []
+        qc.register_job(PlainJob)
+        qc.register_job(OtherJob)
+
+        PlainJob.perform_later(qc, 1)
+        PlainJob.perform_later(qc, 2)
+        OtherJob.perform_later(qc, 100)
+
+        # batch_size=2: prior implementation would only claim default-1.
+        claimed = qc.drain_batch(2)
+        assert len(claimed) == 2, (
+            f"head-of-line stall: throttled queue blocked other queue in "
+            f"the same poll; got {len(claimed)} claimed"
+        )
+    finally:
+        qc.close()
+
+
+def test_batch_claim_partitions_per_queue(db_url, test_prefix) -> None:
+    """Same batch path, mixed queues: a throttled queue contributes at most
+    its limit while unrestricted queues stay unaffected within the same
+    batch call.
+    """
+    qc = _qc(db_url, test_prefix, experimental_queue_concurrency={"default": 1})
+    try:
+        PlainJob.calls = []
+        OtherJob.calls = []
+        qc.register_job(PlainJob)
+        qc.register_job(OtherJob)
+
+        # 3 jobs on throttled "default", 2 on unrestricted "other".
+        for i in range(3):
+            PlainJob.perform_later(qc, i)
+        for i in range(2):
+            OtherJob.perform_later(qc, 100 + i)
+
+        claimed = qc.drain_batch(10)
+        # 1 from default (limit=1) + 2 from other (no limit) = 3 total.
+        assert len(claimed) == 3
+    finally:
+        qc.close()
+
+
+def test_after_executed_releases_queue_slot(db_url, test_prefix) -> None:
+    """Regression for P2 in the review: when a worker completes a job
+    normally, the queue-level semaphore slot acquired at claim time must
+    be released by ``after_executed``. Otherwise the slot stays held
+    until the dispatcher's TTL sweep — falsely throttling later claims.
+
+    Check: claim → assert slot held (next drain returns nothing) →
+    perform() → assert slot freed (next drain succeeds).
+    """
+    qc = _qc(db_url, test_prefix, experimental_queue_concurrency={"default": 1})
+    try:
+        PlainJob.calls = []
+        qc.register_job(PlainJob)
+
+        PlainJob.perform_later(qc, 1)
+        batch = qc.drain_batch(1)
+        assert len(batch) == 1
+
+        # Slot is held by the first claim — second drain must find nothing.
+        assert qc.drain_batch(10) == []
+
+        # perform() drives the shared `Worker::release_queue_slot` path.
+        batch[0].perform()
+
+        # Slot freed → next job claimable.
+        PlainJob.perform_later(qc, 2)
+        next_batch = qc.drain_batch(10)
+        assert len(next_batch) == 1
+        next_batch[0].perform()
+
+        assert sorted(PlainJob.calls) == [1, 2]
+    finally:
+        qc.close()
+
+
+def test_invalid_limit_is_ignored_with_warning(db_url, test_prefix) -> None:
+    """Non-positive limits get dropped from the override map; the rest of
+    the config still loads. (Validates the kwarg-parsing filter.)
+    """
+    qc = _qc(
+        db_url,
+        test_prefix,
+        experimental_queue_concurrency={"default": 0, "": 5, "valid": 1},
+    )
+    try:
+        PlainJob.calls = []
+        qc.register_job(PlainJob)
+
+        # default's entry was dropped (limit=0) → no throttle on default.
+        PlainJob.perform_later(qc, 1)
+        PlainJob.perform_later(qc, 2)
+
+        # Both claim back-to-back since "default" wasn't actually registered.
+        e1 = qc.drain_one()
+        e2 = qc.drain_one()
+        e1.perform()
+        e2.perform()
+        assert sorted(PlainJob.calls) == [1, 2]
+    finally:
+        qc.close()


### PR DESCRIPTION
## Summary

Adds an opt-in Python kwarg `experimental_queue_concurrency` that caps the number of concurrently-running jobs per queue **across the entire cluster**. Useful for isolating misbehaving queues during incident response without changing worker process layout.

```python
qc = quebec.Quebec(
    dsn,
    experimental_queue_concurrency={
        "ConexIcs2": 1,   # singleton: never more than 1 concurrent
        "low": 5,
    },
    # default_concurrency_control_period doubles as the crash-recovery TTL
    # for queue-level locks. Must exceed P99 job runtime + safety margin.
    default_concurrency_control_period=timedelta(minutes=10),
)
```

Queues not listed in the dict behave exactly as before (zero overhead beyond a single `is_empty()` check).

## Motivation

Real production scenario: a job class on the `ConexIcs2` queue deadlocked. The auto-retry path kept re-queuing it, the dispatcher kept promoting retries, and eventually all worker threads were tied up running the same broken job class. No way to throttle that one queue without bringing down workers or hand-editing `concurrency_key` columns in the DB.

This adds the missing knob: cap a queue at the cluster level via the existing `solid_queue_semaphores` table.

## How it complements existing concurrency

| Mechanism | Scope | When enforced | Source of truth |
|---|---|---|---|
| `concurrency_key` (Solid Queue–compatible) | One key | Enqueue time + promotion | `jobs.concurrency_key` column (snapshot) |
| `experimental_queue_concurrency` (this PR) | All jobs on one queue | Claim time | `ctx.experimental_queue_concurrency` map (live config) |

They stack: a job can be subject to both. Class-level acquired at enqueue, queue-level acquired at claim. Both released independently on completion / requeue / fail.

## Implementation

**Two shared helpers in `src/worker.rs`** for symmetric acquire/release with zero-overhead fast paths:

```rust
async fn try_acquire_queue_slot(ctx, db, table_config, queue_name) -> Result<bool>;
async fn release_queue_slot(ctx, db, table_config, queue_name) -> Result<()>;
```

Both short-circuit on `ctx.experimental_queue_concurrency.is_empty()`. Feature-off workers pay one bool check per call and nothing else.

**Claim paths**:

- `claim_jobs()` (production batch path): per-candidate `try_acquire_queue_slot`. Throttled candidates stay in `ready_executions`. An in-transaction retry loop with a local throttled-queue exclude set avoids head-of-line stalls — if the first `N` ready rows all belong to a throttled queue, the loop re-finds with that queue excluded so unrelated queues' jobs still get claimed in the same poll.
- `claim_job()` (single-claim, used by tests / `drain_one`): same shape.

**Release paths** — every code path that removes a row from `claimed_executions` calls `release_queue_slot`:

- `after_executed` (normal completion)
- `release_all_claimed_executions` (graceful shutdown requeue)
- `release_claimed_batch` (dispatch-failure requeue)
- `unblock_next_job` (orphan/prune fail)

**API surface**:

- New Python kwarg `experimental_queue_concurrency: dict[str, int]`
- New test/ops helper `qc.drain_batch(n)` mirroring the existing `drain_one()`. Drives the production `claim_jobs()` path; lets tests verify queue-throttle behaviour deterministically.

**Control plane**: `/queues` page shows a small `🔒 limit N` badge next to throttled queue names. Hover for "experimental: global concurrency limit for this queue (experimental_queue_concurrency)".

## Trade-offs and caveats

1. **`experimental_` prefix is intentional**. Naming and semantics may change; once we have real production usage the API will solidify into something like `queue_concurrency` (no prefix). Until then, treat as unstable.

2. **TTL = `default_concurrency_control_period`** (60s default). Must exceed P99 job runtime + safety margin; otherwise the dispatcher's `delete_expired` sweep can clean up a still-held lock and let true concurrency exceed the declared limit. Document recommends `P99 × 3` or 30s minimum.

3. **Snapshot vs live config**: unlike class-level `concurrency_key` (which is snapshotted into `jobs.concurrency_key` at enqueue time and can't be retroactively changed), `experimental_queue_concurrency` is read live from `ctx` at every claim. Restart the workers/dispatcher/web after config change.

4. **`drain_batch(n)` is part of the public Python API** for now. It's useful enough as an ops/testing tool that it likely stays; if it becomes a maintenance burden we can move it behind a feature flag later.

## Audit: zero side effects when feature is off

| Path | Cost when `experimental_queue_concurrency = {}` |
|---|---|
| `try_acquire_queue_slot` | One `HashMap::is_empty()` check → return `Ok(true)` |
| `release_queue_slot` | One `HashMap::is_empty()` check → return `Ok(())` |
| `claim_jobs` per-record loop | Short-circuited; `accepted.extend(records.iter())` direct, no async helper calls |
| Semaphore table writes | Zero |
| Control plane render | One `HashMap::get` per queue; badge hidden when `concurrency_limit` is `None` |

## Test plan

- [x] `cargo clippy --all-targets --all-features` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo check --no-default-features` — no new errors introduced (pre-existing `crate::worker` feature-gate failure stays)
- [x] `uv run ruff check tests/` — clean
- [x] `uv run pytest --ignore=tests/step_defs` — **160 passed**, including 8 new tests in `tests/test_experimental_queue_concurrency.py`:
  - `test_queue_limit_blocks_concurrent_claim` — single-claim throttle holds the slot
  - `test_queue_limit_does_not_affect_other_queues` — throttled queue doesn't block unrelated queues
  - `test_no_override_keeps_existing_behavior` — absent config = zero behavioural change
  - `test_batch_claim_respects_queue_limit` — 5 same-queue jobs + limit=1 → exactly 1 claimed
  - `test_batch_claim_no_head_of_line_block` — `batch_size=2` + `[throttled, throttled, other]` → both throttled-overflow and `other` get claimed in the same transaction
  - `test_batch_claim_partitions_per_queue` — mixed throttled/unrestricted batches partition correctly
  - `test_after_executed_releases_queue_slot` — slot freed end-to-end after `perform()`
  - `test_invalid_limit_is_ignored_with_warning` — `0` / negative / empty-key entries dropped at config parse

## Deployment

Upgrade all Quebec-aware processes (web for the control-plane handlers + `qc.retry_failed*` API, worker for the actual claim/release, dispatcher for scheduled→ready promotion) and **restart them all**. Mixed old/new processes will leave gaps where the old code path bypasses the queue semaphore.