### PR TITLE
feat(proctitle): append cwd basename and git sha for deploy disambiguation

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -377,6 +377,71 @@ pub(crate) fn parse_duration_f64_env(s: &str) -> Option<Duration> {
         .or_else(|| s.parse::<u64>().ok().map(Duration::from_secs))
 }
 
+/// Build the `<basename>@<sha>` suffix appended to `set_proc_title`. Pure
+/// function (path + revision in, string out) so it can be reasoned about
+/// without spinning up an `AppContext`. Either component is dropped when
+/// absent, leaving:
+/// - "release-id@a1b2c3d" when both present
+/// - "release-id"          when no git available
+/// - "@a1b2c3d"            when path has no usable last component
+/// - None                  when neither is available
+///
+/// `cwd` is canonicalized so Capistrano-style deploys where the working
+/// dir is `<root>/current` (a symlink to `<root>/releases/<id>`) surface
+/// the release id rather than the literal "current".
+pub(crate) fn proctitle_suffix(cwd: &std::path::Path, revision: Option<&str>) -> Option<String> {
+    let resolved = std::fs::canonicalize(cwd).ok();
+    let basename = resolved
+        .as_deref()
+        .unwrap_or(cwd)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .filter(|s| !s.is_empty())
+        .map(String::from);
+    match (basename, revision) {
+        (Some(b), Some(s)) => Some(format!("{b}@{s}")),
+        (Some(b), None) => Some(b),
+        (None, Some(s)) => Some(format!("@{s}")),
+        (None, None) => None,
+    }
+}
+
+#[cfg(test)]
+mod proctitle_suffix_tests {
+    use super::proctitle_suffix;
+    use std::path::Path;
+
+    #[test]
+    fn both_present_joins_with_at() {
+        let cwd = std::env::current_dir().unwrap();
+        let basename = cwd.file_name().unwrap().to_str().unwrap().to_string();
+        assert_eq!(
+            proctitle_suffix(&cwd, Some("a1b2c3d")),
+            Some(format!("{basename}@a1b2c3d"))
+        );
+    }
+
+    #[test]
+    fn only_basename_when_revision_absent() {
+        let cwd = std::env::current_dir().unwrap();
+        let basename = cwd.file_name().unwrap().to_str().unwrap().to_string();
+        assert_eq!(proctitle_suffix(&cwd, None), Some(basename));
+    }
+
+    #[test]
+    fn only_revision_when_basename_absent() {
+        assert_eq!(
+            proctitle_suffix(Path::new("/"), Some("a1b2c3d")),
+            Some("@a1b2c3d".to_string())
+        );
+    }
+
+    #[test]
+    fn none_when_both_missing() {
+        assert_eq!(proctitle_suffix(Path::new("/"), None), None);
+    }
+}
+
 /// Class-level scheduling metadata captured at `register_job_class` time.
 /// Plain Rust types only — readable without the GIL.
 #[derive(Debug, Clone)]
@@ -923,16 +988,26 @@ impl AppContext {
     }
 
     /// Set process title for better visibility in system tools (htop, ps, etc.)
-    /// Format: quebec-app_name [process_type:details]
+    /// Format: `quebec-app_name [process_type:details] <cwd_basename>@<git_sha>`
+    /// where the suffix is computed by [`proctitle_suffix`] from the running
+    /// process's cwd (with symlinks resolved, so a Capistrano-style
+    /// `current` → `releases/<id>` deploy surfaces `<id>` instead of
+    /// `current`) and the cached `git rev-parse --short HEAD` output. Either
+    /// component is dropped when missing, so the suffix is omitted entirely
+    /// for plain checkouts without `.git` in a path with no last component.
     /// Examples:
-    /// - quebec-myapp [worker:3]
-    /// - quebec-myapp [dispatcher]
-    /// - quebec-myapp [scheduler]
+    /// - quebec-myapp [worker:3] myapp@a1b2c3d        (local checkout)
+    /// - quebec-coms [worker:10] 20260523-1738-b5b146b@b5b146b  (Capistrano)
+    /// - quebec-myapp [dispatcher] myapp              (no git available)
     pub fn set_proc_title(&self, process_type: &str, details: Option<&str>) {
-        let title = if let Some(details) = details {
+        let base = if let Some(details) = details {
             format!("quebec-{} [{}:{}]", self.name, process_type, details)
         } else {
             format!("quebec-{} [{}]", self.name, process_type)
+        };
+        let title = match proctitle_suffix(&self.cwd, crate::process::process_revision()) {
+            Some(suffix) => format!("{base} {suffix}"),
+            None => base,
         };
 
         #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary

\`ps aux\` showing two deployments of the same app side-by-side currently can't tell which release a \`quebec-coms [worker:10]\` line belongs to. Append \`<cwd_basename>@<git_sha>\` to every \`set_proc_title\` call, reusing the existing \`process_revision()\` cache that workers already report via heartbeat metadata.

cwd is canonicalized first so Capistrano-style \`current\` → \`releases/<id>\` deploys surface the underlying release id rather than the literal \`current\`. Either component is dropped when missing, so the suffix degrades gracefully.

### Before / After

\`\`\`
# Before — can't tell two deploys apart
quebec-coms [worker:10]
quebec-coms [worker:10]

# After — release id + sha visible
quebec-coms [worker:10] 20260523-1738-b5b146b@b5b146b   # Capistrano
quebec-myapp [worker:3]  myapp@5f70048                   # local checkout
quebec-myapp [dispatcher] myapp                          # no git available
\`\`\`

All 5 \`set_proc_title\` call sites (worker / dispatcher / scheduler / supervisor / Python-exposed \`qc.set_proc_title()\`) funnel through \`AppContext::set_proc_title\` so the single change in \`src/context.rs\` covers every entry point.

## Test plan

- [x] \`cargo check --features python\` clean
- [x] \`cargo clippy --all-targets --all-features\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`uv run pytest --ignore=tests/step_defs\` — 160 passed
- [ ] Manual: spin a quebec worker on Linux, verify \`ps auxwww | grep quebec\` shows the suffix