### PR TITLE
fix(control-plane): right-align Actions header on Recurring/Scheduled jobs

### DIFF
--- a/src/control_plane/templates/recurring-jobs.html
+++ b/src/control_plane/templates/recurring-jobs.html
@@ -65,7 +65,7 @@
         <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Next Run
         </th>
-        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
           Actions
         </th>
       </tr>

--- a/src/control_plane/templates/scheduled-jobs.html
+++ b/src/control_plane/templates/scheduled-jobs.html
@@ -62,7 +62,7 @@
         <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Created At
         </th>
-        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
           Actions
         </th>
       </tr>


### PR DESCRIPTION
## Summary

Two control-plane templates had their \`Actions\` TH using \`text-left\` while the action cells (right-flushed buttons via \`text-right\`) sat at the far right of the column. The header floated alone in the middle/left of the column, visually disconnected from the buttons it labeled.

The other four list pages (Failed jobs, Blocked jobs, Queues, Queue details) already use \`text-right\` on the Actions TH. This brings Recurring and Scheduled into line.

### Affected

- \`src/control_plane/templates/recurring-jobs.html\`
- \`src/control_plane/templates/scheduled-jobs.html\`

Single-character change in each: \`text-left\` → \`text-right\`.

## Test plan

- [ ] Open \`/recurring-jobs\` — \`ACTIONS\` header sits flush right above the \`Run Now\` buttons
- [ ] Open \`/scheduled-jobs\` — \`ACTIONS\` header sits flush right above the action buttons