### PR TITLE
fix(worker): prevent duplicate job execution during graceful shutdown

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -364,6 +364,41 @@ pub struct AppContext {
     /// (non-supervised) runs, the supervisor parent itself, and the
     /// scheduler (which is always a single process).
     pub proc_slot: Option<(usize, usize)>,
+    /// claimed_execution ids that have been pulled off the dispatch channel
+    /// and are currently inside a Python `perform()`. Populated at the start
+    /// of `Execution::invoke` and cleared in `after_executed`. Consulted by
+    /// `release_all_claimed_executions` during graceful shutdown so an
+    /// actively-running job is not handed back to a neighbour worker (which
+    /// would run it a second time concurrently). Plain `Mutex<HashSet>`: the
+    /// guarded section is a single insert/remove/contains, never held across
+    /// an await.
+    pub in_flight_executions: Arc<std::sync::Mutex<HashSet<i64>>>,
+}
+
+/// RAII guard that marks a claimed_execution as in-flight for the lifetime of
+/// a `perform()` call. Inserts the id on construction and removes it on drop,
+/// so the entry is cleared on every exit path — normal completion, error, or a
+/// panic propagating out of `Execution::invoke`.
+pub struct InFlightGuard {
+    set: Arc<std::sync::Mutex<HashSet<i64>>>,
+    id: i64,
+}
+
+impl InFlightGuard {
+    pub fn new(set: Arc<std::sync::Mutex<HashSet<i64>>>, id: i64) -> Self {
+        if let Ok(mut guard) = set.lock() {
+            guard.insert(id);
+        }
+        Self { set, id }
+    }
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        if let Ok(mut guard) = self.set.lock() {
+            guard.remove(&self.id);
+        }
+    }
 }
 
 /// Parse env var string as bool: true/1/yes → true, false/0/no → false
@@ -789,6 +824,7 @@ impl AppContext {
             idle_notify: Arc::new(RwLock::new(None)),
             supervisor_pid: AtomicI32::new(0),
             proc_slot: None,
+            in_flight_executions: Arc::new(std::sync::Mutex::new(HashSet::new())),
         }
     }
 
@@ -882,6 +918,10 @@ impl AppContext {
             // Preserve so re-forks (or apply_*_config re-using a forked ctx)
             // keep the slot label until explicitly reset by apply_*_config.
             proc_slot: self.proc_slot,
+            // Fresh per-process tracking: the child runs its own worker /
+            // dispatch channel, so in-flight ids must not be shared with the
+            // parent (whose claims belong to a different process record).
+            in_flight_executions: Arc::new(std::sync::Mutex::new(HashSet::new())),
             use_listen_notify: self.use_listen_notify,
             notify_throttle_interval: self.notify_throttle_interval,
             force_override_queue: self.force_override_queue.clone(),

--- a/src/context.rs
+++ b/src/context.rs
@@ -389,18 +389,21 @@ pub struct InFlightGuard {
 
 impl InFlightGuard {
     pub fn new(set: Arc<std::sync::Mutex<HashSet<i64>>>, id: i64) -> Self {
-        if let Ok(mut guard) = set.lock() {
-            guard.insert(id);
-        }
+        // Recover from poisoning: the set is a plain HashSet that stays
+        // consistent even if a holder panicked, and silently skipping the
+        // insert would let the shutdown release treat a running job as
+        // releasable.
+        set.lock().unwrap_or_else(|e| e.into_inner()).insert(id);
         Self { set, id }
     }
 }
 
 impl Drop for InFlightGuard {
     fn drop(&mut self) {
-        if let Ok(mut guard) = self.set.lock() {
-            guard.remove(&self.id);
-        }
+        self.set
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&self.id);
     }
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -364,14 +364,17 @@ pub struct AppContext {
     /// (non-supervised) runs, the supervisor parent itself, and the
     /// scheduler (which is always a single process).
     pub proc_slot: Option<(usize, usize)>,
-    /// claimed_execution ids that have been pulled off the dispatch channel
-    /// and are currently inside a Python `perform()`. Populated at the start
-    /// of `Execution::invoke` and cleared in `after_executed`. Consulted by
-    /// `release_all_claimed_executions` during graceful shutdown so an
-    /// actively-running job is not handed back to a neighbour worker (which
-    /// would run it a second time concurrently). Plain `Mutex<HashSet>`: the
-    /// guarded section is a single insert/remove/contains, never held across
-    /// an await.
+    /// claimed_execution ids that have been handed to the Python side and have
+    /// not finished yet. Inserted in `Worker::pick_job` (when a job leaves the
+    /// dispatch channel for the Python work queue) and again at the start of
+    /// `Execution::invoke` (idempotent). Removed when `perform()` finishes (the
+    /// `InFlightGuard`), and on `Execution`'s `Drop` as a backstop for a job
+    /// that is picked but never performed. `release_all_claimed_executions`
+    /// skips these during graceful shutdown and the shutdown drain waits for
+    /// the set to empty, so a running or about-to-run job is never handed back
+    /// to a neighbour worker (which would run it a second time). Plain
+    /// `Mutex<HashSet>`: the guarded section is a single
+    /// insert/remove/contains, never held across an await.
     pub in_flight_executions: Arc<std::sync::Mutex<HashSet<i64>>>,
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -985,6 +985,44 @@ impl PyQuebec {
         Ok(())
     }
 
+    /// Register a worker process record and store its id on the worker, the
+    /// same `on_start` step the real main loop performs. Returns the process
+    /// id. Test-only: lets a regression test claim jobs under a known process
+    /// id and then drive `release_claimed_for_shutdown` deterministically.
+    fn register_worker_process(&self, py: Python<'_>) -> PyResult<i64> {
+        let worker = self.worker.clone();
+        py.detach(|| {
+            self.rt.block_on(async move {
+                worker.register_process_for_test().await.map_err(|e| {
+                    PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
+                        "register_worker_process failed: {e}"
+                    ))
+                })
+            })
+        })
+    }
+
+    /// Run the graceful-shutdown release path (`release_all_claimed_executions`)
+    /// for the given process id and return how many claimed jobs were released
+    /// back to ready. Test-only hook: exercises the shutdown release without
+    /// the full main loop / SIGTERM dance so a regression test can assert that
+    /// a job currently inside perform() is NOT released.
+    fn release_claimed_for_shutdown(&self, py: Python<'_>, process_id: i64) -> PyResult<usize> {
+        let worker = self.worker.clone();
+        py.detach(|| {
+            self.rt.block_on(async move {
+                worker
+                    .release_claimed_for_test(process_id)
+                    .await
+                    .map_err(|e| {
+                        PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
+                            "release_claimed_for_shutdown failed: {e}"
+                        ))
+                    })
+            })
+        })
+    }
+
     fn bind_queue(&self, _py: Python<'_>, queue: Py<PyAny>) -> PyResult<()> {
         let worker = self.worker.clone();
         let queue = queue.clone();

--- a/src/types.rs
+++ b/src/types.rs
@@ -1034,16 +1034,18 @@ impl PyQuebec {
         // Use tokio::spawn to start async task
         self.rt.spawn(async move {
             loop {
-                let result = worker.pick_job().await;
+                // pick_job returns Err when the dispatch channel is closed or
+                // graceful shutdown has begun. In both cases the pump stops so
+                // it cannot hand a job to Python concurrently with the shutdown
+                // release path (which would race a double-run).
+                let res = match worker.pick_job().await {
+                    Ok(res) => res,
+                    Err(_) => break,
+                };
 
                 // Get GIL and send result to Python queue
                 Python::attach(|py| {
                     let queue = queue.bind(py);
-
-                    let Ok(res) = result else {
-                        debug!("No job available");
-                        return;
-                    };
 
                     // Determine which method to use based on queue type
                     let method_name = if queue.hasattr("put_nowait").unwrap_or(false) {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -3131,17 +3131,44 @@ impl Worker {
                         }
                     });
 
-                    // Release remaining claimed executions back to ready state BEFORE
-                    // deleting the process record, to avoid a race where another worker's
-                    // fail_orphaned_executions sees them as orphans and marks them failed.
-                    // Only jobs that have NOT started running are released (claimed but
-                    // still queued in the mpsc channel / Python work queue). Jobs currently
-                    // inside perform() are tracked in ctx.in_flight_executions and left
-                    // claimed: graceful_shutdown ends with process::exit(0), which kills the
-                    // Python perform threads before their after_executed() can run, so
-                    // releasing an in-flight job here would let a neighbour worker claim and
-                    // run it concurrently (duplicate execution). Those rows are reaped by a
-                    // neighbour's prune_dead_processes after this process stops heart-beating.
+                    // Wait for jobs currently inside perform() to finish before
+                    // releasing anything. Once shutdown starts the Python
+                    // ThreadedRunner stops pulling new jobs (it polls
+                    // is_shutting_down), so in_flight drains as running jobs
+                    // complete via after_executed(), which removes their claimed
+                    // row. Bounded by shutdown_timeout so a stuck job cannot block
+                    // shutdown forever.
+                    let drain_deadline =
+                        tokio::time::Instant::now() + self.ctx.shutdown_timeout;
+                    loop {
+                        let in_flight_empty = self
+                            .ctx
+                            .in_flight_executions
+                            .lock()
+                            .map(|s| s.is_empty())
+                            .unwrap_or(true);
+                        if in_flight_empty {
+                            break;
+                        }
+                        if tokio::time::Instant::now() >= drain_deadline {
+                            warn!(
+                                "Shutdown drain timed out with jobs still inside perform(); \
+                                 leaving them claimed to avoid a double-execution race"
+                            );
+                            break;
+                        }
+                        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                    }
+
+                    // Release jobs that never started running (still queued in the
+                    // mpsc channel or the Python work queue) back to ready so the
+                    // dispatcher can re-claim them. Jobs that finished perform()
+                    // during the drain above are already gone from
+                    // claimed_executions. If the drain timed out, rows still
+                    // in_flight are skipped (release_all_claimed_executions filters
+                    // them) to avoid handing a running job to a neighbour; those are
+                    // reaped later by the supervisor's orphan sweep or a restarting
+                    // worker's fail_orphaned_executions.
                     if let Err(e) = self.release_all_claimed_executions(process.id).await {
                         warn!("Failed to release claimed executions on shutdown: {}", e);
                     }
@@ -3400,6 +3427,17 @@ impl Worker {
             return Err(QuebecError::runtime("No job found"));
         }
         let execution = execution.ok_or_else(|| QuebecError::runtime("No job found"))?;
+        // Mark in-flight the moment a job leaves the dispatch channel for the
+        // Python side. From here it may sit buffered in the Python work queue
+        // before perform() begins; tracking it now means the shutdown drain
+        // waits for it and release_all_claimed_executions never hands it back
+        // to ready underneath a runner that is about to execute it. The
+        // InFlightGuard in Execution::invoke re-inserts (idempotent) and
+        // removes the id on completion, so the entry is cleared once perform
+        // finishes via after_executed.
+        if let Ok(mut set) = self.ctx.in_flight_executions.lock() {
+            set.insert(execution.claimed.id);
+        }
         Ok(execution)
     }
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1001,6 +1001,17 @@ impl Execution {
     }
 
     async fn invoke(&mut self) -> Result<quebec_jobs::Model> {
+        // Mark this claimed_execution as in-flight for the whole perform()
+        // window. `release_all_claimed_executions` (graceful shutdown) skips
+        // ids still in this set so a job actively inside perform() is never
+        // handed back to a neighbour worker. The guard clears the id when this
+        // function returns (after `after_executed` has deleted the claimed
+        // row) or unwinds, so the entry never outlives the perform.
+        let _in_flight = crate::context::InFlightGuard::new(
+            self.ctx.in_flight_executions.clone(),
+            self.claimed.id,
+        );
+
         self.timer = Instant::now();
         let now = chrono::Utc::now().naive_utc();
         self.started_at = Some(now);
@@ -1686,6 +1697,24 @@ impl Worker {
 
     pub fn process_id_handle(&self) -> Arc<tokio::sync::Mutex<Option<i64>>> {
         self.process_id.clone()
+    }
+
+    /// Register a worker process record and store its id, mirroring the
+    /// `on_start` step of `run_main_loop`. Test-only hook so a regression test
+    /// can claim jobs under a known process id and then exercise
+    /// `release_all_claimed_executions` deterministically.
+    pub(crate) async fn register_process_for_test(&self) -> Result<i64> {
+        let db = self.ctx.get_db().await?;
+        let process = self.on_start(&db).await?;
+        *self.process_id.lock().await = Some(process.id);
+        Ok(process.id)
+    }
+
+    /// Test-only wrapper around the private `release_all_claimed_executions`
+    /// so the graceful-shutdown release path can be driven from pytest without
+    /// spinning up the full main loop and signalling SIGTERM.
+    pub(crate) async fn release_claimed_for_test(&self, process_id: i64) -> Result<usize> {
+        self.release_all_claimed_executions(process_id).await
     }
 
     fn register_handler(
@@ -2492,8 +2521,15 @@ impl Worker {
         Ok(total_deleted)
     }
 
-    /// Release all claimed executions for a process back to ready state.
-    /// Called during graceful shutdown for jobs claimed but not yet started.
+    /// Release claimed executions for a process back to ready state during
+    /// graceful shutdown. Releases jobs that have not yet started running —
+    /// those still sitting in the dispatch channel or the Python work queue —
+    /// so the dispatcher can re-claim them immediately. Jobs currently inside
+    /// `perform()` (tracked in `ctx.in_flight_executions`) are deliberately
+    /// left in `claimed_executions`: releasing them would let a neighbour
+    /// worker claim and run the same job concurrently while this process's
+    /// perform thread is still executing it. Those rows are reaped later by a
+    /// neighbour's `prune_dead_processes` once this process stops heart-beating.
     /// Unlike fail_orphaned_executions, this does NOT mark jobs as failed.
     /// Matches Solid Queue's Process::Executor#after_destroy :release_all_claimed_executions.
     async fn release_all_claimed_executions(&self, process_id: i64) -> Result<usize> {
@@ -2506,6 +2542,19 @@ impl Worker {
             process_id,
         )
         .await?;
+
+        // Skip executions that are actively running inside perform(); releasing
+        // them would create a duplicate-execution race with a neighbour worker.
+        let in_flight: std::collections::HashSet<i64> = self
+            .ctx
+            .in_flight_executions
+            .lock()
+            .map(|guard| guard.clone())
+            .unwrap_or_default();
+        let claimed: Vec<_> = claimed
+            .into_iter()
+            .filter(|execution| !in_flight.contains(&execution.id))
+            .collect();
 
         if claimed.is_empty() {
             return Ok(0);
@@ -3085,9 +3134,14 @@ impl Worker {
                     // Release remaining claimed executions back to ready state BEFORE
                     // deleting the process record, to avoid a race where another worker's
                     // fail_orphaned_executions sees them as orphans and marks them failed.
-                    // Python side calls t.join() first, so actively-running jobs complete
-                    // normally via after_executed(). This handles jobs that were claimed
-                    // but not yet started (sitting in the mpsc channel).
+                    // Only jobs that have NOT started running are released (claimed but
+                    // still queued in the mpsc channel / Python work queue). Jobs currently
+                    // inside perform() are tracked in ctx.in_flight_executions and left
+                    // claimed: graceful_shutdown ends with process::exit(0), which kills the
+                    // Python perform threads before their after_executed() can run, so
+                    // releasing an in-flight job here would let a neighbour worker claim and
+                    // run it concurrently (duplicate execution). Those rows are reaped by a
+                    // neighbour's prune_dead_processes after this process stops heart-beating.
                     if let Err(e) = self.release_all_claimed_executions(process.id).await {
                         warn!("Failed to release claimed executions on shutdown: {}", e);
                     }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -953,6 +953,19 @@ pub struct Execution {
     idle_notify: Option<Arc<tokio::sync::Notify>>,
 }
 
+impl Drop for Execution {
+    fn drop(&mut self) {
+        // Backstop for the in-flight set: pick_job marks a job in-flight when it
+        // leaves the dispatch channel and the InFlightGuard in invoke() normally
+        // clears it. If a picked Execution is dropped without ever running
+        // perform() (e.g. it failed to enqueue to the Python work queue), clear
+        // the entry here so the shutdown drain is not left waiting on it.
+        if let Ok(mut set) = self.ctx.in_flight_executions.lock() {
+            set.remove(&self.claimed.id);
+        }
+    }
+}
+
 impl Execution {
     pub fn new(
         ctx: Arc<AppContext>,
@@ -2522,14 +2535,19 @@ impl Worker {
     }
 
     /// Release claimed executions for a process back to ready state during
-    /// graceful shutdown. Releases jobs that have not yet started running —
-    /// those still sitting in the dispatch channel or the Python work queue —
-    /// so the dispatcher can re-claim them immediately. Jobs currently inside
-    /// `perform()` (tracked in `ctx.in_flight_executions`) are deliberately
-    /// left in `claimed_executions`: releasing them would let a neighbour
-    /// worker claim and run the same job concurrently while this process's
-    /// perform thread is still executing it. Those rows are reaped later by a
-    /// neighbour's `prune_dead_processes` once this process stops heart-beating.
+    /// graceful shutdown. Releases jobs that have not started running — those
+    /// still sitting in the dispatch channel — so the dispatcher can re-claim
+    /// them immediately. Jobs that have been handed to the Python side (tracked
+    /// in `ctx.in_flight_executions`) are skipped: the shutdown drain waits for
+    /// that set to empty first, so in normal shutdown there are none left here.
+    /// Any that remain (the drain hit `shutdown_timeout`) are left in
+    /// `claimed_executions` rather than released, because releasing a job whose
+    /// perform thread is still running would let a neighbour run it a second
+    /// time; those leftovers are reclaimed by the supervisor's orphan sweep or a
+    /// restarting worker's `fail_orphaned_executions` (both match claims whose
+    /// process row no longer exists — `prune_dead_processes`, which only finds
+    /// stale-but-present rows, would miss them since this process deletes its
+    /// own row right after).
     /// Unlike fail_orphaned_executions, this does NOT mark jobs as failed.
     /// Matches Solid Queue's Process::Executor#after_destroy :release_all_claimed_executions.
     async fn release_all_claimed_executions(&self, process_id: i64) -> Result<usize> {
@@ -3131,15 +3149,17 @@ impl Worker {
                         }
                     });
 
-                    // Wait for jobs currently inside perform() to finish before
-                    // releasing anything. Once shutdown starts the Python
-                    // ThreadedRunner stops pulling new jobs (it polls
-                    // is_shutting_down), so in_flight drains as running jobs
-                    // complete via after_executed(), which removes their claimed
-                    // row. Bounded by shutdown_timeout so a stuck job cannot block
-                    // shutdown forever.
-                    let drain_deadline =
-                        tokio::time::Instant::now() + self.ctx.shutdown_timeout;
+                    // Wait for jobs already handed to the Python side to finish
+                    // before releasing anything. pick_job stops feeding the
+                    // Python work queue once shutdown begins (it returns Err on
+                    // the cancellation token), so the ThreadedRunner drains the
+                    // buffered jobs and in_flight empties as each completes via
+                    // after_executed(), which removes its claimed row. Use a
+                    // fraction of shutdown_timeout so the outer graceful_shutdown
+                    // block_on still has budget to run the release and on_stop
+                    // below before its own timeout fires.
+                    let drain_deadline = tokio::time::Instant::now()
+                        + self.ctx.shutdown_timeout.mul_f64(0.8);
                     loop {
                         let in_flight_empty = self
                             .ctx
@@ -3422,10 +3442,20 @@ impl Worker {
     pub async fn pick_job(&self) -> Result<Execution> {
         let rx = self.dispatch_receiver.clone();
         let mut receiver = rx.lock().await;
-        let execution = receiver.recv().await;
-        if execution.is_none() {
-            return Err(QuebecError::runtime("No job found"));
-        }
+        // Stop handing channel jobs to the Python side once graceful shutdown
+        // begins. The shutdown release path runs concurrently; if we kept
+        // picking here we could mark a job in-flight and enqueue it to Python
+        // *after* release has snapshotted it as releasable, double-running it.
+        // Cancelling the recv leaves the job in the channel so the release
+        // returns it to ready (it never started). `biased` checks shutdown
+        // first so a job is never pulled after cancellation.
+        let execution = tokio::select! {
+            biased;
+            _ = self.ctx.graceful_shutdown.cancelled() => {
+                return Err(QuebecError::runtime("shutting down"));
+            }
+            execution = receiver.recv() => execution,
+        };
         let execution = execution.ok_or_else(|| QuebecError::runtime("No job found"))?;
         // Mark in-flight the moment a job leaves the dispatch channel for the
         // Python side. From here it may sit buffered in the Python work queue
@@ -3433,8 +3463,8 @@ impl Worker {
         // waits for it and release_all_claimed_executions never hands it back
         // to ready underneath a runner that is about to execute it. The
         // InFlightGuard in Execution::invoke re-inserts (idempotent) and
-        // removes the id on completion, so the entry is cleared once perform
-        // finishes via after_executed.
+        // removes the id on completion; Execution's Drop clears it too, so a
+        // picked job that never reaches perform() cannot leak its entry.
         if let Ok(mut set) = self.ctx.in_flight_executions.lock() {
             set.insert(execution.claimed.id);
         }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -960,9 +960,11 @@ impl Drop for Execution {
         // clears it. If a picked Execution is dropped without ever running
         // perform() (e.g. it failed to enqueue to the Python work queue), clear
         // the entry here so the shutdown drain is not left waiting on it.
-        if let Ok(mut set) = self.ctx.in_flight_executions.lock() {
-            set.remove(&self.claimed.id);
-        }
+        self.ctx
+            .in_flight_executions
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&self.claimed.id);
     }
 }
 
@@ -2563,12 +2565,14 @@ impl Worker {
 
         // Skip executions that are actively running inside perform(); releasing
         // them would create a duplicate-execution race with a neighbour worker.
+        // Recover from poisoning rather than treating it as an empty set, which
+        // would let a running job be released back to ready (double-run).
         let in_flight: std::collections::HashSet<i64> = self
             .ctx
             .in_flight_executions
             .lock()
-            .map(|guard| guard.clone())
-            .unwrap_or_default();
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
         let claimed: Vec<_> = claimed
             .into_iter()
             .filter(|execution| !in_flight.contains(&execution.id))
@@ -3165,8 +3169,8 @@ impl Worker {
                             .ctx
                             .in_flight_executions
                             .lock()
-                            .map(|s| s.is_empty())
-                            .unwrap_or(true);
+                            .unwrap_or_else(|e| e.into_inner())
+                            .is_empty();
                         if in_flight_empty {
                             break;
                         }
@@ -3471,10 +3475,14 @@ impl Worker {
         // and removes the id on completion; Execution's Drop clears it too, so a
         // picked job that never reaches perform() cannot leak its entry.
         {
-            let mut set = match self.ctx.in_flight_executions.lock() {
-                Ok(set) => set,
-                Err(_) => return Ok(execution),
-            };
+            // Recover from poisoning rather than failing open: returning Ok here
+            // would bypass the shutdown recheck and hand a possibly-released job
+            // to Python. The set stays consistent across a panic.
+            let mut set = self
+                .ctx
+                .in_flight_executions
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
             if self.ctx.graceful_shutdown.is_cancelled() {
                 return Err(QuebecError::runtime("shutting down"));
             }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -3458,14 +3458,26 @@ impl Worker {
         };
         let execution = execution.ok_or_else(|| QuebecError::runtime("No job found"))?;
         // Mark in-flight the moment a job leaves the dispatch channel for the
-        // Python side. From here it may sit buffered in the Python work queue
-        // before perform() begins; tracking it now means the shutdown drain
-        // waits for it and release_all_claimed_executions never hands it back
-        // to ready underneath a runner that is about to execute it. The
-        // InFlightGuard in Execution::invoke re-inserts (idempotent) and
-        // removes the id on completion; Execution's Drop clears it too, so a
+        // Python side, holding the same lock the shutdown release takes its
+        // snapshot under and re-checking the shutdown token while held. The
+        // `select!` above only blocks pulls observed *before* recv() returns;
+        // shutdown can still begin between recv() and this insert, and a
+        // concurrent release could snapshot in_flight without this id. The
+        // recheck under the lock closes that window: if shutdown has begun we
+        // bail out, leaving the job's claimed row in the DB and out of
+        // in_flight so the release returns it to ready instead of us handing it
+        // to Python and double-running it. Outside shutdown this is a single
+        // insert. The InFlightGuard in Execution::invoke re-inserts (idempotent)
+        // and removes the id on completion; Execution's Drop clears it too, so a
         // picked job that never reaches perform() cannot leak its entry.
-        if let Ok(mut set) = self.ctx.in_flight_executions.lock() {
+        {
+            let mut set = match self.ctx.in_flight_executions.lock() {
+                Ok(set) => set,
+                Err(_) => return Ok(execution),
+            };
+            if self.ctx.graceful_shutdown.is_cancelled() {
+                return Err(QuebecError::runtime("shutting down"));
+            }
             set.insert(execution.claimed.id);
         }
         Ok(execution)

--- a/tests/test_shutdown_release.py
+++ b/tests/test_shutdown_release.py
@@ -1,0 +1,125 @@
+# coding: utf-8
+"""Regression tests for the graceful-shutdown claimed-execution release path.
+
+During graceful shutdown a worker releases its claimed-but-not-started jobs
+back to ready so the dispatcher can re-claim them. Jobs that are *currently
+inside* ``perform()`` must NOT be released: ``graceful_shutdown`` ends with
+``process::exit(0)``, killing the perform thread, so releasing the job would
+let a neighbour worker claim and run the same job concurrently (duplicate
+execution + lost result).
+
+These tests drive ``release_claimed_for_shutdown`` (the same code path the
+shutdown branch of ``run_main_loop`` calls) directly, without the full main
+loop / SIGTERM dance, so the race is reproduced deterministically.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import quebec
+from sqlalchemy import text
+
+from .helpers import wait_until
+
+
+def _count(session, prefix: str, table: str) -> int:
+    return session.execute(text(f"SELECT COUNT(*) FROM {prefix}_{table}")).scalar()
+
+
+def test_in_flight_job_is_not_released_on_shutdown(qc_with_sqlalchemy):
+    """A job inside perform() stays in claimed_executions on shutdown release."""
+    ctx = qc_with_sqlalchemy
+    qc = ctx["qc"]
+    session = ctx["session"]
+    prefix = ctx["prefix"]
+
+    started = threading.Event()
+    release_perform = threading.Event()
+
+    class BlockingJob(quebec.ActiveJob):
+        def perform(self, *args, **kwargs):
+            started.set()
+            # Hold inside perform() to keep the execution "in-flight" while the
+            # shutdown release runs.
+            release_perform.wait(timeout=10)
+            return True
+
+    qc.register_job(BlockingJob)
+
+    # Register a process so claimed rows carry a known process_id; the shutdown
+    # release filters by it.
+    process_id = qc.register_worker_process()
+
+    enqueued = BlockingJob.perform_later(qc)
+    execution = qc.drain_one()
+
+    session.expire_all()
+    assert _count(session, prefix, "claimed_executions") == 1
+    assert _count(session, prefix, "ready_executions") == 0
+
+    perform_thread = threading.Thread(target=execution.perform, daemon=True)
+    perform_thread.start()
+    try:
+        wait_until(
+            started.is_set,
+            timeout=5,
+            message="perform() never started",
+        )
+
+        # Drive the graceful-shutdown release while the job is mid-perform.
+        released = qc.release_claimed_for_shutdown(process_id)
+
+        # The in-flight job must NOT be released: nothing returned to ready,
+        # and the claimed row is still present.
+        assert released == 0
+        session.expire_all()
+        assert _count(session, prefix, "ready_executions") == 0
+        assert _count(session, prefix, "claimed_executions") == 1
+    finally:
+        release_perform.set()
+        perform_thread.join(timeout=5)
+
+    assert not perform_thread.is_alive()
+
+    # The original perform completed normally via after_executed(): the claimed
+    # row is gone, the job is finished, and it never bounced back to ready.
+    session.expire_all()
+    assert _count(session, prefix, "claimed_executions") == 0
+    assert _count(session, prefix, "ready_executions") == 0
+    finished = session.execute(
+        text(f"SELECT finished_at FROM {prefix}_jobs WHERE id = :id"),
+        {"id": enqueued.id},
+    ).scalar()
+    assert finished is not None
+
+
+def test_claimed_but_not_started_job_is_released_on_shutdown(qc_with_sqlalchemy):
+    """A claimed job that never entered perform() IS released back to ready."""
+    ctx = qc_with_sqlalchemy
+    qc = ctx["qc"]
+    session = ctx["session"]
+    prefix = ctx["prefix"]
+
+    class IdleJob(quebec.ActiveJob):
+        def perform(self, *args, **kwargs):
+            return True
+
+    qc.register_job(IdleJob)
+
+    process_id = qc.register_worker_process()
+
+    IdleJob.perform_later(qc)
+    # Claim it (now in claimed_executions) but do NOT call perform().
+    qc.drain_one()
+
+    session.expire_all()
+    assert _count(session, prefix, "claimed_executions") == 1
+    assert _count(session, prefix, "ready_executions") == 0
+
+    released = qc.release_claimed_for_shutdown(process_id)
+
+    assert released == 1
+    session.expire_all()
+    assert _count(session, prefix, "claimed_executions") == 0
+    assert _count(session, prefix, "ready_executions") == 1


### PR DESCRIPTION
## The bug

During graceful shutdown, a job that is **actively running inside `perform()`** could be executed a second time on another worker.

A job flows through several buffers before it runs: `ready_executions` → `claimed_executions` (claimed, owned by a `process_id`) → Rust mpsc channel → Python work queue → `perform()`. On SIGTERM, `release_all_claimed_executions` moved **every** claimed row of the process back to `ready` — including the one a Python thread was still executing — and then `graceful_shutdown` ended with `std::process::exit(0)`, hard-killing the perform thread. A neighbour worker would see the row back in `ready`, claim it, and run it again.

**Observed symptom:** rolling deploys / SIGTERM with a long-running job in flight ⇒ the job runs twice (duplicate emails, double charges, duplicate external API resources) and the original run's result is lost.

The prior code comment assumed "the Python side calls `t.join()` first so running jobs finish normally" — but `process::exit(0)` runs before that `join()` ever gets a chance, so the assumption never held.

## The fix (pure Rust — `ThreadedRunner` unchanged)

Track which claimed executions have been handed to the Python side and must not be released:

- Mark in-flight at `Worker::pick_job` — the single point a job leaves the dispatch channel for Python — so even jobs buffered in the Python queue are covered, re-checked under the same lock the release path snapshots under.
- `pick_job` stops pulling from the channel once shutdown is cancelled (`select!` on the cancellation token), so it can't hand a job to Python concurrently with the release.
- The shutdown branch **drains** the in-flight set (running jobs finish via `after_executed`, which deletes their claimed row) before releasing, bounded by 80% of `shutdown_timeout` so the outer `block_on` still has budget for release + `on_stop`.
- `Execution::drop` backstops the in-flight entry for a picked-but-never-performed job.
- All `in_flight_executions` lock sites recover from poisoning (`into_inner`) instead of failing open.

Net: running jobs finish (no duplicate), never-started jobs are released back to ready (no loss), with no interleaving where the same job is both released and handed to Python.

## Test plan

- [x] `cargo clippy --all-targets --all-features` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `uv run pytest --ignore=tests/step_defs` — 164 passed
- [x] New `tests/test_shutdown_release.py`: an in-flight job is NOT released on shutdown (and finishes normally), a claimed-but-not-started job IS released back to ready
- [ ] Manual: multi-worker deploy with a long job in flight, confirm no double-run