### PR TITLE
feat(control-plane): responsive layout for mobile viewports

### DIFF
--- a/src/control_plane/templates/base.html
+++ b/src/control_plane/templates/base.html
@@ -2,12 +2,58 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="base-path" content="{{ base_path }}">
   <title>{% block title %}Control Plane{% endblock %}</title>
   <script src="{{ base_path }}/static/tailwindcss.js?v={{ version }}"></script>
   <script type="module" src="{{ base_path }}/static/turbo.es2017-esm.min.js?v={{ version }}"></script>
   <script src="{{ base_path }}/static/chart.min.js?v={{ version }}"></script>
+
+  <style>
+    @supports (padding: env(safe-area-inset-bottom)) {
+      body {
+        padding-left: env(safe-area-inset-left);
+        padding-right: env(safe-area-inset-right);
+        padding-bottom: env(safe-area-inset-bottom);
+      }
+    }
+
+    .qc-nav-scroll {
+      scrollbar-width: none;
+      -ms-overflow-style: none;
+      scroll-snap-type: x proximity;
+    }
+    .qc-nav-scroll::-webkit-scrollbar { display: none; }
+    .qc-nav-scroll > a { scroll-snap-align: start; }
+    @media (max-width: 1023px) {
+      .qc-nav-scroll {
+        mask-image: linear-gradient(to right, #000 0, #000 calc(100% - 24px), transparent 100%);
+        -webkit-mask-image: linear-gradient(to right, #000 0, #000 calc(100% - 24px), transparent 100%);
+      }
+      .overflow-x-auto:not(.qc-nav-scroll) {
+        scrollbar-width: thin;
+        scrollbar-color: rgba(0, 0, 0, 0.25) transparent;
+      }
+      .overflow-x-auto:not(.qc-nav-scroll)[data-scroll-x="start"] {
+        mask-image: linear-gradient(to right, #000 0, #000 calc(100% - 20px), transparent 100%);
+        -webkit-mask-image: linear-gradient(to right, #000 0, #000 calc(100% - 20px), transparent 100%);
+      }
+      .overflow-x-auto:not(.qc-nav-scroll)[data-scroll-x="middle"] {
+        mask-image: linear-gradient(to right, transparent 0, #000 20px, #000 calc(100% - 20px), transparent 100%);
+        -webkit-mask-image: linear-gradient(to right, transparent 0, #000 20px, #000 calc(100% - 20px), transparent 100%);
+      }
+      .overflow-x-auto:not(.qc-nav-scroll)[data-scroll-x="end"] {
+        mask-image: linear-gradient(to right, transparent 0, #000 20px, #000 100%);
+        -webkit-mask-image: linear-gradient(to right, transparent 0, #000 20px, #000 100%);
+      }
+      .overflow-x-auto:not(.qc-nav-scroll)::-webkit-scrollbar { height: 6px; }
+      .overflow-x-auto:not(.qc-nav-scroll)::-webkit-scrollbar-thumb {
+        background: rgba(0, 0, 0, 0.25);
+        border-radius: 3px;
+      }
+      .overflow-x-auto:not(.qc-nav-scroll)::-webkit-scrollbar-track { background: transparent; }
+    }
+  </style>
 
   <script type="module">
     import { Application, Controller } from "{{ base_path | safe }}/static/stimulus.min.js?v={{ version | safe }}"
@@ -467,7 +513,7 @@
 
     // Navigation controller - manages navigation and active page state
     Stimulus.register("nav", class extends Controller {
-      static targets = ["navItem", "content"]
+      static targets = ["navItem", "content", "navSelect"]
       static values = {
         activeClass: { type: String, default: "border-b-2 border-black" }
       }
@@ -478,13 +524,27 @@
 
       setActivePageFromUrl() {
         const path = window.location.pathname
+        let matched = null
         this.navItemTargets.forEach(item => {
           const href = item.getAttribute('href')
           this.removeActiveClass(item)
           if (href === path) {
-            this.addActiveClass(item)
+            matched = item
           }
         })
+        if (!matched) {
+          // Sub-pages (e.g. /queues/low, /jobs/123) — highlight the closest section
+          matched = this.navItemTargets
+            .filter(item => {
+              const href = item.getAttribute('href')
+              return href !== '/' && path.startsWith(href + '/')
+            })
+            .sort((a, b) => b.getAttribute('href').length - a.getAttribute('href').length)[0]
+        }
+        if (matched) this.addActiveClass(matched)
+        if (this.hasNavSelectTarget) {
+          this.navSelectTarget.value = matched ? matched.getAttribute('href') : ''
+        }
       }
 
       navigate(event) {
@@ -498,9 +558,24 @@
           this.addActiveClass(event.currentTarget)
 
           const href = event.currentTarget.getAttribute('href')
-          this.contentTarget.setAttribute('src', href)
-          history.pushState({}, '', href)
+          if (this.hasNavSelectTarget) this.navSelectTarget.value = href
+          this._goto(href)
         }
+      }
+
+      navigateSelect(event) {
+        const href = event.currentTarget.value
+        if (!href) return
+        this.navItemTargets.forEach(item => {
+          this.removeActiveClass(item)
+          if (item.getAttribute('href') === href) this.addActiveClass(item)
+        })
+        this._goto(href)
+      }
+
+      _goto(href) {
+        this.contentTarget.setAttribute('src', href)
+        history.pushState({}, '', href)
       }
 
       addActiveClass(element) {
@@ -602,11 +677,41 @@
       }
     })
   </script>
+
+  <script>
+    (function () {
+      const SELECTOR = '.overflow-x-auto:not(.qc-nav-scroll)'
+      const update = (el) => {
+        const max = el.scrollWidth - el.clientWidth
+        if (max <= 1) { el.dataset.scrollX = 'fit'; return }
+        if (el.scrollLeft <= 0) { el.dataset.scrollX = 'start' }
+        else if (el.scrollLeft >= max - 1) { el.dataset.scrollX = 'end' }
+        else { el.dataset.scrollX = 'middle' }
+      }
+      const ro = new ResizeObserver((entries) => {
+        for (const e of entries) update(e.target)
+      })
+      const scan = () => {
+        document.querySelectorAll(SELECTOR).forEach((el) => {
+          update(el)
+          ro.observe(el)
+          if (!el.dataset.scrollHintBound) {
+            el.addEventListener('scroll', () => update(el), { passive: true })
+            el.dataset.scrollHintBound = '1'
+          }
+        })
+      }
+      document.addEventListener('DOMContentLoaded', scan)
+      document.addEventListener('turbo:load', scan)
+      document.addEventListener('turbo:frame-load', scan)
+    })()
+
+  </script>
 </head>
 <body class="bg-white text-black min-h-screen flex flex-col">
-  <div class="max-w-screen-2xl mx-auto p-4 md:p-6 w-full flex-grow flex flex-col">
-    <div class="flex items-center gap-3 mb-6">
-      <h1 class="text-3xl font-bold">Control Plane</h1>
+  <div class="max-w-screen-2xl mx-auto p-3 sm:p-4 md:p-6 w-full flex-grow flex flex-col">
+    <div class="flex flex-wrap items-center gap-2 sm:gap-3 mb-4 sm:mb-6">
+      <h1 class="text-2xl sm:text-3xl font-bold">Control Plane</h1>
       {% if force_override_queue %}
         <span title="QUEBEC_FORCE_OVERRIDE_QUEUE is active — every enqueue is rewritten to this queue, ignoring class queue config and any `.set(queue=...)` call. Intended for multi-branch dev isolation; do not leave this set in production."
               class="inline-flex items-center gap-1.5 rounded-md border border-amber-300 bg-amber-50 px-2.5 py-1 text-xs font-medium text-amber-900">
@@ -620,7 +725,27 @@
 
     <div data-controller="nav" data-nav-active-class-value="border-b-2 border-black" class="flex flex-col flex-grow">
       <turbo-frame id="nav-frame">
-        <nav class="flex flex-nowrap border-b mb-6">
+        <div class="relative sm:hidden mb-4">
+          <select data-nav-target="navSelect" data-action="change->nav#navigateSelect"
+                  class="w-full appearance-none bg-white border border-gray-300 rounded-md h-8 pl-3 pr-10 text-sm font-medium text-gray-900 focus:outline-none focus:ring-1 focus:ring-black focus:border-black">
+            <option value="" disabled hidden data-nav-fallback>— Detail page —</option>
+            <option value="{{ base_path }}/">Overview</option>
+            <option value="{{ base_path }}/queues">Queues</option>
+            <option id="nav-option-failed-jobs" value="{{ base_path }}/failed-jobs">Failed jobs · {{ nav_failed_jobs | default(value=0) }}</option>
+            <option id="nav-option-in-progress-jobs" value="{{ base_path }}/in-progress-jobs">In Progress jobs · {{ nav_in_progress_jobs | default(value=0) }}</option>
+            <option id="nav-option-blocked-jobs" value="{{ base_path }}/blocked-jobs">Blocked jobs · {{ nav_blocked_jobs | default(value=0) }}</option>
+            <option id="nav-option-scheduled-jobs" value="{{ base_path }}/scheduled-jobs">Scheduled jobs · {{ nav_scheduled_jobs | default(value=0) }}</option>
+            <option value="{{ base_path }}/recurring-jobs">Recurring jobs</option>
+            <option id="nav-option-finished-jobs" value="{{ base_path }}/finished-jobs">Finished jobs · {{ finished_jobs_count | default(value=0) }}</option>
+            <option value="{{ base_path }}/workers">Workers</option>
+          </select>
+          <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-700">
+            <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+            </svg>
+          </div>
+        </div>
+        <nav class="qc-nav-scroll hidden sm:flex flex-nowrap border-b mb-4 sm:mb-6 overflow-x-auto">
           <a href="{{ base_path }}/" data-nav-target="navItem" data-action="click->nav#navigate" class="shrink-0 whitespace-nowrap px-4 h-8 font-medium text-gray-600 hover:text-black border-b-2 border-transparent hover:border-black">
             Overview
           </a>
@@ -661,24 +786,24 @@
 
       <!-- Footer -->
       <div class="mt-8 pt-4 border-t border-gray-200 mt-auto">
-        <div class="flex flex-col md:flex-row justify-between items-center text-sm text-gray-500">
-          <div class="mb-2 md:mb-0">
+        <div class="flex flex-col md:flex-row md:justify-between md:items-center gap-2 text-sm text-gray-500">
+          <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
             <span>Version: {{ version }}</span>
-            <span class="mx-2">|</span>
-            <span class="inline-flex items-center">
+            <span class="hidden sm:inline">|</span>
+            <span class="hidden sm:inline-flex items-center">
               <span class="h-2 w-2 rounded-full bg-green-500 mr-1"></span>
               <span>Operational</span>
             </span>
             {% if db_info %}
-            <span class="mx-2">|</span>
-            <span class="inline-flex items-center">
-              <span class="h-2 w-2 rounded-full {% if db_info.status == 'Connected' %}bg-green-500{% else %}bg-red-500{% endif %} mr-1"></span>
-              <span>{{ db_info.database_type }} ({{ db_info.connection_type }})</span>
-              <span class="ml-1 text-xs text-gray-400" title="{{ db_info.dsn }}">{{ db_info.dsn }}</span>
+            <span class="hidden sm:inline">|</span>
+            <span class="inline-flex items-center min-w-0 ml-auto sm:ml-0">
+              <span class="h-2 w-2 rounded-full {% if db_info.status == 'Connected' %}bg-green-500{% else %}bg-red-500{% endif %} mr-1 shrink-0"></span>
+              <span class="shrink-0">{{ db_info.database_type }} ({{ db_info.connection_type }})</span>
+              <span class="hidden sm:inline ml-1 text-xs text-gray-400 truncate" title="{{ db_info.dsn }}">{{ db_info.dsn }}</span>
             </span>
             {% endif %}
           </div>
-          <div class="flex space-x-4 items-center">
+          <div class="hidden sm:flex space-x-4 items-center">
             <a href="https://github.com/ratazzi/quebec" target="_blank" class="hover:text-black">Documentation</a>
             <a href="https://github.com/ratazzi/quebec" class="hover:text-black flex items-center">
               <svg class="h-4 w-4 mr-1" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
@@ -688,7 +813,7 @@
             </a>
           </div>
         </div>
-        <div class="mt-2 text-xs text-gray-400 text-right">
+        <div class="hidden sm:block mt-2 text-xs text-gray-400 text-left md:text-right">
           Last updated: <span id="current-time"></span>
         </div>
       </div>

--- a/src/control_plane/templates/blocked-jobs.html
+++ b/src/control_plane/templates/blocked-jobs.html
@@ -6,8 +6,8 @@
 <turbo-frame id="content">
 <!-- Filters -->
 <div class="flex flex-wrap items-center gap-3 mb-6" data-controller="filter">
-  <div class="relative">
-    <select data-filter-target="classSelect" data-action="change->filter#apply" class="appearance-none bg-white border border-gray-300 rounded-md h-8 pl-3 pr-10 text-sm focus:outline-none focus:ring-1 focus:ring-black focus:border-black">
+  <div class="relative w-full sm:w-auto">
+    <select data-filter-target="classSelect" data-action="change->filter#apply" class="w-full sm:w-auto appearance-none bg-white border border-gray-300 rounded-md h-8 pl-3 pr-10 text-sm focus:outline-none focus:ring-1 focus:ring-black focus:border-black">
       <option value="">Filter by job class...</option>
       {% for name in filter_options.class_names %}
       <option value="{{ name }}">{{ name }}</option>
@@ -20,8 +20,8 @@
     </div>
   </div>
 
-  <div class="relative">
-    <select data-filter-target="queueSelect" data-action="change->filter#apply" class="appearance-none bg-white border border-gray-300 rounded-md h-8 pl-3 pr-10 text-sm focus:outline-none focus:ring-1 focus:ring-black focus:border-black">
+  <div class="relative flex-1 min-w-0 sm:flex-none">
+    <select data-filter-target="queueSelect" data-action="change->filter#apply" class="w-full sm:w-auto appearance-none bg-white border border-gray-300 rounded-md h-8 pl-3 pr-10 text-sm focus:outline-none focus:ring-1 focus:ring-black focus:border-black">
       <option value="">Filter by queue name</option>
       {% for name in filter_options.queue_names %}
       <option value="{{ name }}">{{ name }}</option>
@@ -38,7 +38,7 @@
     Clear
   </button>
 
-  <div class="flex-grow"></div>
+  <div class="flex-grow basis-full sm:basis-auto"></div>
 
   {% set filter_args = "" %}
   {% if filter_class_name %}{% set encoded_cn = filter_class_name | urlencode %}{% set filter_args = filter_args ~ "class_name=" ~ encoded_cn %}{% endif %}
@@ -48,6 +48,10 @@
 
   <form action="{{ base_path }}/blocked-jobs/all/unblock{{ filter_qs }}" method="post" data-turbo-frame="_top">
     <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-gray-900 text-gray-50 hover:bg-gray-900/90 h-8 px-4 py-1.5">
+      <svg class="h-4 w-4 mr-1.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" aria-hidden="true">
+        <rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
+        <path d="M7 11V7a5 5 0 0 1 9.9-1"></path>
+      </svg>
       {% if filter_class_name or filter_queue_name %}Unblock filtered{% else %}Unblock all{% endif %}
     </button>
   </form>
@@ -58,19 +62,19 @@
   <table class="min-w-full divide-y divide-gray-200">
     <thead class="bg-gray-50">
       <tr>
-        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Job
         </th>
-        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Queue
         </th>
-        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Blocked By
         </th>
-        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Waiting Since
         </th>
-        <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
           Actions
         </th>
       </tr>
@@ -79,31 +83,39 @@
       {% if blocked_jobs|length > 0 %}
         {% for job in blocked_jobs %}
         <tr>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm font-medium text-gray-900">
               <a href="{{ base_path }}/jobs/{{ job.job_id }}" data-turbo-action="advance" class="hover:underline">{{ job.class_name }}</a>
             </div>
             <div class="text-sm text-gray-500">id: {{ job.job_id }}</div>
             <div class="text-xs text-gray-400">Enqueued <span data-controller="localtime" data-localtime-datetime-value="{{ job.created_at }}">{{ job.created_at }}</span></div>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm text-gray-900">{{ job.queue_name }}</div>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm text-gray-900">{{ job.concurrency_key }}</div>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm text-gray-900">{{ job.waiting_time }}</div>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap text-right text-sm font-medium">
             <form action="{{ base_path }}/blocked-jobs/{{ job.id }}/unblock" method="post" class="inline" data-turbo-frame="_top">
-              <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-3 py-1 mr-2">
-                Unblock
+              <button type="submit" aria-label="Unblock" title="Unblock" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-3 py-1 mr-2">
+                <svg class="h-4 w-4 sm:hidden" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" aria-hidden="true">
+                  <rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
+                  <path d="M7 11V7a5 5 0 0 1 9.9-1"></path>
+                </svg>
+                <span class="hidden sm:inline">Unblock</span>
               </button>
             </form>
             <form action="{{ base_path }}/blocked-jobs/{{ job.id }}/cancel" method="post" class="inline" data-turbo-frame="_top">
-              <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-3 py-1">
-                Cancel
+              <button type="submit" aria-label="Cancel" title="Cancel" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-3 py-1">
+                <svg class="h-4 w-4 sm:hidden" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" aria-hidden="true">
+                  <line x1="18" x2="6" y1="6" y2="18"></line>
+                  <line x1="6" x2="18" y1="6" y2="18"></line>
+                </svg>
+                <span class="hidden sm:inline">Cancel</span>
               </button>
             </form>
           </td>
@@ -111,7 +123,7 @@
         {% endfor %}
       {% else %}
         <tr>
-          <td colspan="5" class="px-6 py-4 text-center text-sm text-gray-500">
+          <td colspan="5" class="px-3 py-3 sm:px-6 sm:py-4 text-center text-sm text-gray-500">
             No blocked jobs found
           </td>
         </tr>

--- a/src/control_plane/templates/failed-jobs.html
+++ b/src/control_plane/templates/failed-jobs.html
@@ -6,8 +6,8 @@
   <turbo-frame id="content">
   <!-- Filters -->
   <div class="flex flex-wrap items-center gap-3 mb-6" data-controller="filter">
-    <div class="relative">
-      <select data-filter-target="classSelect" data-action="change->filter#apply" class="appearance-none bg-white border border-gray-300 rounded-md h-8 pl-3 pr-10 text-sm focus:outline-none focus:ring-1 focus:ring-black focus:border-black">
+    <div class="relative w-full sm:w-auto">
+      <select data-filter-target="classSelect" data-action="change->filter#apply" class="w-full sm:w-auto appearance-none bg-white border border-gray-300 rounded-md h-8 pl-3 pr-10 text-sm focus:outline-none focus:ring-1 focus:ring-black focus:border-black">
         <option value="">Filter by job class...</option>
         {% for name in filter_options.class_names %}
         <option value="{{ name }}">{{ name }}</option>
@@ -20,8 +20,8 @@
       </div>
     </div>
 
-    <div class="relative">
-      <select data-filter-target="queueSelect" data-action="change->filter#apply" class="appearance-none bg-white border border-gray-300 rounded-md h-8 pl-3 pr-10 text-sm focus:outline-none focus:ring-1 focus:ring-black focus:border-black">
+    <div class="relative flex-1 min-w-0 sm:flex-none">
+      <select data-filter-target="queueSelect" data-action="change->filter#apply" class="w-full sm:w-auto appearance-none bg-white border border-gray-300 rounded-md h-8 pl-3 pr-10 text-sm focus:outline-none focus:ring-1 focus:ring-black focus:border-black">
         <option value="">Filter by queue name</option>
         {% for name in filter_options.queue_names %}
         <option value="{{ name }}">{{ name }}</option>
@@ -38,7 +38,7 @@
       Clear
     </button>
 
-    <div class="flex-grow"></div>
+    <div class="flex-grow basis-full sm:basis-auto"></div>
 
     {% set filter_args = "" %}
     {% if filter_class_name %}{% set encoded_cn = filter_class_name | urlencode %}{% set filter_args = filter_args ~ "class_name=" ~ encoded_cn %}{% endif %}
@@ -46,15 +46,26 @@
     {% set filter_qs = "" %}
     {% if filter_args %}{% set filter_qs = "?" ~ filter_args %}{% endif %}
 
-    <form action="{{ base_path }}/failed-jobs/all/delete{{ filter_qs }}" method="post" data-turbo-frame="_top" data-turbo-confirm="{% if filter_class_name or filter_queue_name %}Discard all filtered failed jobs?{% else %}Discard all failed jobs?{% endif %}">
+    <form action="{{ base_path }}/failed-jobs/all/retry{{ filter_qs }}" method="post" data-turbo-frame="_top">
       <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-gray-900 text-gray-50 hover:bg-gray-900/90 h-8 px-4 py-1.5 mr-2">
-        {% if filter_class_name or filter_queue_name %}Discard filtered{% else %}Discard all{% endif %}
+        <svg class="h-4 w-4 mr-1.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" aria-hidden="true">
+          <polyline points="23 4 23 10 17 10"></polyline>
+          <polyline points="1 20 1 14 7 14"></polyline>
+          <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path>
+        </svg>
+        {% if filter_class_name or filter_queue_name %}Retry filtered{% else %}Retry all{% endif %}
       </button>
     </form>
 
-    <form action="{{ base_path }}/failed-jobs/all/retry{{ filter_qs }}" method="post" data-turbo-frame="_top">
-      <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-gray-900 text-gray-50 hover:bg-gray-900/90 h-8 px-4 py-1.5">
-        {% if filter_class_name or filter_queue_name %}Retry filtered{% else %}Retry all{% endif %}
+    <form action="{{ base_path }}/failed-jobs/all/delete{{ filter_qs }}" method="post" data-turbo-frame="_top" data-turbo-confirm="{% if filter_class_name or filter_queue_name %}Discard all filtered failed jobs?{% else %}Discard all failed jobs?{% endif %}">
+      <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-600 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-red-600 text-white hover:bg-red-700 h-8 px-4 py-1.5">
+        <svg class="h-4 w-4 mr-1.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" aria-hidden="true">
+          <polyline points="3 6 5 6 21 6"></polyline>
+          <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+          <line x1="10" x2="10" y1="11" y2="17"></line>
+          <line x1="14" x2="14" y1="11" y2="17"></line>
+        </svg>
+        {% if filter_class_name or filter_queue_name %}Discard filtered{% else %}Discard all{% endif %}
       </button>
     </form>
   </div>
@@ -64,13 +75,13 @@
     <table class="min-w-full divide-y divide-gray-200">
       <thead class="bg-gray-50">
         <tr>
-          <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
             Job
           </th>
-          <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
             Error
           </th>
-          <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+          <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
             Actions
           </th>
         </tr>
@@ -79,14 +90,14 @@
         {% if failed_jobs|length > 0 %}
         {% for job in failed_jobs %}
         <tr>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm font-medium text-gray-900">
               <a href="{{ base_path }}/jobs/{{ job.id }}" data-turbo-action="advance" class="hover:underline">{{ job.class_name }}</a>
             </div>
             <div class="text-sm text-gray-500">ID: {{ job.id }}</div>
             <div class="text-xs text-gray-400">Queue: {{ job.queue_name }}</div>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm text-red-600">
               <details>
                 <summary class="cursor-pointer">Error details</summary>
@@ -95,15 +106,26 @@
             </div>
             <div class="text-xs text-gray-400"><span data-controller="localtime" data-localtime-datetime-value="{{ job.failed_at }}">{{ job.failed_at }}</span></div>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-            <form action="{{ base_path }}/failed-jobs/{{ job.id }}/delete" method="post" class="inline" data-turbo-frame="_top">
-              <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-3 py-1 mr-2">
-                Discard
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap text-right text-sm font-medium">
+            <form action="{{ base_path }}/failed-jobs/{{ job.id }}/retry" method="post" class="inline" data-turbo-frame="_top">
+              <button type="submit" aria-label="Retry" title="Retry" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-3 py-1 mr-2">
+                <svg class="h-4 w-4 sm:hidden" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" aria-hidden="true">
+                  <polyline points="23 4 23 10 17 10"></polyline>
+                  <polyline points="1 20 1 14 7 14"></polyline>
+                  <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path>
+                </svg>
+                <span class="hidden sm:inline">Retry</span>
               </button>
             </form>
-            <form action="{{ base_path }}/failed-jobs/{{ job.id }}/retry" method="post" class="inline" data-turbo-frame="_top">
-              <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-3 py-1">
-                Retry
+            <form action="{{ base_path }}/failed-jobs/{{ job.id }}/delete" method="post" class="inline" data-turbo-frame="_top">
+              <button type="submit" aria-label="Discard" title="Discard" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-600 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-red-300 bg-white text-red-700 hover:bg-red-50 h-8 px-3 py-1">
+                <svg class="h-4 w-4 sm:hidden" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" aria-hidden="true">
+                  <polyline points="3 6 5 6 21 6"></polyline>
+                  <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+                  <line x1="10" x2="10" y1="11" y2="17"></line>
+                  <line x1="14" x2="14" y1="11" y2="17"></line>
+                </svg>
+                <span class="hidden sm:inline">Discard</span>
               </button>
             </form>
           </td>
@@ -111,7 +133,7 @@
         {% endfor %}
         {% else %}
         <tr>
-          <td colspan="3" class="px-6 py-4 text-center text-sm text-gray-500">
+          <td colspan="3" class="px-3 py-3 sm:px-6 sm:py-4 text-center text-sm text-gray-500">
             No failed jobs found.
           </td>
         </tr>

--- a/src/control_plane/templates/finished-jobs.html
+++ b/src/control_plane/templates/finished-jobs.html
@@ -6,8 +6,8 @@
 <turbo-frame id="content">
 <!-- Filters -->
 <div class="flex flex-wrap items-center gap-3 mb-6" data-controller="filter">
-  <div class="relative">
-    <select data-filter-target="classSelect" data-action="change->filter#apply" class="appearance-none bg-white border border-gray-300 rounded-md h-8 pl-3 pr-10 text-sm focus:outline-none focus:ring-1 focus:ring-black focus:border-black">
+  <div class="relative w-full sm:w-auto">
+    <select data-filter-target="classSelect" data-action="change->filter#apply" class="w-full sm:w-auto appearance-none bg-white border border-gray-300 rounded-md h-8 pl-3 pr-10 text-sm focus:outline-none focus:ring-1 focus:ring-black focus:border-black">
       <option value="">Filter by job class...</option>
       {% for name in filter_options.class_names %}
       <option value="{{ name }}">{{ name }}</option>
@@ -20,8 +20,8 @@
     </div>
   </div>
 
-  <div class="relative">
-    <select data-filter-target="queueSelect" data-action="change->filter#apply" class="appearance-none bg-white border border-gray-300 rounded-md h-8 pl-3 pr-10 text-sm focus:outline-none focus:ring-1 focus:ring-black focus:border-black">
+  <div class="relative flex-1 min-w-0 sm:flex-none">
+    <select data-filter-target="queueSelect" data-action="change->filter#apply" class="w-full sm:w-auto appearance-none bg-white border border-gray-300 rounded-md h-8 pl-3 pr-10 text-sm focus:outline-none focus:ring-1 focus:ring-black focus:border-black">
       <option value="">Filter by queue name</option>
       {% for name in filter_options.queue_names %}
       <option value="{{ name }}">{{ name }}</option>
@@ -38,31 +38,57 @@
     Clear
   </button>
 
-  <div class="flex-grow"></div>
+  <div class="flex-grow basis-full sm:basis-auto"></div>
 </div>
 
 {% set filter_args = "" %}
 {% if filter_class_name %}{% set encoded_cn = filter_class_name | urlencode %}{% set filter_args = filter_args ~ "class_name=" ~ encoded_cn %}{% endif %}
 {% if filter_queue_name %}{% if filter_args %}{% set filter_args = filter_args ~ "&" %}{% endif %}{% set encoded_qn = filter_queue_name | urlencode %}{% set filter_args = filter_args ~ "queue_name=" ~ encoded_qn %}{% endif %}
 
-<!-- Table -->
-<div class="overflow-x-auto rounded-lg border border-gray-200">
+<!-- Mobile cards -->
+<div class="sm:hidden space-y-3">
+  {% if finished_jobs|length > 0 %}
+    {% for job in finished_jobs %}
+    <div class="rounded-lg border border-gray-200 p-4 space-y-2 text-sm">
+      <div class="min-w-0">
+        <div class="font-medium text-gray-900 truncate">
+          <a href="{{ base_path }}/jobs/{{ job.id }}" data-turbo-action="advance" class="hover:underline">{{ job.class_name }}</a>
+        </div>
+        <div class="text-xs text-gray-500">id {{ job.id }} · {{ job.queue_name }}</div>
+      </div>
+      <dl class="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
+        <dt class="text-gray-500">Created</dt>
+        <dd class="text-gray-900"><span data-controller="localtime" data-localtime-datetime-value="{{ job.created_at }}">{{ job.created_at }}</span></dd>
+        <dt class="text-gray-500">Finished</dt>
+        <dd class="text-gray-900"><span data-controller="localtime" data-localtime-datetime-value="{{ job.finished_at }}">{{ job.finished_at }}</span></dd>
+        <dt class="text-gray-500">Runtime</dt>
+        <dd class="text-gray-900">{{ job.runtime }}</dd>
+      </dl>
+    </div>
+    {% endfor %}
+  {% else %}
+    <div class="rounded-lg border border-gray-200 p-4 text-sm text-center text-gray-500">No finished jobs found</div>
+  {% endif %}
+</div>
+
+<!-- Desktop table -->
+<div class="hidden sm:block overflow-x-auto rounded-lg border border-gray-200">
   <table class="min-w-full divide-y divide-gray-200">
     <thead class="bg-gray-50">
       <tr>
-        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Job
         </th>
-        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Queue
         </th>
-        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Created At
         </th>
-        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Finished At
         </th>
-        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Runtime
         </th>
       </tr>
@@ -71,29 +97,29 @@
       {% if finished_jobs|length > 0 %}
         {% for job in finished_jobs %}
         <tr>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm font-medium text-gray-900">
               <a href="{{ base_path }}/jobs/{{ job.id }}" data-turbo-action="advance" class="hover:underline">{{ job.class_name }}</a>
             </div>
             <div class="text-sm text-gray-500">id: {{ job.id }}</div>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm text-gray-900">{{ job.queue_name }}</div>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm text-gray-900"><span data-controller="localtime" data-localtime-datetime-value="{{ job.created_at }}">{{ job.created_at }}</span></div>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm text-gray-900"><span data-controller="localtime" data-localtime-datetime-value="{{ job.finished_at }}">{{ job.finished_at }}</span></div>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm text-gray-900">{{ job.runtime }}</div>
           </td>
         </tr>
         {% endfor %}
       {% else %}
         <tr>
-          <td colspan="5" class="px-6 py-4 text-center text-sm text-gray-500">
+          <td colspan="5" class="px-3 py-3 sm:px-6 sm:py-4 text-center text-sm text-gray-500">
             No finished jobs found
           </td>
         </tr>

--- a/src/control_plane/templates/in-progress-jobs.html
+++ b/src/control_plane/templates/in-progress-jobs.html
@@ -6,8 +6,8 @@
 <turbo-frame id="content">
 <!-- Filters -->
 <div class="flex flex-wrap items-center gap-3 mb-6" data-controller="filter">
-  <div class="relative">
-    <select data-filter-target="classSelect" data-action="change->filter#apply" class="appearance-none bg-white border border-gray-300 rounded-md h-8 pl-3 pr-10 text-sm focus:outline-none focus:ring-1 focus:ring-black focus:border-black">
+  <div class="relative w-full sm:w-auto">
+    <select data-filter-target="classSelect" data-action="change->filter#apply" class="w-full sm:w-auto appearance-none bg-white border border-gray-300 rounded-md h-8 pl-3 pr-10 text-sm focus:outline-none focus:ring-1 focus:ring-black focus:border-black">
       <option value="">Filter by job class...</option>
       {% for name in filter_options.class_names %}
       <option value="{{ name }}">{{ name }}</option>
@@ -20,8 +20,8 @@
     </div>
   </div>
 
-  <div class="relative">
-    <select data-filter-target="queueSelect" data-action="change->filter#apply" class="appearance-none bg-white border border-gray-300 rounded-md h-8 pl-3 pr-10 text-sm focus:outline-none focus:ring-1 focus:ring-black focus:border-black">
+  <div class="relative flex-1 min-w-0 sm:flex-none">
+    <select data-filter-target="queueSelect" data-action="change->filter#apply" class="w-full sm:w-auto appearance-none bg-white border border-gray-300 rounded-md h-8 pl-3 pr-10 text-sm focus:outline-none focus:ring-1 focus:ring-black focus:border-black">
       <option value="">Filter by queue name</option>
       {% for name in filter_options.queue_names %}
       <option value="{{ name }}">{{ name }}</option>
@@ -38,31 +38,57 @@
     Clear
   </button>
 
-  <div class="flex-grow"></div>
+  <div class="flex-grow basis-full sm:basis-auto"></div>
 </div>
 
 {% set filter_args = "" %}
 {% if filter_class_name %}{% set encoded_cn = filter_class_name | urlencode %}{% set filter_args = filter_args ~ "class_name=" ~ encoded_cn %}{% endif %}
 {% if filter_queue_name %}{% if filter_args %}{% set filter_args = filter_args ~ "&" %}{% endif %}{% set encoded_qn = filter_queue_name | urlencode %}{% set filter_args = filter_args ~ "queue_name=" ~ encoded_qn %}{% endif %}
 
-<!-- Table -->
-<div class="overflow-x-auto rounded-lg border border-gray-200">
+<!-- Mobile cards -->
+<div class="sm:hidden space-y-3">
+  {% if in_progress_jobs|length > 0 %}
+    {% for job in in_progress_jobs %}
+    <div class="rounded-lg border border-gray-200 p-4 space-y-2 text-sm">
+      <div class="min-w-0">
+        <div class="font-medium text-gray-900 truncate">
+          <a href="{{ base_path }}/jobs/{{ job.job_id }}" data-turbo-action="advance" class="hover:underline">{{ job.class_name }}</a>
+        </div>
+        <div class="text-xs text-gray-500">id {{ job.job_id }} · {{ job.queue_name }}</div>
+      </div>
+      <dl class="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
+        <dt class="text-gray-500">Started</dt>
+        <dd class="text-gray-900"><span data-controller="localtime" data-localtime-datetime-value="{{ job.started_at }}">{{ job.started_at }}</span></dd>
+        <dt class="text-gray-500">Worker</dt>
+        <dd class="text-gray-900 truncate">{{ job.worker_info }}</dd>
+        <dt class="text-gray-500">Runtime</dt>
+        <dd class="text-gray-900">{{ job.runtime }}</dd>
+      </dl>
+    </div>
+    {% endfor %}
+  {% else %}
+    <div class="rounded-lg border border-gray-200 p-4 text-sm text-center text-gray-500">No in-progress jobs found</div>
+  {% endif %}
+</div>
+
+<!-- Desktop table -->
+<div class="hidden sm:block overflow-x-auto rounded-lg border border-gray-200">
   <table class="min-w-full divide-y divide-gray-200">
     <thead class="bg-gray-50">
       <tr>
-        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Job
         </th>
-        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Queue
         </th>
-        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Worker
         </th>
-        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Runtime
         </th>
-        <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
         </th>
       </tr>
     </thead>
@@ -70,29 +96,29 @@
       {% if in_progress_jobs|length > 0 %}
         {% for job in in_progress_jobs %}
         <tr>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm font-medium text-gray-900">
               <a href="{{ base_path }}/jobs/{{ job.job_id }}" data-turbo-action="advance" class="hover:underline">{{ job.class_name }}</a>
             </div>
             <div class="text-sm text-gray-500">id: {{ job.job_id }}</div>
             <div class="text-xs text-gray-400">Started <span data-controller="localtime" data-localtime-datetime-value="{{ job.started_at }}">{{ job.started_at }}</span></div>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm text-gray-900">{{ job.queue_name }}</div>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm text-gray-900">{{ job.worker_info }}</div>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm text-gray-900">{{ job.runtime }}</div>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap text-right text-sm font-medium">
           </td>
         </tr>
         {% endfor %}
       {% else %}
         <tr>
-          <td colspan="5" class="px-6 py-4 text-center text-sm text-gray-500">
+          <td colspan="5" class="px-3 py-3 sm:px-6 sm:py-4 text-center text-sm text-gray-500">
             No in-progress jobs found
           </td>
         </tr>

--- a/src/control_plane/templates/job-details.html
+++ b/src/control_plane/templates/job-details.html
@@ -24,21 +24,21 @@
   </div>
   
   <!-- Job Header -->
-  <div class="flex flex-col md:flex-row justify-between items-start md:items-center mb-6">
-    <div>
-      <h2 class="text-2xl font-bold">{{ job.class_name }}</h2>
-      <p class="text-gray-500">ID: {{ job.id }}</p>
+  <div class="flex flex-col md:flex-row justify-between items-start md:items-center gap-4 mb-6">
+    <div class="min-w-0">
+      <h2 class="text-xl sm:text-2xl font-bold break-words">{{ job.class_name }}</h2>
+      <p class="text-gray-500 text-sm">ID: {{ job.id }}</p>
     </div>
-    <div class="flex mt-4 md:mt-0 space-x-3">
+    <div class="flex flex-wrap gap-3">
       {% if job.status == 'failed' %}
-        <form action="{{ base_path }}/failed-jobs/{{ job.id }}/delete" method="post" data-turbo-frame="_top">
-          <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-4 py-1.5">
-            Discard
-          </button>
-        </form>
         <form action="{{ base_path }}/failed-jobs/{{ job.id }}/retry" method="post" data-turbo-frame="_top">
           <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-gray-900 text-gray-50 hover:bg-gray-900/90 h-8 px-4 py-1.5">
             Retry
+          </button>
+        </form>
+        <form action="{{ base_path }}/failed-jobs/{{ job.id }}/delete" method="post" data-turbo-frame="_top">
+          <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-600 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-red-300 bg-white text-red-700 hover:bg-red-50 h-8 px-4 py-1.5">
+            Discard
           </button>
         </form>
       {% elif job.status == 'scheduled' %}

--- a/src/control_plane/templates/overview.html
+++ b/src/control_plane/templates/overview.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <turbo-frame id="content">
-  <div class="max-w-7xl mx-auto p-4" data-controller="charts">
+  <div data-controller="charts">
 
     <!-- Time Range Selector -->
     <div class="flex justify-end mb-6" data-controller="filter">
@@ -113,23 +113,23 @@
         <table class="min-w-full divide-y divide-gray-200">
           <thead>
             <tr>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Queue Name</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Jobs Processed</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Avg. Duration</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Failed Rate</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+              <th class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Queue Name</th>
+              <th class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Jobs Processed</th>
+              <th class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Avg. Duration</th>
+              <th class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Failed Rate</th>
+              <th class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
             </tr>
           </thead>
           <tbody class="bg-white divide-y divide-gray-200">
             {% for queue in queue_stats %}
             <tr>
-              <td class="px-6 py-4 whitespace-nowrap">
+              <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
                 <a href="{{ base_path }}/queues/{{ queue.name }}" data-turbo-action="advance" class="text-gray-900 hover:underline">{{ queue.name }}</a>
               </td>
-              <td class="px-6 py-4 whitespace-nowrap">{{ queue.jobs_processed }}</td>
-              <td class="px-6 py-4 whitespace-nowrap">{{ queue.avg_duration }}</td>
-              <td class="px-6 py-4 whitespace-nowrap">{{ queue.failed_rate }}%</td>
-              <td class="px-6 py-4 whitespace-nowrap">
+              <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">{{ queue.jobs_processed }}</td>
+              <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">{{ queue.avg_duration }}</td>
+              <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">{{ queue.failed_rate }}%</td>
+              <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
                 {% if queue.status == "paused" %}
                 <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">Paused</span>
                 {% else %}
@@ -150,44 +150,44 @@
         <table class="min-w-full divide-y divide-gray-200">
           <thead>
             <tr>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Job ID</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Class Name</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Queue</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Failed At</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Error</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+              <th class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Job ID</th>
+              <th class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Class Name</th>
+              <th class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Queue</th>
+              <th class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Failed At</th>
+              <th class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Error</th>
+              <th class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
             </tr>
           </thead>
           <tbody class="bg-white divide-y divide-gray-200">
             {% if recent_failed_jobs|length > 0 %}
               {% for job in recent_failed_jobs %}
               <tr>
-                <td class="px-6 py-4 whitespace-nowrap text-sm">
+                <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap text-sm">
                   {{ job.id }}
                 </td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm">
+                <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap text-sm">
                   {{ job.class_name }}
                 </td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm">
+                <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap text-sm">
                   {{ job.queue_name }}
                 </td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm">
+                <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap text-sm">
                   <span data-controller="localtime" data-localtime-datetime-value="{{ job.failed_at }}">{{ job.failed_at }}</span>
                 </td>
-                <td class="px-6 py-4 text-sm max-w-xs truncate">
+                <td class="px-3 py-3 sm:px-6 sm:py-4 text-sm max-w-xs truncate">
                   <div class="tooltip">
                     <span>{{ job.error|truncate(length=50) }}</span>
                     <span class="tooltip-text">{{ job.error }}</span>
                   </div>
                 </td>
-                <td class="px-6 py-4 whitespace-nowrap text-sm">
+                <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap text-sm">
                   <a href="{{ base_path }}/jobs/{{ job.id }}" data-turbo-action="advance" class="text-gray-900 hover:underline">Details</a>
                 </td>
               </tr>
               {% endfor %}
             {% else %}
               <tr>
-                <td colspan="6" class="px-6 py-4 text-center text-sm text-gray-500">
+                <td colspan="6" class="px-3 py-3 sm:px-6 sm:py-4 text-center text-sm text-gray-500">
                   No failed jobs in the selected time period
                 </td>
               </tr>

--- a/src/control_plane/templates/queue-details.html
+++ b/src/control_plane/templates/queue-details.html
@@ -5,12 +5,12 @@
 {% block content %}
 <turbo-frame id="content">
 <div class="mb-8">
-  <div class="flex items-center justify-between mb-6">
-    <div>
-      <h1 class="text-2xl font-bold text-gray-900">Queue: {{ queue_name }}</h1>
+  <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+    <div class="min-w-0">
+      <h1 class="text-xl sm:text-2xl font-bold text-gray-900 break-words">Queue: {{ queue_name }}</h1>
       <p class="text-sm text-gray-500 mt-1">Status: <span class="font-medium {% if queue_status == 'active' %}text-green-600{% else %}text-amber-600{% endif %}">{{ queue_status }}</span></p>
     </div>
-    <div class="flex gap-2">
+    <div class="flex flex-wrap gap-2">
       {% if queue_status == 'active' %}
         <form action="{{ base_path }}/queues/{{ queue_name }}/pause" method="post" data-turbo-frame="_top">
           <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-gray-900 text-gray-50 hover:bg-gray-900/90 h-9 px-4 py-2">
@@ -33,23 +33,68 @@
   <!-- Jobs Table -->
   <div class="mb-6">
     <h2 class="text-lg font-semibold text-gray-900 mb-4">Jobs in Queue</h2>
-    <div class="overflow-x-auto rounded-lg border border-gray-200">
+
+    <!-- Mobile cards -->
+    <div class="sm:hidden space-y-3">
+      {% if jobs|length > 0 %}
+        {% for job in jobs %}
+        <div class="rounded-lg border border-gray-200 p-4 space-y-2 text-sm">
+          <div class="flex items-start justify-between gap-2">
+            <div class="min-w-0">
+              <div class="font-medium text-gray-900 truncate">
+                <a href="{{ base_path }}/jobs/{{ job.id }}" data-turbo-action="advance" class="hover:underline">{{ job.class_name }}</a>
+              </div>
+              <div class="text-xs text-gray-500">ID {{ job.id }}</div>
+            </div>
+            <span class="shrink-0 px-2 inline-flex text-xs leading-5 font-semibold rounded-full
+              {% if job.status == 'processing' %}bg-blue-100 text-blue-800
+              {% elif job.status == 'scheduled' %}bg-purple-100 text-purple-800
+              {% elif job.status == 'failed' %}bg-red-100 text-red-800
+              {% else %}bg-gray-100 text-gray-800{% endif %}">
+              {{ job.status }}
+            </span>
+          </div>
+          <div class="flex items-center justify-between text-xs">
+            <span class="text-gray-500">
+              Created <span data-controller="localtime" data-localtime-datetime-value="{{ job.created_at }}">{{ job.created_at }}</span>
+            </span>
+            {% if job.status == 'failed' %}
+              <form action="{{ base_path }}/failed-jobs/{{ job.id }}/retry" method="post" class="shrink-0" data-turbo-frame="_top">
+                <button type="submit" aria-label="Retry" title="Retry" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-7 w-7">
+                  <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" aria-hidden="true">
+                    <polyline points="23 4 23 10 17 10"></polyline>
+                    <polyline points="1 20 1 14 7 14"></polyline>
+                    <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path>
+                  </svg>
+                </button>
+              </form>
+            {% endif %}
+          </div>
+        </div>
+        {% endfor %}
+      {% else %}
+        <div class="rounded-lg border border-gray-200 p-4 text-sm text-center text-gray-500">No jobs found in this queue</div>
+      {% endif %}
+    </div>
+
+    <!-- Desktop table -->
+    <div class="hidden sm:block overflow-x-auto rounded-lg border border-gray-200">
       <table class="min-w-full divide-y divide-gray-200">
         <thead class="bg-gray-50">
           <tr>
-            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+            <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
               Job Class
             </th>
-            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+            <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
               Job ID
             </th>
-            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+            <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
               Status
             </th>
-            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+            <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
               Created At
             </th>
-            <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+            <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
               Actions
             </th>
           </tr>
@@ -58,15 +103,15 @@
           {% if jobs|length > 0 %}
             {% for job in jobs %}
             <tr>
-              <td class="px-6 py-4 whitespace-nowrap">
+              <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
                 <div class="text-sm font-medium text-gray-900">
                   <a href="{{ base_path }}/jobs/{{ job.id }}" data-turbo-action="advance" class="hover:underline">{{ job.class_name }}</a>
                 </div>
               </td>
-              <td class="px-6 py-4 whitespace-nowrap">
+              <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
                 <div class="text-sm text-gray-500">{{ job.id }}</div>
               </td>
-              <td class="px-6 py-4 whitespace-nowrap">
+              <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
                 <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full
                   {% if job.status == 'processing' %}
                     bg-blue-100 text-blue-800
@@ -81,13 +126,20 @@
                   {{ job.status }}
                 </span>
               </td>
-              <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+              <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap text-sm text-gray-500">
                 <span data-controller="localtime" data-localtime-datetime-value="{{ job.created_at }}">{{ job.created_at }}</span>
               </td>
-              <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+              <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap text-right text-sm font-medium">
                 {% if job.status == 'failed' %}
                   <form action="{{ base_path }}/failed-jobs/{{ job.id }}/retry" method="post" class="inline" data-turbo-frame="_top">
-                    <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-3 py-1">Retry</button>
+                    <button type="submit" aria-label="Retry" title="Retry" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-3 py-1">
+                      <svg class="h-4 w-4 sm:hidden" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" aria-hidden="true">
+                        <polyline points="23 4 23 10 17 10"></polyline>
+                        <polyline points="1 20 1 14 7 14"></polyline>
+                        <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path>
+                      </svg>
+                      <span class="hidden sm:inline">Retry</span>
+                    </button>
                   </form>
                 {% endif %}
               </td>
@@ -95,7 +147,7 @@
             {% endfor %}
           {% else %}
             <tr>
-              <td colspan="5" class="px-6 py-4 text-center text-sm text-gray-500">
+              <td colspan="5" class="px-3 py-3 sm:px-6 sm:py-4 text-center text-sm text-gray-500">
                 No jobs found in this queue
               </td>
             </tr>

--- a/src/control_plane/templates/queues.html
+++ b/src/control_plane/templates/queues.html
@@ -6,8 +6,8 @@
 <turbo-frame id="content">
 <!-- Filters -->
 <div class="flex flex-wrap items-center gap-3 mb-6" data-controller="filter">
-  <div class="relative">
-    <select data-filter-target="statusSelect" data-action="change->filter#apply" class="appearance-none bg-white border border-gray-300 rounded-md h-8 pl-3 pr-10 text-sm focus:outline-none focus:ring-1 focus:ring-black focus:border-black">
+  <div class="relative flex-1 min-w-0 sm:flex-none">
+    <select data-filter-target="statusSelect" data-action="change->filter#apply" class="w-full sm:w-auto appearance-none bg-white border border-gray-300 rounded-md h-8 pl-3 pr-10 text-sm focus:outline-none focus:ring-1 focus:ring-black focus:border-black">
       <option value="">Filter by status...</option>
       <option value="active">Active</option>
       <option value="paused">Paused</option>
@@ -23,16 +23,23 @@
     Clear
   </button>
 
-  <div class="flex-grow"></div>
+  <div class="flex-grow basis-full sm:basis-auto"></div>
 
   <form action="{{ base_path }}/queues/all/pause" method="post">
     <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-gray-900 text-gray-50 hover:bg-gray-900/90 h-8 px-4 py-1.5 mr-2">
+      <svg class="h-4 w-4 mr-1.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" aria-hidden="true">
+        <rect x="6" y="4" width="4" height="16"></rect>
+        <rect x="14" y="4" width="4" height="16"></rect>
+      </svg>
       Pause all
     </button>
   </form>
 
   <form action="{{ base_path }}/queues/all/resume" method="post">
     <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-gray-900 text-gray-50 hover:bg-gray-900/90 h-8 px-4 py-1.5">
+      <svg class="h-4 w-4 mr-1.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" aria-hidden="true">
+        <polygon points="6 4 20 12 6 20 6 4"></polygon>
+      </svg>
       Resume all
     </button>
   </form>
@@ -43,16 +50,16 @@
   <table class="min-w-full divide-y divide-gray-200">
     <thead class="bg-gray-50">
       <tr>
-        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Queue Name
         </th>
-        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Jobs Count
         </th>
-        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Status
         </th>
-        <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
           Actions
         </th>
       </tr>
@@ -60,7 +67,7 @@
     <tbody class="bg-white divide-y divide-gray-200">
       {% for queue in queues %}
       <tr>
-        <td class="px-6 py-4 whitespace-nowrap">
+        <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
           <a href="{{ base_path }}/queues/{{ queue.name }}" data-turbo-action="advance" class="text-sm font-medium text-gray-900 hover:underline">{{ queue.name }}</a>
           {% if queue.concurrency_limit %}
             <span class="ml-1.5 inline-flex items-center gap-1 rounded-full border border-gray-200 px-2 py-0.5 text-xs font-mono text-gray-600" title="Experimental: global concurrency limit for this queue (experimental_queue_concurrency)">
@@ -72,30 +79,41 @@
             </span>
           {% endif %}
         </td>
-        <td class="px-6 py-4 whitespace-nowrap" id="queue-count-{{ queue.slug }}">
+        <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap" id="queue-count-{{ queue.slug }}">
           <div class="text-sm text-gray-900">{{ queue.jobs_count }}</div>
         </td>
-        <td class="px-6 py-4 whitespace-nowrap" id="queue-status-{{ queue.slug }}">
+        <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap" id="queue-status-{{ queue.slug }}">
           <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full {% if queue.status == 'active' %}bg-green-100 text-green-800{% else %}bg-yellow-100 text-yellow-800{% endif %}">
             {{ queue.status | title }}
           </span>
         </td>
-        <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+        <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap text-right text-sm font-medium">
           {% if queue.status == 'active' %}
           <button
             data-queue-name="{{ queue.name }}"
             data-action="pause"
             onclick="toggleQueueStatus(this)"
+            aria-label="Pause"
+            title="Pause"
             class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-3 py-1">
-            Pause
+            <svg class="h-4 w-4 sm:hidden" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" aria-hidden="true">
+              <rect x="6" y="4" width="4" height="16"></rect>
+              <rect x="14" y="4" width="4" height="16"></rect>
+            </svg>
+            <span class="hidden sm:inline">Pause</span>
           </button>
           {% else %}
           <button
             data-queue-name="{{ queue.name }}"
             data-action="resume"
             onclick="toggleQueueStatus(this)"
+            aria-label="Resume"
+            title="Resume"
             class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-3 py-1">
-            Resume
+            <svg class="h-4 w-4 sm:hidden" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" aria-hidden="true">
+              <polygon points="6 4 20 12 6 20 6 4"></polygon>
+            </svg>
+            <span class="hidden sm:inline">Resume</span>
           </button>
           {% endif %}
         </td>

--- a/src/control_plane/templates/recurring-jobs-schedule.html
+++ b/src/control_plane/templates/recurring-jobs-schedule.html
@@ -8,8 +8,26 @@
     {% endif %}
   </template>
 </turbo-stream>
+<turbo-stream action="update" target="recurring-{{ time.id }}-last-run-m">
+  <template>
+    {% if time.last_run_at %}
+      <span data-controller="timeago" data-timeago-datetime-value="{{ time.last_run_at }}"></span>
+    {% else %}
+      <span class="text-gray-400">Never</span>
+    {% endif %}
+  </template>
+</turbo-stream>
 
 <turbo-stream action="update" target="recurring-{{ time.id }}-next-run">
+  <template>
+    {% if time.next_run_at %}
+      <span data-controller="timeago" data-timeago-datetime-value="{{ time.next_run_at }}"></span>
+    {% else %}
+      <span class="text-gray-400">-</span>
+    {% endif %}
+  </template>
+</turbo-stream>
+<turbo-stream action="update" target="recurring-{{ time.id }}-next-run-m">
   <template>
     {% if time.next_run_at %}
       <span data-controller="timeago" data-timeago-datetime-value="{{ time.next_run_at }}"></span>

--- a/src/control_plane/templates/recurring-jobs.html
+++ b/src/control_plane/templates/recurring-jobs.html
@@ -6,27 +6,66 @@
 <turbo-frame id="content">
 <div data-controller="recurring-times">
 
-<!-- Table -->
-<div class="overflow-x-auto rounded-lg border border-gray-200">
+<!-- Mobile cards -->
+<div class="sm:hidden space-y-3">
+  {% if recurring_tasks|length > 0 %}
+    {% for task in recurring_tasks %}
+    <div class="rounded-lg border border-gray-200 p-4 space-y-2 text-sm">
+      <div class="flex items-start justify-between gap-2">
+        <div class="min-w-0">
+          <div class="font-medium text-gray-900 truncate">{{ task.key }}</div>
+          <div class="text-xs text-gray-500">{{ task.class_name }}</div>
+          {% if task.description %}
+          <div class="text-xs text-gray-400">{{ task.description }}</div>
+          {% endif %}
+        </div>
+        <form action="{{ base_path }}/recurring-jobs/{{ task.id }}/run" method="post" class="shrink-0" data-turbo-frame="_top">
+          <button type="submit" aria-label="Run Now" title="Run Now" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-3 py-1">
+            <svg class="h-4 w-4 sm:hidden" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" aria-hidden="true">
+              <polygon points="6 4 20 12 6 20 6 4"></polygon>
+            </svg>
+            <span class="hidden sm:inline">Run Now</span>
+          </button>
+        </form>
+      </div>
+      <dl class="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
+        <dt class="text-gray-500">Schedule</dt>
+        <dd><code class="bg-gray-100 px-2 py-0.5 rounded">{{ task.schedule }}</code></dd>
+        <dt class="text-gray-500">Queue</dt>
+        <dd class="text-gray-900">{{ task.queue_name }} <span class="text-gray-400">· priority {{ task.priority }}</span></dd>
+        <dt class="text-gray-500">Last run</dt>
+        <dd id="recurring-{{ task.id }}-last-run-m" class="text-gray-900"><span class="text-gray-400">-</span></dd>
+        <dt class="text-gray-500">Next run</dt>
+        <dd id="recurring-{{ task.id }}-next-run-m" class="text-gray-900"><span class="text-gray-400">-</span></dd>
+      </dl>
+    </div>
+    {% endfor %}
+  {% else %}
+    <div class="rounded-lg border border-gray-200 p-4 text-sm text-center text-gray-500">No recurring tasks configured</div>
+  {% endif %}
+</div>
+
+<!-- Desktop table -->
+<div class="hidden sm:block overflow-x-auto rounded-lg border border-gray-200">
   <table class="min-w-full divide-y divide-gray-200">
     <thead class="bg-gray-50">
       <tr>
-        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Task
         </th>
-        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Schedule
         </th>
-        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Queue
         </th>
-        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Last Run
         </th>
-        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Next Run
         </th>
-        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Actions
         </th>
       </tr>
@@ -35,34 +74,37 @@
       {% if recurring_tasks|length > 0 %}
         {% for task in recurring_tasks %}
         <tr>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm font-medium text-gray-900">{{ task.key }}</div>
             <div class="text-sm text-gray-500">{{ task.class_name }}</div>
             {% if task.description %}
             <div class="text-xs text-gray-400">{{ task.description }}</div>
             {% endif %}
           </td>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <code class="text-sm text-gray-900 bg-gray-100 px-2 py-1 rounded">{{ task.schedule }}</code>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm text-gray-900">{{ task.queue_name }}</div>
             <div class="text-xs text-gray-500">priority: {{ task.priority }}</div>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div id="recurring-{{ task.id }}-last-run" class="text-sm text-gray-900">
               <span class="text-gray-400">-</span>
             </div>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div id="recurring-{{ task.id }}-next-run" class="text-sm text-gray-900">
               <span class="text-gray-400">-</span>
             </div>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap text-right text-sm font-medium">
             <form action="{{ base_path }}/recurring-jobs/{{ task.id }}/run" method="post" class="inline" data-turbo-frame="_top">
-              <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-3 py-1">
-                Run Now
+              <button type="submit" aria-label="Run Now" title="Run Now" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-3 py-1">
+                <svg class="h-4 w-4 sm:hidden" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" aria-hidden="true">
+                  <polygon points="6 4 20 12 6 20 6 4"></polygon>
+                </svg>
+                <span class="hidden sm:inline">Run Now</span>
               </button>
             </form>
           </td>
@@ -70,7 +112,7 @@
         {% endfor %}
       {% else %}
         <tr>
-          <td colspan="6" class="px-6 py-4 text-center text-sm text-gray-500">
+          <td colspan="6" class="px-3 py-3 sm:px-6 sm:py-4 text-center text-sm text-gray-500">
             No recurring tasks configured
           </td>
         </tr>

--- a/src/control_plane/templates/scheduled-jobs.html
+++ b/src/control_plane/templates/scheduled-jobs.html
@@ -6,8 +6,8 @@
 <turbo-frame id="content">
 <!-- Filters -->
 <div class="flex flex-wrap items-center gap-3 mb-6" data-controller="filter">
-  <div class="relative">
-    <select data-filter-target="classSelect" data-action="change->filter#apply" class="appearance-none bg-white border border-gray-300 rounded-md h-8 pl-3 pr-10 text-sm focus:outline-none focus:ring-1 focus:ring-black focus:border-black">
+  <div class="relative w-full sm:w-auto">
+    <select data-filter-target="classSelect" data-action="change->filter#apply" class="w-full sm:w-auto appearance-none bg-white border border-gray-300 rounded-md h-8 pl-3 pr-10 text-sm focus:outline-none focus:ring-1 focus:ring-black focus:border-black">
       <option value="">Filter by job class...</option>
       {% for name in filter_options.class_names %}
       <option value="{{ name }}">{{ name }}</option>
@@ -20,8 +20,8 @@
     </div>
   </div>
 
-  <div class="relative">
-    <select data-filter-target="queueSelect" data-action="change->filter#apply" class="appearance-none bg-white border border-gray-300 rounded-md h-8 pl-3 pr-10 text-sm focus:outline-none focus:ring-1 focus:ring-black focus:border-black">
+  <div class="relative flex-1 min-w-0 sm:flex-none">
+    <select data-filter-target="queueSelect" data-action="change->filter#apply" class="w-full sm:w-auto appearance-none bg-white border border-gray-300 rounded-md h-8 pl-3 pr-10 text-sm focus:outline-none focus:ring-1 focus:ring-black focus:border-black">
       <option value="">Filter by queue name</option>
       {% for name in filter_options.queue_names %}
       <option value="{{ name }}">{{ name }}</option>
@@ -38,7 +38,7 @@
     Clear
   </button>
 
-  <div class="flex-grow"></div>
+  <div class="flex-grow basis-full sm:basis-auto"></div>
 </div>
 
 {% set filter_args = "" %}
@@ -50,19 +50,19 @@
   <table class="min-w-full divide-y divide-gray-200">
     <thead class="bg-gray-50">
       <tr>
-        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Job
         </th>
-        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Queue
         </th>
-        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Scheduled At
         </th>
-        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Created At
         </th>
-        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Actions
         </th>
       </tr>
@@ -71,26 +71,30 @@
       {% if scheduled_jobs|length > 0 %}
         {% for job in scheduled_jobs %}
         <tr>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm font-medium text-gray-900">
               <a href="{{ base_path }}/jobs/{{ job.job_id }}" data-turbo-action="advance" class="hover:underline">{{ job.class_name }}</a>
             </div>
             <div class="text-sm text-gray-500">id: {{ job.job_id }}</div>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm text-gray-900">{{ job.queue_name }}</div>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm text-gray-900"><span data-controller="localtime" data-localtime-datetime-value="{{ job.scheduled_at }}">{{ job.scheduled_at }}</span></div>
             <div class="text-xs text-gray-400">{{ job.scheduled_in }}</div>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm text-gray-900"><span data-controller="localtime" data-localtime-datetime-value="{{ job.created_at }}">{{ job.created_at }}</span></div>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap text-right text-sm font-medium">
             <form action="{{ base_path }}/scheduled-jobs/{{ job.id }}/cancel" method="post" class="inline" data-turbo-frame="_top">
-              <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-3 py-1">
-                Cancel
+              <button type="submit" aria-label="Cancel" title="Cancel" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-3 py-1">
+                <svg class="h-4 w-4 sm:hidden" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" aria-hidden="true">
+                  <line x1="18" x2="6" y1="6" y2="18"></line>
+                  <line x1="6" x2="18" y1="6" y2="18"></line>
+                </svg>
+                <span class="hidden sm:inline">Cancel</span>
               </button>
             </form>
           </td>
@@ -98,7 +102,7 @@
         {% endfor %}
       {% else %}
         <tr>
-          <td colspan="5" class="px-6 py-4 text-center text-sm text-gray-500">
+          <td colspan="5" class="px-3 py-3 sm:px-6 sm:py-4 text-center text-sm text-gray-500">
             No scheduled jobs found
           </td>
         </tr>

--- a/src/control_plane/templates/stats.html
+++ b/src/control_plane/templates/stats.html
@@ -4,11 +4,17 @@
     <span class="px-1 py-0.5 text-xs rounded-full bg-gray-200 text-gray-800">{{ failed_jobs_count }}</span>
   </template>
 </turbo-stream>
+<turbo-stream action="update" target="nav-option-failed-jobs">
+  <template>Failed jobs · {{ failed_jobs_count }}</template>
+</turbo-stream>
 
 <turbo-stream action="update" target="in-progress-jobs-count">
   <template>
     <span class="px-1 py-0.5 text-xs rounded-full bg-gray-200 text-gray-800">{{ in_progress_jobs_count }}</span>
   </template>
+</turbo-stream>
+<turbo-stream action="update" target="nav-option-in-progress-jobs">
+  <template>In Progress jobs · {{ in_progress_jobs_count }}</template>
 </turbo-stream>
 
 <turbo-stream action="update" target="blocked-jobs-count">
@@ -16,17 +22,26 @@
     <span class="px-1 py-0.5 text-xs rounded-full bg-gray-200 text-gray-800">{{ blocked_jobs_count }}</span>
   </template>
 </turbo-stream>
+<turbo-stream action="update" target="nav-option-blocked-jobs">
+  <template>Blocked jobs · {{ blocked_jobs_count }}</template>
+</turbo-stream>
 
 <turbo-stream action="update" target="scheduled-jobs-count">
   <template>
     <span class="px-1 py-0.5 text-xs rounded-full bg-gray-200 text-gray-800">{{ scheduled_jobs_count }}</span>
   </template>
 </turbo-stream>
+<turbo-stream action="update" target="nav-option-scheduled-jobs">
+  <template>Scheduled jobs · {{ scheduled_jobs_count }}</template>
+</turbo-stream>
 
 <turbo-stream action="update" target="finished-jobs-count">
   <template>
     <span class="px-1 py-0.5 text-xs rounded-full bg-gray-200 text-gray-800">{{ finished_jobs_count }}</span>
   </template>
+</turbo-stream>
+<turbo-stream action="update" target="nav-option-finished-jobs">
+  <template>Finished jobs · {{ finished_jobs_count }}</template>
 </turbo-stream>
 
 {# Per-queue live counters. Anchored to id="queue-count-{slug}" and

--- a/src/control_plane/templates/workers.html
+++ b/src/control_plane/templates/workers.html
@@ -8,35 +8,79 @@
     <h2 class="text-2xl font-bold">Workers</h2>
   </div>
 
-  <div class="overflow-x-auto rounded-lg border border-gray-200">
+  <div class="sm:hidden space-y-3">
+    {% for worker in workers %}
+    <div class="rounded-lg border border-gray-200 p-4 space-y-2 text-sm">
+      <div class="flex items-start justify-between gap-2">
+        <div class="min-w-0">
+          <div class="font-medium text-gray-900">{{ worker.name }}</div>
+          <div class="text-xs text-gray-500">#{{ worker.id }} · {{ worker.kind }}</div>
+        </div>
+        <div class="flex flex-wrap justify-end gap-1 shrink-0">
+          {% if worker.status == "alive" %}
+            <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">Active</span>
+          {% else %}
+            <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-red-100 text-red-800">Dead</span>
+          {% endif %}
+          {% if worker.quiet %}
+            <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800" title="Worker is in quiet mode: no longer claiming new jobs, draining in-flight work">Quiet</span>
+          {% endif %}
+        </div>
+      </div>
+      <dl class="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
+        <dt class="text-gray-500">Hostname</dt>
+        <dd class="text-gray-900 truncate">{{ worker.hostname | default(value="unknown") }}</dd>
+        <dt class="text-gray-500">PID</dt>
+        <dd class="text-gray-900 flex items-center gap-1.5 min-w-0">
+          <span>{{ worker.pid }}</span>
+          {% if worker.revision %}
+            <svg class="h-3.5 w-3.5 text-gray-400 shrink-0" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" aria-hidden="true">
+              <circle cx="12" cy="12" r="3"></circle>
+              <line x1="3" x2="9" y1="12" y2="12"></line>
+              <line x1="15" x2="21" y1="12" y2="12"></line>
+            </svg>
+            <span class="font-mono text-gray-500 truncate" title="Process revision reported at heartbeat (git SHA when available)">{{ worker.revision }}</span>
+          {% endif %}
+        </dd>
+        <dt class="text-gray-500">Heartbeat</dt>
+        <dd class="text-gray-900"><span data-controller="timeago" data-timeago-datetime-value="{{ worker.last_heartbeat_at }}"></span></dd>
+      </dl>
+    </div>
+    {% endfor %}
+    {% if workers | length == 0 %}
+    <div class="rounded-lg border border-gray-200 p-4 text-sm text-center text-gray-500">No workers found</div>
+    {% endif %}
+  </div>
+
+  <div class="hidden sm:block overflow-x-auto rounded-lg border border-gray-200">
     <table class="min-w-full divide-y divide-gray-200">
       <thead class="bg-gray-50">
         <tr>
-          <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Worker ID</th>
-          <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
-          <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Kind</th>
-          <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Hostname</th>
-          <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">PID</th>
-          <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Last Heartbeat</th>
-          <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+          <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Worker ID</th>
+          <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+          <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Kind</th>
+          <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Hostname</th>
+          <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">PID</th>
+          <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Last Heartbeat</th>
+          <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
         </tr>
       </thead>
       <tbody class="bg-white divide-y divide-gray-200">
         {% for worker in workers %}
         <tr>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm text-gray-900">{{ worker.id }}</div>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm text-gray-900">{{ worker.name }}</div>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm text-gray-900">{{ worker.kind }}</div>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm text-gray-900">{{ worker.hostname | default(value="unknown") }}</div>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="flex items-center gap-1.5 text-sm text-gray-900">
               <span>{{ worker.pid }}</span>
               {% if worker.revision %}
@@ -49,10 +93,10 @@
               {% endif %}
             </div>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm text-gray-900"><span data-controller="timeago" data-timeago-datetime-value="{{ worker.last_heartbeat_at }}"></span></div>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap">
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             {% if worker.status == "alive" %}
               <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
                 Active


### PR DESCRIPTION
## Summary

Make the control plane usable at iPhone widths (>=375px) without breaking the desktop layout.

Key changes:
- **Nav**: native `<select>` on `<sm`, edge-fade horizontal scroll on `>=sm`. Live counts in the select stay fresh via new `nav-option-*` turbo-stream targets.
- **List pages**: mobile-card layout + desktop table for queue-details, workers, recurring-jobs, finished-jobs, in-progress-jobs. Other list pages keep the table with reduced padding and a smart scroll-fade hint.
- **Table cell padding**: `px-3 py-2` on mobile, `px-6 py-3/4` on `>=sm`.
- **Filters**: long status/class filter takes its own row on mobile so option labels don't get clipped.
- **Action buttons**: icon-only on mobile (aria-label preserved) for Pause/Resume/Retry/Discard/Unblock/Cancel/Run.
- **Footer**: hide redundant "Operational" pill on `<sm`; push DB indicator to the right for balance.
- **iOS safe-area-inset**: `viewport-fit=cover` + `env()` padding on body so footer doesn't sit under the home indicator or rounded corners.

## Test plan

- [ ] Open the control plane at 375px, 640px, 768px, 1024px; nav, filters, tables and footer render correctly at each breakpoint
- [ ] Mobile select dropdown navigates between sections; selected option syncs when desktop nav clicks
- [ ] Mobile cards on queue-details / workers / recurring-jobs / finished-jobs / in-progress-jobs show the same data as the desktop table
- [ ] Counts in mobile select stay live (failed/in-progress/blocked/scheduled/finished)
- [ ] Tables wider than the viewport scroll horizontally with edge-fade hint
- [ ] iPhone Safari: footer not obscured by the home indicator
- [ ] Desktop layout unchanged at >=1024px