### PR TITLE
fix(control-plane): align queue detail with list (ready executions only)

### DIFF
--- a/src/control_plane/handlers/queues.rs
+++ b/src/control_plane/handlers/queues.rs
@@ -3,10 +3,6 @@ use axum::{
     http::StatusCode,
     response::{Html, IntoResponse, Response},
 };
-use sea_orm::sea_query::{
-    Alias, Expr, MysqlQueryBuilder, PostgresQueryBuilder, Query as SeaQuery, SqliteQueryBuilder,
-};
-use sea_orm::{ConnectionTrait, DbBackend, Statement};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
@@ -229,14 +225,18 @@ impl ControlPlane {
             .await
             .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
-        // Get total job count for this queue using query_builder
+        // Count and fetch ready executions for this queue. This matches the
+        // /queues list size (and Mission Control's Queue#size + Queue#jobs):
+        // only ready/pending jobs belong to a queue's listing. Blocked /
+        // scheduled / claimed / failed jobs are surfaced through their own
+        // top-nav tabs to avoid the "list shows 0 but detail shows blocked"
+        // double-counting confusion.
         let total_jobs =
-            query_builder::jobs::count_by_queue_unfinished(db, table_config, &queue_name)
+            query_builder::ready_executions::count_by_queue_name(db, table_config, &queue_name)
                 .await
                 .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
-        // Get jobs for this queue with pagination using query_builder
-        let jobs = query_builder::jobs::find_by_queue_unfinished_paginated(
+        let ready_rows = query_builder::ready_executions::find_by_queue_paginated(
             db,
             table_config,
             &queue_name,
@@ -246,156 +246,22 @@ impl ControlPlane {
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
-        // Get execution status for each job
-        let job_ids: Vec<i64> = jobs.iter().map(|j| j.id).collect();
-
-        // Check for failed executions
-        let failed_table = Alias::new(&state.ctx.table_config.failed_executions);
-
-        let failed_query = SeaQuery::select()
-            .column(Alias::new("job_id"))
-            .from(failed_table)
-            .and_where(Expr::col(Alias::new("job_id")).is_in(job_ids.clone()))
-            .to_owned();
-
-        let (failed_sql, failed_values) = match db.get_database_backend() {
-            DbBackend::Postgres => failed_query.build(PostgresQueryBuilder),
-            DbBackend::Sqlite => failed_query.build(SqliteQueryBuilder),
-            DbBackend::MySql => failed_query.build(MysqlQueryBuilder),
-        };
-
-        let failed_executions_stmt =
-            Statement::from_sql_and_values(db.get_database_backend(), &failed_sql, failed_values);
-
-        let failed_job_ids: Vec<i64> = db
-            .query_all(failed_executions_stmt)
+        let job_ids: Vec<i64> = ready_rows.iter().map(|r| r.job_id).collect();
+        let jobs = query_builder::jobs::find_by_ids(db, table_config, job_ids)
             .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        let jobs_by_id: HashMap<i64, _> = jobs.into_iter().map(|j| (j.id, j)).collect();
+
+        let queue_jobs: Vec<crate::control_plane::models::QueueJobInfo> = ready_rows
             .iter()
-            .map(|row| row.try_get::<i64>("", "job_id").unwrap_or(0))
-            .collect();
-
-        // Check for claimed executions (in progress)
-        let claimed_table = Alias::new(&state.ctx.table_config.claimed_executions);
-
-        let claimed_query = SeaQuery::select()
-            .columns([Alias::new("id"), Alias::new("job_id")])
-            .from(claimed_table)
-            .and_where(Expr::col(Alias::new("job_id")).is_in(job_ids.clone()))
-            .to_owned();
-
-        let (claimed_sql, claimed_values) = match db.get_database_backend() {
-            DbBackend::Postgres => claimed_query.build(PostgresQueryBuilder),
-            DbBackend::Sqlite => claimed_query.build(SqliteQueryBuilder),
-            DbBackend::MySql => claimed_query.build(MysqlQueryBuilder),
-        };
-
-        let claimed_executions_stmt =
-            Statement::from_sql_and_values(db.get_database_backend(), &claimed_sql, claimed_values);
-
-        let claimed_map: HashMap<i64, i64> = db
-            .query_all(claimed_executions_stmt)
-            .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-            .iter()
-            .map(|row| {
-                let job_id: i64 = row.try_get("", "job_id").unwrap_or(0);
-                let execution_id: i64 = row.try_get("", "id").unwrap_or(0);
-                (job_id, execution_id)
-            })
-            .collect();
-
-        // Check for scheduled executions
-        let scheduled_table = Alias::new(&state.ctx.table_config.scheduled_executions);
-
-        let scheduled_query = SeaQuery::select()
-            .columns([Alias::new("id"), Alias::new("job_id")])
-            .from(scheduled_table)
-            .and_where(Expr::col(Alias::new("job_id")).is_in(job_ids.clone()))
-            .to_owned();
-
-        let (scheduled_sql, scheduled_values) = match db.get_database_backend() {
-            DbBackend::Postgres => scheduled_query.build(PostgresQueryBuilder),
-            DbBackend::Sqlite => scheduled_query.build(SqliteQueryBuilder),
-            DbBackend::MySql => scheduled_query.build(MysqlQueryBuilder),
-        };
-
-        let scheduled_executions_stmt = Statement::from_sql_and_values(
-            db.get_database_backend(),
-            &scheduled_sql,
-            scheduled_values,
-        );
-
-        let scheduled_map: HashMap<i64, i64> = db
-            .query_all(scheduled_executions_stmt)
-            .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-            .iter()
-            .map(|row| {
-                let job_id: i64 = row.try_get("", "job_id").unwrap_or(0);
-                let execution_id: i64 = row.try_get("", "id").unwrap_or(0);
-                (job_id, execution_id)
-            })
-            .collect();
-
-        // Check for blocked executions
-        let blocked_table = Alias::new(&state.ctx.table_config.blocked_executions);
-
-        let blocked_query = SeaQuery::select()
-            .columns([Alias::new("id"), Alias::new("job_id")])
-            .from(blocked_table)
-            .and_where(Expr::col(Alias::new("job_id")).is_in(job_ids))
-            .to_owned();
-
-        let (blocked_sql, blocked_values) = match db.get_database_backend() {
-            DbBackend::Postgres => blocked_query.build(PostgresQueryBuilder),
-            DbBackend::Sqlite => blocked_query.build(SqliteQueryBuilder),
-            DbBackend::MySql => blocked_query.build(MysqlQueryBuilder),
-        };
-
-        let blocked_executions_stmt =
-            Statement::from_sql_and_values(db.get_database_backend(), &blocked_sql, blocked_values);
-
-        let blocked_map: HashMap<i64, i64> = db
-            .query_all(blocked_executions_stmt)
-            .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-            .iter()
-            .map(|row| {
-                let job_id: i64 = row.try_get("", "job_id").unwrap_or(0);
-                let execution_id: i64 = row.try_get("", "id").unwrap_or(0);
-                (job_id, execution_id)
-            })
-            .collect();
-
-        let queue_jobs: Vec<crate::control_plane::models::QueueJobInfo> = jobs
-            .into_iter()
-            .map(|job| {
-                let status = if failed_job_ids.contains(&job.id) {
-                    "failed"
-                } else if claimed_map.contains_key(&job.id) {
-                    "in_progress"
-                } else if scheduled_map.contains_key(&job.id) {
-                    "scheduled"
-                } else if blocked_map.contains_key(&job.id) {
-                    "blocked"
-                } else {
-                    "ready"
-                };
-
-                let execution_id = claimed_map
-                    .get(&job.id)
-                    .or_else(|| scheduled_map.get(&job.id))
-                    .or_else(|| blocked_map.get(&job.id))
-                    .copied();
-
-                crate::control_plane::models::QueueJobInfo {
-                    id: job.id,
-                    class_name: job.class_name.clone(),
-                    status: status.to_string(),
-                    created_at: Self::format_naive_datetime(job.created_at),
-                    execution_id,
-                }
+            .filter_map(|ready| {
+                jobs_by_id.get(&ready.job_id).map(|job| {
+                    crate::control_plane::models::QueueJobInfo {
+                        id: job.id,
+                        class_name: job.class_name.clone(),
+                        created_at: Self::format_naive_datetime(job.created_at),
+                    }
+                })
             })
             .collect();
 

--- a/src/control_plane/models.rs
+++ b/src/control_plane/models.rs
@@ -125,9 +125,7 @@ pub struct InProgressJobInfo {
 pub struct QueueJobInfo {
     pub id: i64,
     pub class_name: String,
-    pub status: String,
     pub created_at: String,
-    pub execution_id: Option<i64>,
 }
 
 #[derive(Debug, Serialize)]

--- a/src/control_plane/templates/queue-details.html
+++ b/src/control_plane/templates/queue-details.html
@@ -32,48 +32,27 @@
 
   <!-- Jobs Table -->
   <div class="mb-6">
-    <h2 class="text-lg font-semibold text-gray-900 mb-4">Jobs in Queue</h2>
+    <h2 class="text-lg font-semibold text-gray-900 mb-4">Ready Jobs in Queue</h2>
+    <p class="text-sm text-gray-500 -mt-2 mb-4">Only jobs ready to be claimed by a worker are listed here. Scheduled, blocked, in-progress and failed jobs appear in their respective top-nav tabs.</p>
 
     <!-- Mobile cards -->
     <div class="sm:hidden space-y-3">
       {% if jobs|length > 0 %}
         {% for job in jobs %}
         <div class="rounded-lg border border-gray-200 p-4 space-y-2 text-sm">
-          <div class="flex items-start justify-between gap-2">
-            <div class="min-w-0">
-              <div class="font-medium text-gray-900 truncate">
-                <a href="{{ base_path }}/jobs/{{ job.id }}" data-turbo-action="advance" class="hover:underline">{{ job.class_name }}</a>
-              </div>
-              <div class="text-xs text-gray-500">ID {{ job.id }}</div>
+          <div class="min-w-0">
+            <div class="font-medium text-gray-900 truncate">
+              <a href="{{ base_path }}/jobs/{{ job.id }}" data-turbo-action="advance" class="hover:underline">{{ job.class_name }}</a>
             </div>
-            <span class="shrink-0 px-2 inline-flex text-xs leading-5 font-semibold rounded-full
-              {% if job.status == 'processing' %}bg-blue-100 text-blue-800
-              {% elif job.status == 'scheduled' %}bg-purple-100 text-purple-800
-              {% elif job.status == 'failed' %}bg-red-100 text-red-800
-              {% else %}bg-gray-100 text-gray-800{% endif %}">
-              {{ job.status }}
-            </span>
+            <div class="text-xs text-gray-500">ID {{ job.id }}</div>
           </div>
-          <div class="flex items-center justify-between text-xs">
-            <span class="text-gray-500">
-              Created <span data-controller="localtime" data-localtime-datetime-value="{{ job.created_at }}">{{ job.created_at }}</span>
-            </span>
-            {% if job.status == 'failed' %}
-              <form action="{{ base_path }}/failed-jobs/{{ job.id }}/retry" method="post" class="shrink-0" data-turbo-frame="_top">
-                <button type="submit" aria-label="Retry" title="Retry" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-7 w-7">
-                  <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" aria-hidden="true">
-                    <polyline points="23 4 23 10 17 10"></polyline>
-                    <polyline points="1 20 1 14 7 14"></polyline>
-                    <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path>
-                  </svg>
-                </button>
-              </form>
-            {% endif %}
+          <div class="text-xs text-gray-500">
+            Created <span data-controller="localtime" data-localtime-datetime-value="{{ job.created_at }}">{{ job.created_at }}</span>
           </div>
         </div>
         {% endfor %}
       {% else %}
-        <div class="rounded-lg border border-gray-200 p-4 text-sm text-center text-gray-500">No jobs found in this queue</div>
+        <div class="rounded-lg border border-gray-200 p-4 text-sm text-center text-gray-500">No ready jobs in this queue</div>
       {% endif %}
     </div>
 
@@ -89,13 +68,7 @@
               Job ID
             </th>
             <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-              Status
-            </th>
-            <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
               Created At
-            </th>
-            <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-              Actions
             </th>
           </tr>
         </thead>
@@ -111,44 +84,15 @@
               <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
                 <div class="text-sm text-gray-500">{{ job.id }}</div>
               </td>
-              <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
-                <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full
-                  {% if job.status == 'processing' %}
-                    bg-blue-100 text-blue-800
-                  {% elif job.status == 'scheduled' %}
-                    bg-purple-100 text-purple-800
-                  {% elif job.status == 'failed' %}
-                    bg-red-100 text-red-800
-                  {% else %}
-                    bg-gray-100 text-gray-800
-                  {% endif %}
-                ">
-                  {{ job.status }}
-                </span>
-              </td>
               <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap text-sm text-gray-500">
                 <span data-controller="localtime" data-localtime-datetime-value="{{ job.created_at }}">{{ job.created_at }}</span>
-              </td>
-              <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap text-right text-sm font-medium">
-                {% if job.status == 'failed' %}
-                  <form action="{{ base_path }}/failed-jobs/{{ job.id }}/retry" method="post" class="inline" data-turbo-frame="_top">
-                    <button type="submit" aria-label="Retry" title="Retry" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-3 py-1">
-                      <svg class="h-4 w-4 sm:hidden" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" aria-hidden="true">
-                        <polyline points="23 4 23 10 17 10"></polyline>
-                        <polyline points="1 20 1 14 7 14"></polyline>
-                        <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path>
-                      </svg>
-                      <span class="hidden sm:inline">Retry</span>
-                    </button>
-                  </form>
-                {% endif %}
               </td>
             </tr>
             {% endfor %}
           {% else %}
             <tr>
-              <td colspan="5" class="px-3 py-3 sm:px-6 sm:py-4 text-center text-sm text-gray-500">
-                No jobs found in this queue
+              <td colspan="3" class="px-3 py-3 sm:px-6 sm:py-4 text-center text-sm text-gray-500">
+                No ready jobs in this queue
               </td>
             </tr>
           {% endif %}

--- a/src/query_builder.rs
+++ b/src/query_builder.rs
@@ -1313,6 +1313,51 @@ pub mod ready_executions {
         Ok(out)
     }
 
+    /// Count ready executions for a single queue
+    pub async fn count_by_queue_name<C>(
+        db: &C,
+        table_config: &TableConfig,
+        queue_name: &str,
+    ) -> Result<u64, DbErr>
+    where
+        C: ConnectionTrait,
+    {
+        let table = Alias::new(&table_config.ready_executions);
+        let query = Query::select()
+            .expr(Expr::col(Asterisk).count())
+            .from(table)
+            .and_where(Expr::col(col("queue_name")).eq(queue_name))
+            .to_owned();
+
+        execute_count(db, query).await
+    }
+
+    /// Find ready executions for a queue with pagination, ordered by priority then id
+    /// (matching the order workers will pull jobs in).
+    pub async fn find_by_queue_paginated<C>(
+        db: &C,
+        table_config: &TableConfig,
+        queue_name: &str,
+        offset: u64,
+        limit: u64,
+    ) -> Result<Vec<quebec_ready_executions::Model>, DbErr>
+    where
+        C: ConnectionTrait,
+    {
+        let table = Alias::new(&table_config.ready_executions);
+        let query = Query::select()
+            .column(Asterisk)
+            .from(table)
+            .and_where(Expr::col(col("queue_name")).eq(queue_name))
+            .order_by(col("priority"), Order::Asc)
+            .order_by(col("job_id"), Order::Asc)
+            .offset(offset)
+            .limit(limit)
+            .to_owned();
+
+        execute_select(db, query).await
+    }
+
     /// Get the oldest ready execution's created_at for pending latency calculation
     pub async fn oldest_created_at<C>(
         db: &C,


### PR DESCRIPTION
## Summary

- Queue list page counted only `ready_executions`, but the queue detail page counted `jobs.finished_at IS NULL` (ready + blocked + scheduled + claimed + failed). A queue listed as size 0 could still show blocked jobs when clicked through, and the detail number never lined up with either the list or the top-nav `Blocked/Scheduled/...` counters.
- Switch the detail page to `ready_executions` to match the list and Mission Control's `Queue#jobs` (pending only). Blocked / scheduled / in-progress / failed are surfaced via their own top-nav tabs.
- Drop the dead status badge and per-row Retry button from the detail template (no non-ready rows reach it anymore), and clarify the page heading + empty state so the new semantics are obvious.

## Changes

- `src/query_builder.rs`: add `ready_executions::count_by_queue_name` and `ready_executions::find_by_queue_paginated` (priority ASC, job_id ASC — same order workers pull in).
- `src/control_plane/handlers/queues.rs`: `queue_details` counts and fetches from `ready_executions`, joins to `jobs` for class_name/created_at. Removes ~100 lines of failed/claimed/scheduled/blocked status-tagging.
- `src/control_plane/models.rs`: drop now-unused `status` / `execution_id` from `QueueJobInfo`.
- `src/control_plane/templates/queue-details.html`: remove Status / Actions columns (desktop) and status badge / Retry button (mobile); rename "Jobs in Queue" → "Ready Jobs in Queue" with a sentence explaining other statuses live in the top-nav tabs.

## Test plan

- [x] `cargo check --all-features`
- [x] `cargo clippy --all-targets --all-features`
- [x] `cargo fmt --all -- --check`
- [ ] Manually verify `/queues/<name>` in the control plane shows the same count as the row in `/queues`, and that empty queues say "No ready jobs in this queue"