### PR TITLE
feat(proctitle): supervisor entry+slot index for worker/dispatcher

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -357,6 +357,13 @@ pub struct AppContext {
     /// if it no longer matches (i.e. the supervisor died and we got reparented
     /// to init/launchd). Zero means "not supervised, do not check".
     pub supervisor_pid: AtomicI32,
+    /// `(entry_index, within_entry)` populated by `apply_worker_config` /
+    /// `apply_dispatcher_config` after fork so `set_proc_title` can show
+    /// `[worker.<entry>.<within>:threads]` instead of all sibling processes
+    /// sharing the same `[worker:threads]` line. `None` for standalone
+    /// (non-supervised) runs, the supervisor parent itself, and the
+    /// scheduler (which is always a single process).
+    pub proc_slot: Option<(usize, usize)>,
 }
 
 /// Parse env var string as bool: true/1/yes → true, false/0/no → false
@@ -716,6 +723,7 @@ impl AppContext {
             table_config: TableConfig::default(),
             idle_notify: Arc::new(RwLock::new(None)),
             supervisor_pid: AtomicI32::new(0),
+            proc_slot: None,
         }
     }
 
@@ -806,6 +814,9 @@ impl AppContext {
             idle_notify: Arc::new(RwLock::new(None)),
             // Fresh state; child must call `watch_parent_pid` after fork.
             supervisor_pid: AtomicI32::new(0),
+            // Preserve so re-forks (or apply_*_config re-using a forked ctx)
+            // keep the slot label until explicitly reset by apply_*_config.
+            proc_slot: self.proc_slot,
             use_listen_notify: self.use_listen_notify,
             notify_throttle_interval: self.notify_throttle_interval,
             force_override_queue: self.force_override_queue.clone(),
@@ -923,16 +934,27 @@ impl AppContext {
     }
 
     /// Set process title for better visibility in system tools (htop, ps, etc.)
-    /// Format: quebec-app_name [process_type:details]
+    /// Base format: `quebec-app_name [process_type:details]`. When the
+    /// context has a `proc_slot = Some((entry, within))` (set by
+    /// `apply_worker_config` / `apply_dispatcher_config` in supervisor
+    /// children), the role becomes `process_type#<entry>/<within>` so
+    /// sibling workers / dispatchers can be told apart in `ps`. `#N`
+    /// names the queue.yml entry, `/M` the process index inside it.
     /// Examples:
-    /// - quebec-myapp [worker:3]
-    /// - quebec-myapp [dispatcher]
-    /// - quebec-myapp [scheduler]
+    /// - quebec-myapp [worker:3]              (standalone, no supervisor)
+    /// - quebec-myapp [worker#0/1:5]          (supervised, entry 0, 2nd process)
+    /// - quebec-myapp [dispatcher#1/0]        (supervised, entry 1, 1st process)
+    /// - quebec-myapp [supervisor]            (parent, no slot)
+    /// - quebec-myapp [scheduler]             (single-process role)
     pub fn set_proc_title(&self, process_type: &str, details: Option<&str>) {
+        let role = match self.proc_slot {
+            Some((entry, within)) => format!("{process_type}#{entry}/{within}"),
+            None => process_type.to_string(),
+        };
         let title = if let Some(details) = details {
-            format!("quebec-{} [{}:{}]", self.name, process_type, details)
+            format!("quebec-{} [{}:{}]", self.name, role, details)
         } else {
-            format!("quebec-{} [{}]", self.name, process_type)
+            format!("quebec-{} [{}]", self.name, role)
         };
 
         #[cfg(target_os = "macos")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -89,17 +89,27 @@ use crate::worker::{Execution, Worker};
 use tracing::{debug, error, info, trace, warn};
 
 /// Map a supervisor slot index (0..total_processes) to the config entry that
-/// should drive that slot's configuration. Entries with `processes == 0` are
-/// skipped entirely to match the counting done in `supervisor_plan_from_config`.
-fn slot_to_entry<T>(slot: usize, entries: &[T], processes: impl Fn(&T) -> u32) -> Option<&T> {
+/// should drive that slot's configuration. Entries with `processes == 0`
+/// contribute zero slots (matching `supervisor_plan_from_config`).
+///
+/// Returns `(entry_index, within_entry, &entry)` where `entry_index` is the
+/// raw position of the entry in the input slice (including any
+/// `processes == 0` siblings that were skipped while counting), so it
+/// lines up 1:1 with the order users see in their `queue.yml`. `within_entry`
+/// is 0-based among that entry's siblings.
+fn slot_to_entry<T>(
+    slot: usize,
+    entries: &[T],
+    processes: impl Fn(&T) -> u32,
+) -> Option<(usize, usize, &T)> {
     let mut acc = 0usize;
-    for entry in entries {
+    for (entry_idx, entry) in entries.iter().enumerate() {
         let n = processes(entry) as usize;
         if n == 0 {
             continue;
         }
         if slot < acc + n {
-            return Some(entry);
+            return Some((entry_idx, slot - acc, entry));
         }
         acc += n;
     }
@@ -1457,6 +1467,14 @@ impl PyQuebec {
         py.detach(|| Ok(self.rt.block_on(async move { *handle.lock().await })))
     }
 
+    /// Debug accessor — returns the current `(entry_index, within_entry)`
+    /// proctitle slot if set by a prior `apply_worker_config` /
+    /// `apply_dispatcher_config`, otherwise `None`.
+    #[pyo3(name = "_proc_slot")]
+    fn proc_slot(&self) -> Option<(usize, usize)> {
+        self.ctx.proc_slot
+    }
+
     /// Read `workers`/`dispatchers` from the loaded queue.yml and return a plan
     /// dict suitable for `Supervisor(plan=...)`, or `None` if the config file
     /// is absent or specifies fewer than 2 total child processes.
@@ -1507,25 +1525,39 @@ impl PyQuebec {
     /// No-op if no config file is loaded or the `workers` section is missing.
     fn apply_worker_config(&mut self, py: Python<'_>, slot_index: usize) -> PyResult<()> {
         let env = std::env::var("QUEBEC_ENV").ok();
-        let Some(config) = crate::config::QueueConfig::find(env.as_deref()).ok() else {
-            return Ok(());
-        };
-        let Some(workers) = config.workers else {
-            return Ok(());
-        };
-        let Some(worker_cfg) = slot_to_entry(slot_index, &workers, |w| w.processes.unwrap_or(1))
-        else {
-            let total: u32 = workers.iter().map(|w| w.processes.unwrap_or(1)).sum();
-            return Err(pyo3::exceptions::PyIndexError::new_err(format!(
-                "apply_worker_config: slot {} out of range (have {} total worker processes across {} entries)",
-                slot_index, total, workers.len()
-            )));
+        let workers_opt = crate::config::QueueConfig::find(env.as_deref())
+            .ok()
+            .and_then(|c| c.workers);
+
+        // Determine (entry_idx, within_entry, optional config override).
+        // Falling back to (0, slot_index) when no queue.yml / no workers
+        // section means supervised processes still get distinguishable
+        // proctitles (`worker#0/0`, `worker#0/1`, ...) — without this the
+        // documented "embedded services without a yml" path leaves
+        // `proc_slot = None` for every child and they all share
+        // `[worker:threads]`.
+        let (entry_idx, within_entry, worker_cfg) = match workers_opt.as_ref() {
+            Some(workers) => match slot_to_entry(slot_index, workers, |w| w.processes.unwrap_or(1))
+            {
+                Some((e, w, cfg)) => (e, w, Some(cfg)),
+                None => {
+                    let total: u32 = workers.iter().map(|w| w.processes.unwrap_or(1)).sum();
+                    return Err(pyo3::exceptions::PyIndexError::new_err(format!(
+                        "apply_worker_config: slot {} out of range (have {} total worker processes across {} entries)",
+                        slot_index, total, workers.len()
+                    )));
+                }
+            },
+            None => (0usize, slot_index, None),
         };
 
         let mut new_inner = self
             .ctx
             .fork_clone(self.ctx.db.clone(), self.rt.handle().clone());
-        apply_worker_cfg_to(&mut new_inner, worker_cfg)?;
+        if let Some(cfg) = worker_cfg {
+            apply_worker_cfg_to(&mut new_inner, cfg)?;
+        }
+        new_inner.proc_slot = Some((entry_idx, within_entry));
         let new_ctx = Arc::new(new_inner);
         self.rebuild_wrappers_with_ctx(py, new_ctx);
         Ok(())
@@ -1535,26 +1567,33 @@ impl PyQuebec {
     /// apply_worker_config.
     fn apply_dispatcher_config(&mut self, py: Python<'_>, slot_index: usize) -> PyResult<()> {
         let env = std::env::var("QUEBEC_ENV").ok();
-        let Some(config) = crate::config::QueueConfig::find(env.as_deref()).ok() else {
-            return Ok(());
-        };
-        let Some(dispatchers) = config.dispatchers else {
-            return Ok(());
-        };
-        let Some(dispatcher_cfg) =
-            slot_to_entry(slot_index, &dispatchers, |d| d.processes.unwrap_or(1))
-        else {
-            let total: u32 = dispatchers.iter().map(|d| d.processes.unwrap_or(1)).sum();
-            return Err(pyo3::exceptions::PyIndexError::new_err(format!(
-                "apply_dispatcher_config: slot {} out of range (have {} total dispatcher processes across {} entries)",
-                slot_index, total, dispatchers.len()
-            )));
+        let dispatchers_opt = crate::config::QueueConfig::find(env.as_deref())
+            .ok()
+            .and_then(|c| c.dispatchers);
+
+        let (entry_idx, within_entry, dispatcher_cfg) = match dispatchers_opt.as_ref() {
+            Some(dispatchers) => {
+                match slot_to_entry(slot_index, dispatchers, |d| d.processes.unwrap_or(1)) {
+                    Some((e, w, cfg)) => (e, w, Some(cfg)),
+                    None => {
+                        let total: u32 = dispatchers.iter().map(|d| d.processes.unwrap_or(1)).sum();
+                        return Err(pyo3::exceptions::PyIndexError::new_err(format!(
+                            "apply_dispatcher_config: slot {} out of range (have {} total dispatcher processes across {} entries)",
+                            slot_index, total, dispatchers.len()
+                        )));
+                    }
+                }
+            }
+            None => (0usize, slot_index, None),
         };
 
         let mut new_inner = self
             .ctx
             .fork_clone(self.ctx.db.clone(), self.rt.handle().clone());
-        apply_dispatcher_cfg_to(&mut new_inner, dispatcher_cfg)?;
+        if let Some(cfg) = dispatcher_cfg {
+            apply_dispatcher_cfg_to(&mut new_inner, cfg)?;
+        }
+        new_inner.proc_slot = Some((entry_idx, within_entry));
         let new_ctx = Arc::new(new_inner);
         self.rebuild_wrappers_with_ctx(py, new_ctx);
         Ok(())

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -201,6 +201,32 @@ class TestApplyConfig:
         except Exception as exc:
             pytest.fail(f"unexpected exception: {exc!r}")
 
+    def test_apply_worker_config_without_yml_still_sets_proc_slot(
+        self, qc, monkeypatch, tmp_path
+    ):
+        # Embedded-services path: queue.yml present but has no workers section
+        # (or no yml at all). supervisor passes slot_index straight through.
+        # proc_slot must still be set so children get distinguishable proctitles
+        # (`worker#0/N`) instead of all sharing `[worker:threads]`.
+        empty = tmp_path / "empty.yml"
+        empty.write_text("development: {}\n")
+        monkeypatch.setenv("QUEBEC_CONFIG", str(empty))
+
+        assert qc._proc_slot() is None
+        qc.apply_worker_config(2)
+        assert qc._proc_slot() == (0, 2)
+
+    def test_apply_dispatcher_config_without_yml_still_sets_proc_slot(
+        self, qc, monkeypatch, tmp_path
+    ):
+        empty = tmp_path / "empty.yml"
+        empty.write_text("development: {}\n")
+        monkeypatch.setenv("QUEBEC_CONFIG", str(empty))
+
+        assert qc._proc_slot() is None
+        qc.apply_dispatcher_config(1)
+        assert qc._proc_slot() == (0, 1)
+
 
 class TestSupervisorPlanFromConfig:
     def test_returns_dict_or_none(self, qc):


### PR DESCRIPTION
## Summary

(Re-opening — original #72 was inadvertently force-pushed after a rebase; reopened here with merge-based history to preserve the project's no-force-push invariant.)

Under supervisor mode all sibling workers / dispatchers shared the same \`quebec-app [worker:5]\` proctitle because the 'details' field encoded the **thread count**, not the slot. \`ps aux\` couldn't tell three workers apart.

Track \`(entry_index, within_entry)\` on \`AppContext.proc_slot\`, populated by \`apply_worker_config\` / \`apply_dispatcher_config\` after fork, and weave it into \`set_proc_title\` as \`role#<entry>/<within>\` — \`#N\` names the queue.yml entry, \`/M\` the process index inside that entry. Composes with the cwd@sha suffix landed via #71.

### Before / After

\`\`\`
# Before — three sibling workers, indistinguishable
quebec-coms [worker:5]
quebec-coms [worker:5]
quebec-coms [worker:5]

# After — entry + within-entry slot visible, plus cwd@sha from #71
quebec-coms [worker#0/0:5] release@sha    queue.yml entry 0, 1st proc, 5 threads
quebec-coms [worker#0/1:5] release@sha    queue.yml entry 0, 2nd proc
quebec-coms [worker#1/0:10] release@sha   queue.yml entry 1, 1st proc, 10 threads
quebec-coms [dispatcher#0/0] release@sha
\`\`\`

Supervisor parent / scheduler / standalone runs leave \`proc_slot = None\` and keep the existing single-role title.

The no-yml \`Supervisor(qc, {\"worker\": 2})\` fallback path (embedded-services usage) also sets \`proc_slot = (0, slot_index)\` so those children still get distinct titles instead of all sharing \`[worker:threads]\`.

### Touched APIs

- \`slot_to_entry\` now returns \`(entry_index, within_entry, &T)\` — entry_index is the raw queue.yml position (including any \`processes: 0\` siblings) so it lines up 1:1 with what users see in the file.
- New PyO3 debug accessor \`qc._proc_slot()\` (underscore-prefixed, for tests).
- \`apply_worker_config\` / \`apply_dispatcher_config\` set \`proc_slot\` in both the with-yml and no-yml paths.

## Test plan

- [x] \`cargo check --features python\` clean
- [x] \`cargo clippy --all-targets --all-features\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`uv run pytest --ignore=tests/step_defs\` — 162 passed (+2 new tests)
- [x] New tests catch the bug: temporarily reverting the no-yml fallback makes \`test_apply_worker_config_without_yml_still_sets_proc_slot\` fail with \`assert None == (0, 2)\`
- [ ] Manual: spin a quebec supervisor with multiple workers, verify \`ps auxwww | grep quebec\` shows distinct \`#entry/slot\` labels