### PR TITLE
test: Solid Queue parity regression tests

### DIFF
--- a/tests/test_concurrency_force_fail.py
+++ b/tests/test_concurrency_force_fail.py
@@ -1,0 +1,107 @@
+"""Regression: force-failing a dead worker's claimed execution must release the
+class-level concurrency lock and promote the next blocked job.
+
+Mirror of Solid Queue PR #547 / commit 95dc9b4: ``ClaimedExecution.fail_all_with``
+used to only write failed_executions rows without releasing the class-level
+concurrency semaphore, so jobs blocked on the same ``concurrency_key`` stayed
+stuck until the semaphore TTL expired (default 60s).
+
+Quebec routes every force-fail path (supervisor reap, orphan sweep,
+``prune_dead_processes``) through ``Worker::fail_claimed_execution`` →
+``unblock_next_job``, which releases the semaphore and promotes the next blocked
+job. This test locks that behavior in via the supervisor force-fail entrypoint
+``qc.supervisor_fail_claimed_by_process_id``.
+"""
+
+from __future__ import annotations
+
+import quebec
+from sqlalchemy import text
+
+
+class ForceFailJob(quebec.BaseClass):
+    concurrency_limit = 1
+
+    @staticmethod
+    def concurrency_key(*args, **kwargs) -> str:
+        return "exclusive-resource"
+
+    def perform(self, value: int) -> None:
+        return None
+
+
+def test_force_fail_releases_lock_and_promotes_blocked(
+    qc_with_sqlalchemy, db_assert
+) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    qc.register_job(ForceFailJob)
+
+    # Register a process row to act as the (soon to be dead) worker that holds
+    # job A's claim.
+    process_id = qc.register_supervisor()
+
+    # A enqueues normally: acquires the only slot for the key, lands in ready.
+    job_a = ForceFailJob.perform_later(qc, 1)
+    assert db_assert.count_ready_executions() == 1
+    assert db_assert.count_blocked_executions() == 0
+
+    # Simulate A having been claimed by that worker: move it from ready to
+    # claimed under the process. The class-level semaphore stays held.
+    session.execute(
+        text(f"DELETE FROM {prefix}_ready_executions WHERE job_id = :jid"),
+        {"jid": job_a.id},
+    )
+    session.execute(
+        text(
+            f"INSERT INTO {prefix}_claimed_executions "
+            "(job_id, process_id, created_at) "
+            "VALUES (:jid, :pid, CURRENT_TIMESTAMP)"
+        ),
+        {"jid": job_a.id, "pid": process_id},
+    )
+    session.commit()
+    session.expire_all()
+    assert db_assert.count_claimed_executions() == 1
+
+    # B enqueues for the same key while A holds the slot -> blocked.
+    job_b = ForceFailJob.perform_later(qc, 2)
+    session.expire_all()
+    assert db_assert.count_blocked_executions() == 1
+    assert db_assert.count_ready_executions() == 0
+    blocked_job_id = session.execute(
+        text(f"SELECT job_id FROM {prefix}_blocked_executions")
+    ).scalar()
+    assert blocked_job_id == job_b.id
+
+    # Semaphore is held (value=0) before the worker dies.
+    sem = session.execute(text(f"SELECT value FROM {prefix}_semaphores")).fetchone()
+    assert sem.value == 0
+
+    # The worker dies: supervisor force-fails its claimed executions. This is
+    # the path that must also release the class-level lock and unblock B.
+    failed = qc.supervisor_fail_claimed_by_process_id(process_id)
+    assert failed == 1
+
+    session.expire_all()
+
+    # A's claim is gone and recorded as failed.
+    assert db_assert.count_claimed_executions() == 0
+    assert db_assert.job_is_failed(job_a.id)
+
+    # The lock was released: B is promoted from blocked to ready immediately,
+    # not left waiting for the semaphore TTL to expire.
+    assert db_assert.count_blocked_executions() == 0, (
+        "blocked job must be promoted after the held lock is released"
+    )
+    assert db_assert.count_ready_executions() == 1
+    ready_job_id = session.execute(
+        text(f"SELECT job_id FROM {prefix}_ready_executions")
+    ).scalar()
+    assert ready_job_id == job_b.id
+
+    # The slot is now held by B (value back to 0 after its promotion acquire).
+    sem = session.execute(text(f"SELECT value FROM {prefix}_semaphores")).fetchone()
+    assert sem.value == 0

--- a/tests/test_recurring_discard.py
+++ b/tests/test_recurring_discard.py
@@ -1,0 +1,181 @@
+"""Regression tests for recurring task + concurrency Discard interaction.
+
+Mirrors the Solid Queue edge case from commit be1a5bc / issue #598: a recurring
+task fires, its underlying job is dropped by concurrency control, and Solid
+Queue then crashed trying to record a recurring_execution row whose FK pointed
+at a job that was never persisted.
+
+Quebec is structurally immune because ``scheduler::enqueue_job`` runs in a
+different order than Solid Queue:
+
+1. Insert the job row.
+2. Insert the recurring_execution row (FK already valid).
+3. Run concurrency control.
+
+When concurrency control discards the job it calls ``mark_finished`` (sets
+``finished_at``), it does NOT delete the job row. So the recurring_execution
+FK stays valid and the row is correctly recorded against a finished job.
+
+These tests lock that behaviour in.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import quebec
+from sqlalchemy import text
+
+
+class RecurringDiscardJob(quebec.BaseClass):
+    """Discard-mode job with a fixed concurrency key (singleton)."""
+
+    concurrency_limit = 1
+    concurrency_on_conflict = quebec.ConcurrencyConflict.Discard
+
+    @staticmethod
+    def concurrency_key(*args, **kwargs) -> str:
+        return "recurring-singleton"
+
+    def perform(self, *args, **kwargs) -> None:
+        return None
+
+
+class RecurringBlockJob(quebec.BaseClass):
+    """Block-mode job with a fixed concurrency key (singleton)."""
+
+    concurrency_limit = 1
+
+    @staticmethod
+    def concurrency_key(*args, **kwargs) -> str:
+        return "recurring-block-singleton"
+
+    def perform(self, *args, **kwargs) -> None:
+        return None
+
+
+def _seed_recurring_task(session, prefix: str, key: str, class_name: str) -> None:
+    """Insert a recurring_tasks row so run_recurring_now() can look it up."""
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    session.execute(
+        text(
+            f"INSERT INTO {prefix}_recurring_tasks "
+            "(key, schedule, class_name, arguments, queue_name, priority, "
+            '"static", created_at, updated_at) '
+            "VALUES (:key, :schedule, :class_name, :arguments, :queue_name, "
+            ":priority, :static, :created_at, :updated_at)"
+        ),
+        {
+            "key": key,
+            "schedule": "every minute",
+            "class_name": class_name,
+            "arguments": "[]",
+            "queue_name": "default",
+            "priority": 0,
+            "static": True,
+            "created_at": now,
+            "updated_at": now,
+        },
+    )
+    session.commit()
+
+
+def test_recurring_discard_with_slot_taken_records_finished_execution(
+    qc_with_sqlalchemy, db_assert
+) -> None:
+    """Recurring task fires while the concurrency slot is taken (Discard mode).
+
+    The underlying job must still be persisted (then marked finished), and the
+    recurring_execution row must reference that real, finished job. No crash,
+    no orphaned FK.
+    """
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    qc.register_job(RecurringDiscardJob)
+
+    # Take the singleton slot first with a regular enqueue: this acquires the
+    # semaphore so the recurring task that follows will be discarded.
+    RecurringDiscardJob.perform_later(qc)
+    assert db_assert.count_ready_executions() == 1
+    assert db_assert.count_blocked_executions() == 0
+
+    task_key = "recurring_discard_singleton"
+    _seed_recurring_task(session, prefix, task_key, RecurringDiscardJob.__qualname__)
+
+    # Fire the recurring task. This runs the exact scheduler enqueue path.
+    # Returns False because the job was discarded (not actually enqueued),
+    # and crucially must NOT raise (the Solid Queue bug shape).
+    enqueued = qc.run_recurring_now(task_key)
+    assert enqueued is False
+
+    session.expire_all()
+
+    # The recurring_execution row was recorded (insert happens before the
+    # discard) and references a real, finished job — FK stays valid.
+    rec = session.execute(
+        text(
+            f"SELECT job_id, task_key FROM {prefix}_recurring_executions "
+            "WHERE task_key = :k"
+        ),
+        {"k": task_key},
+    ).fetchone()
+    assert rec is not None, "recurring_execution row should be recorded"
+
+    job = db_assert.get_job(rec.job_id)
+    assert job is not None, "recurring_execution must reference a real job"
+    assert job["finished_at"] is not None, "discarded job must be marked finished"
+
+    # The discarded recurring job did not reach ready/blocked, and did not fail.
+    assert db_assert.count_ready_executions() == 1  # only the slot holder
+    assert db_assert.count_blocked_executions() == 0
+    assert db_assert.count_failed_executions() == 0
+
+
+def test_recurring_block_with_slot_taken_records_blocked_execution(
+    qc_with_sqlalchemy, db_assert
+) -> None:
+    """Recurring task fires while the slot is taken (Block mode).
+
+    The job is persisted and routed to blocked_executions; the
+    recurring_execution row references the same real job.
+    """
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    qc.register_job(RecurringBlockJob)
+
+    # Take the slot first.
+    RecurringBlockJob.perform_later(qc)
+    assert db_assert.count_ready_executions() == 1
+    assert db_assert.count_blocked_executions() == 0
+
+    task_key = "recurring_block_singleton"
+    _seed_recurring_task(session, prefix, task_key, RecurringBlockJob.__qualname__)
+
+    # Block mode persists the job (goes to blocked_executions), so the recurring
+    # task counts as enqueued.
+    enqueued = qc.run_recurring_now(task_key)
+    assert enqueued is True
+
+    session.expire_all()
+
+    rec = session.execute(
+        text(f"SELECT job_id FROM {prefix}_recurring_executions WHERE task_key = :k"),
+        {"k": task_key},
+    ).fetchone()
+    assert rec is not None
+
+    # The recurring_execution references a real job that is blocked, not finished.
+    job = db_assert.get_job(rec.job_id)
+    assert job is not None
+    assert job["finished_at"] is None
+
+    blocked = session.execute(
+        text(f"SELECT job_id FROM {prefix}_blocked_executions WHERE job_id = :j"),
+        {"j": rec.job_id},
+    ).fetchone()
+    assert blocked is not None, "blocked recurring job must reference the same job_id"
+    assert db_assert.count_failed_executions() == 0

--- a/tests/test_supervisor_pruned_race.py
+++ b/tests/test_supervisor_pruned_race.py
@@ -1,0 +1,168 @@
+"""Regression test: a crashed fork's claimed jobs must still be failed even
+when the supervisor's own ``processes`` row has already been pruned.
+
+This mirrors Solid Queue commit 9f12681. In Solid Queue the supervisor looked
+up the terminated fork via ``process.supervisees.find_by(name:)``; if the
+supervisor's own row had been pruned (e.g. a peer worker's maintenance loop
+reaped it after a missed heartbeat from a sleep/wake), ``supervisees`` returned
+nothing and the dead fork's claimed executions were never failed. The fix made
+the lookup global (``SolidQueue::Process.find_by(name:)``).
+
+Quebec's fail path is already global: ``supervisor_fail_claimed_by_pid`` looks
+up the *child's* row by (pid, hostname) and fails claims scoped to that child's
+process_id, never consulting the supervisor's row or ``supervisor_id``. This
+test pins that invariant so a future refactor cannot reintroduce the scoping.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import text
+
+
+def _insert_process(session, prefix: str, *, kind: str, pid: int, hostname: str) -> int:
+    """Insert a processes row with an explicit pid/hostname; return its id."""
+    session.execute(
+        text(
+            f"INSERT INTO {prefix}_processes "
+            f"(kind, last_heartbeat_at, pid, hostname, metadata, created_at, name) "
+            f"VALUES (:kind, CURRENT_TIMESTAMP, :pid, :hostname, NULL, "
+            f"CURRENT_TIMESTAMP, :name)"
+        ),
+        {"kind": kind, "pid": pid, "hostname": hostname, "name": f"{kind}-{pid}"},
+    )
+    row_id = session.execute(text("SELECT last_insert_rowid()")).scalar()
+    session.commit()
+    return row_id
+
+
+def _insert_claimed(session, prefix: str, process_id: int) -> int:
+    """Insert a minimal job + claimed_execution for a process_id; return job_id."""
+    session.execute(
+        text(
+            f"INSERT INTO {prefix}_jobs "
+            f"(queue_name, class_name, arguments, priority, active_job_id, "
+            f"scheduled_at, finished_at, concurrency_key, created_at, updated_at) "
+            f"VALUES ('default', 'TestJob', '[]', 0, 'ajid', NULL, NULL, NULL, "
+            f"CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+        )
+    )
+    job_id = session.execute(text("SELECT last_insert_rowid()")).scalar()
+    session.execute(
+        text(
+            f"INSERT INTO {prefix}_claimed_executions "
+            f"(job_id, process_id, created_at) "
+            f"VALUES (:job_id, :process_id, CURRENT_TIMESTAMP)"
+        ),
+        {"job_id": job_id, "process_id": process_id},
+    )
+    session.commit()
+    return job_id
+
+
+class TestSupervisorPrunedRace:
+    def test_fork_claims_fail_even_after_supervisor_row_pruned(
+        self, qc_with_sqlalchemy
+    ):
+        qc = qc_with_sqlalchemy["qc"]
+        session = qc_with_sqlalchemy["session"]
+        prefix = qc_with_sqlalchemy["prefix"]
+        hostname = "test-host"
+
+        # A supervisor row and a forked-worker row on the same host. The fork
+        # owns a claimed execution.
+        supervisor_id = _insert_process(
+            session, prefix, kind="Supervisor", pid=11111, hostname=hostname
+        )
+        fork_pid = 22222
+        fork_id = _insert_process(
+            session, prefix, kind="Worker", pid=fork_pid, hostname=hostname
+        )
+        job_id = _insert_claimed(session, prefix, fork_id)
+
+        # Simulate the race: a peer's maintenance loop already pruned the
+        # supervisor's own processes row (missed heartbeat after sleep/wake).
+        session.execute(
+            text(f"DELETE FROM {prefix}_processes WHERE id = :id"),
+            {"id": supervisor_id},
+        )
+        session.commit()
+        assert (
+            session.execute(
+                text(f"SELECT COUNT(*) FROM {prefix}_processes WHERE id = :id"),
+                {"id": supervisor_id},
+            ).scalar()
+            == 0
+        ), "supervisor row should be gone before the fork is reaped"
+
+        # The supervisor notices the fork died and reaps it by (pid, hostname).
+        # This is the path the bug would have broken if it were scoped to the
+        # supervisor's (now-deleted) row. It must still fail the fork's claim.
+        failed = qc.supervisor_fail_claimed_by_pid(fork_pid, hostname)
+        assert failed == 1, (
+            "dead fork's claimed execution must still be failed even though the "
+            "supervisor's own processes row was pruned — the lookup is global by "
+            "(pid, hostname), not scoped to supervisor_id"
+        )
+
+        session.expire_all()
+        assert (
+            session.execute(
+                text(
+                    f"SELECT COUNT(*) FROM {prefix}_claimed_executions WHERE job_id = :id"
+                ),
+                {"id": job_id},
+            ).scalar()
+            == 0
+        ), "claim row should be removed"
+        assert (
+            session.execute(
+                text(
+                    f"SELECT COUNT(*) FROM {prefix}_failed_executions WHERE job_id = :id"
+                ),
+                {"id": job_id},
+            ).scalar()
+            == 1
+        ), "a failed execution should be recorded so the job can be retried"
+        assert (
+            session.execute(
+                text(f"SELECT COUNT(*) FROM {prefix}_processes WHERE id = :id"),
+                {"id": fork_id},
+            ).scalar()
+            == 0
+        ), "the dead fork's process row should be pruned"
+
+    def test_orphaned_claims_swept_when_process_row_already_gone(
+        self, qc_with_sqlalchemy
+    ):
+        """Maintenance safety net: a claim whose process row no longer exists is
+        failed regardless of which supervisor (if any) owns the sweep."""
+        qc = qc_with_sqlalchemy["qc"]
+        session = qc_with_sqlalchemy["session"]
+        prefix = qc_with_sqlalchemy["prefix"]
+
+        # A fork row + claim, then delete the fork row directly so the claim is
+        # orphaned (no backing process). No supervisor row exists at all.
+        fork_id = _insert_process(
+            session, prefix, kind="Worker", pid=33333, hostname="test-host"
+        )
+        job_id = _insert_claimed(session, prefix, fork_id)
+        session.execute(
+            text(f"DELETE FROM {prefix}_processes WHERE id = :id"),
+            {"id": fork_id},
+        )
+        session.commit()
+
+        # run_maintenance with no excluded id: the orphan sweep is global.
+        pruned, orphaned = qc.supervisor_run_maintenance(None)
+        assert orphaned == 1, "orphaned claim must be failed by the global sweep"
+
+        session.expire_all()
+        assert (
+            session.execute(
+                text(
+                    f"SELECT COUNT(*) FROM {prefix}_failed_executions WHERE job_id = :id"
+                ),
+                {"id": job_id},
+            ).scalar()
+            == 1
+        )


### PR DESCRIPTION
## Summary

Three regression tests added while auditing whether Quebec shares known Solid Queue bugs. **In all three cases Quebec is already correct** — these tests pin the invariants so a future change can't regress them.

- **`test_concurrency_force_fail.py`** — mirrors Solid Queue #547. When a dead worker's claimed jobs are force-failed, the class-level concurrency lock must be released so a blocked job is promoted immediately (not stuck until the semaphore TTL). Quebec already does this via `fail_claimed_execution → unblock_next_job`.
- **`test_supervisor_pruned_race.py`** — mirrors Solid Queue `9f12681`. A dead fork's claimed jobs must still be failed even if the supervisor's own `processes` row was pruned (sleep/wake). Quebec looks up the dead fork globally by `(pid, hostname)`, never scoped to the supervisor's row, so it's immune.
- **`test_recurring_discard.py`** — mirrors Solid Queue #598. A recurring task dropped by concurrency `Discard` must not crash recording the `recurring_execution`. Quebec inserts the job row before the recurring_execution and marks-finished (never deletes) on discard, so the FK stays valid.

No production code changes.

## Test plan

- [x] `uv run pytest tests/test_concurrency_force_fail.py tests/test_supervisor_pruned_race.py tests/test_recurring_discard.py` — 5 passed
- [x] Verified on a clean `master` base (no dependency on the shutdown-race fix in #76)