### PR TITLE
feat(worker): quiet_then_exit — drain-then-exit on quiet signal

### DIFF
--- a/python/quebec/__init__.py
+++ b/python/quebec/__init__.py
@@ -459,6 +459,14 @@ def _quebec_wait(self):
                 state["shutdown_event"].set()
                 self.graceful_shutdown()
                 break
+            # quiet_then_exit: once a quiet signal has drained all in-flight and
+            # claimed jobs, exit on our own (no timeout) instead of waiting for a
+            # later SIGTERM. Mirrors Sidekiq Enterprise's USR2 rolling restart.
+            if self.should_drain_exit():
+                logger.info("quiet_then_exit: worker drained, shutting down")
+                state["shutdown_event"].set()
+                self.graceful_shutdown()
+                break
             time.sleep(0.5)
     except KeyboardInterrupt:
         logger.debug("KeyboardInterrupt, shutting down...")

--- a/src/context.rs
+++ b/src/context.rs
@@ -320,6 +320,12 @@ pub struct AppContext {
     pub process_heartbeat_interval: Duration,
     pub process_alive_threshold: Duration,
     pub shutdown_timeout: Duration,
+    /// When a quiet signal (SIGUSR1/SIGTSTP) is received, also exit the process
+    /// once all of this worker's in-flight and claimed jobs have drained — with
+    /// no time limit, matching Sidekiq Enterprise's USR2 rolling restart. Opt-in
+    /// (default false). Independent of `shutdown_timeout`, which still bounds the
+    /// SIGTERM graceful-shutdown path.
+    pub quiet_then_exit: bool,
     pub silence_polling: bool,
     pub preserve_finished_jobs: bool,
     pub clear_finished_jobs_after: Duration,
@@ -617,6 +623,9 @@ impl AppContext {
             if let Some(v) = get_bool("silence_polling") {
                 ctx.silence_polling = v;
             }
+            if let Some(v) = get_bool("quiet_then_exit") {
+                ctx.quiet_then_exit = v;
+            }
             if let Some(v) = get_bool("preserve_finished_jobs") {
                 ctx.preserve_finished_jobs = v;
             }
@@ -806,6 +815,7 @@ impl AppContext {
             process_alive_threshold: Duration::from_secs(300),
             shutdown_timeout: Duration::from_secs(5),
             silence_polling: true,
+            quiet_then_exit: false,
             preserve_finished_jobs: true,
             clear_finished_jobs_after: Duration::from_secs(3600 * 24 * 14), // 14 days
             cleanup_batch_size: 500,
@@ -896,6 +906,7 @@ impl AppContext {
             process_alive_threshold: self.process_alive_threshold,
             shutdown_timeout: self.shutdown_timeout,
             silence_polling: self.silence_polling,
+            quiet_then_exit: self.quiet_then_exit,
             preserve_finished_jobs: self.preserve_finished_jobs,
             clear_finished_jobs_after: self.clear_finished_jobs_after,
             cleanup_batch_size: self.cleanup_batch_size,

--- a/src/context.rs
+++ b/src/context.rs
@@ -4,7 +4,7 @@ use english_to_cron::str_cron_syntax;
 use sea_orm::{ConnectOptions, Database, DatabaseConnection, DbErr};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
-use std::sync::atomic::{AtomicI32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use tokio::runtime::Handle;
@@ -323,8 +323,10 @@ pub struct AppContext {
     /// When a quiet signal (SIGUSR1/SIGTSTP) is received, also exit the process
     /// once all of this worker's in-flight and claimed jobs have drained — with
     /// no time limit, matching Sidekiq Enterprise's USR2 rolling restart. Opt-in
-    /// (default false). Independent of `shutdown_timeout`, which still bounds the
-    /// SIGTERM graceful-shutdown path.
+    /// (default false). Standalone-only: ignored under the fork supervisor, where
+    /// a self-exited child would just be reforked — use a supervisor-level
+    /// rolling restart there instead. Independent of `shutdown_timeout`, which
+    /// still bounds the SIGTERM graceful-shutdown path.
     pub quiet_then_exit: bool,
     pub silence_polling: bool,
     pub preserve_finished_jobs: bool,
@@ -363,6 +365,13 @@ pub struct AppContext {
     /// if it no longer matches (i.e. the supervisor died and we got reparented
     /// to init/launchd). Zero means "not supervised, do not check".
     pub supervisor_pid: AtomicI32,
+    /// True while a worker claim transaction is in flight (from before the quiet
+    /// gate in `process_available_jobs` until the claimed jobs have been
+    /// dispatched). `should_drain_exit` requires this to be false so a job that
+    /// passed the quiet check just before quiet was signalled cannot be missed
+    /// by the idle snapshot, which would otherwise let the process self-exit
+    /// while that batch is still being published.
+    pub claim_in_progress: AtomicBool,
     /// `(entry_index, within_entry)` populated by `apply_worker_config` /
     /// `apply_dispatcher_config` after fork so `set_proc_title` can show
     /// `[worker.<entry>.<within>:threads]` instead of all sibling processes
@@ -839,6 +848,7 @@ impl AppContext {
             table_config: TableConfig::default(),
             idle_notify: Arc::new(RwLock::new(None)),
             supervisor_pid: AtomicI32::new(0),
+            claim_in_progress: AtomicBool::new(false),
             proc_slot: None,
             in_flight_executions: Arc::new(std::sync::Mutex::new(HashSet::new())),
         }
@@ -932,6 +942,7 @@ impl AppContext {
             idle_notify: Arc::new(RwLock::new(None)),
             // Fresh state; child must call `watch_parent_pid` after fork.
             supervisor_pid: AtomicI32::new(0),
+            claim_in_progress: AtomicBool::new(false),
             // Preserve so re-forks (or apply_*_config re-using a forked ctx)
             // keep the slot label until explicitly reset by apply_*_config.
             proc_slot: self.proc_slot,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1228,6 +1228,13 @@ impl PyQuebec {
         })
     }
 
+    /// Test-only: directly set the claim-in-progress flag so a regression test
+    /// can verify should_drain_exit refuses to exit while a claim transaction
+    /// is still publishing work.
+    fn _set_claim_in_progress(&self, value: bool) {
+        self.ctx.claim_in_progress.store(value, Ordering::SeqCst);
+    }
+
     fn ping(&self) -> PyResult<bool> {
         self.rt.block_on(async move {
             let db = self.ctx.get_db().await.map_err(|e| {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1182,6 +1182,19 @@ impl PyQuebec {
         if !self.ctx.quiet_then_exit || !self.ctx.quiet.is_cancelled() {
             return false;
         }
+        // Standalone-only: under the fork supervisor a self-exited worker child
+        // would just be reforked, so quiet_then_exit is a no-op there. Supervised
+        // deployments should use a supervisor-level rolling restart instead.
+        if self.ctx.supervisor_pid.load(Ordering::Relaxed) != 0 {
+            return false;
+        }
+        // A claim that passed the quiet gate before quiet was signalled may still
+        // be publishing work; wait for it so the idle snapshot below is not taken
+        // mid-claim (which could let the process exit and subject that batch to
+        // graceful_shutdown's bounded drain).
+        if self.ctx.claim_in_progress.load(Ordering::SeqCst) {
+            return false;
+        }
         let in_flight_empty = self
             .ctx
             .in_flight_executions

--- a/src/types.rs
+++ b/src/types.rs
@@ -1171,6 +1171,50 @@ impl PyQuebec {
         self.ctx.worker_threads
     }
 
+    /// Whether the process should now exit because a quiet signal was received
+    /// with `quiet_then_exit` enabled and this worker has fully drained: no jobs
+    /// in flight (being performed) and none claimed-but-not-yet-running. The
+    /// Python wait loop polls this to trigger graceful_shutdown once the worker
+    /// is idle, with no time limit (Sidekiq Enterprise USR2 rolling-restart
+    /// semantics). Quiet has already stopped new claims, so an empty result is
+    /// terminal — no new work can arrive to make it non-empty again.
+    fn should_drain_exit(&self, py: Python<'_>) -> bool {
+        if !self.ctx.quiet_then_exit || !self.ctx.quiet.is_cancelled() {
+            return false;
+        }
+        let in_flight_empty = self
+            .ctx
+            .in_flight_executions
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .is_empty();
+        if !in_flight_empty {
+            return false;
+        }
+        let worker = self.worker.clone();
+        let ctx = self.ctx.clone();
+        py.detach(|| {
+            self.rt.block_on(async move {
+                let process_id = match *worker.process_id_handle().lock().await {
+                    Some(id) => id,
+                    None => return false,
+                };
+                let Ok(db) = ctx.get_db().await else {
+                    return false;
+                };
+                matches!(
+                    crate::query_builder::claimed_executions::count_by_process_id(
+                        db.as_ref(),
+                        &ctx.table_config,
+                        process_id,
+                    )
+                    .await,
+                    Ok(0)
+                )
+            })
+        })
+    }
+
     fn ping(&self) -> PyResult<bool> {
         self.rt.block_on(async move {
             let db = self.ctx.get_db().await.map_err(|e| {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -933,6 +933,25 @@ impl Metric {
     }
 }
 
+/// RAII flag set for the duration of a worker claim transaction so
+/// `should_drain_exit` (quiet_then_exit self-exit) cannot observe an empty idle
+/// snapshot while a batch that passed the quiet gate is still being claimed and
+/// dispatched. Set on construction, cleared on drop.
+struct ClaimInProgressGuard<'a>(&'a std::sync::atomic::AtomicBool);
+
+impl<'a> ClaimInProgressGuard<'a> {
+    fn new(flag: &'a std::sync::atomic::AtomicBool) -> Self {
+        flag.store(true, std::sync::atomic::Ordering::SeqCst);
+        Self(flag)
+    }
+}
+
+impl Drop for ClaimInProgressGuard<'_> {
+    fn drop(&mut self) {
+        self.0.store(false, std::sync::atomic::Ordering::SeqCst);
+    }
+}
+
 #[pyclass(name = "Execution", subclass)]
 #[derive(Debug)]
 pub struct Execution {
@@ -3253,6 +3272,12 @@ impl Worker {
         thread_id: &str,
         source: &str,
     ) {
+        // Mark a claim transaction in progress for the whole body (before the
+        // quiet gate, through dispatch) so quiet_then_exit's should_drain_exit
+        // cannot see an empty idle snapshot while a batch that passed the quiet
+        // gate is still being claimed/dispatched.
+        let _claim_guard = ClaimInProgressGuard::new(&ctx.claim_in_progress);
+
         // Sidekiq-style quiet mode: keep running but stop claiming new work
         // so in-flight jobs can drain. Used for seamless restarts.
         if ctx.quiet.is_cancelled() {

--- a/tests/test_quiet_then_exit.py
+++ b/tests/test_quiet_then_exit.py
@@ -54,3 +54,44 @@ def test_should_drain_exit_false_with_claimed_job(db_url, test_prefix):
         assert qc.should_drain_exit() is False
     finally:
         qc.close()
+
+
+def test_should_drain_exit_disabled_when_supervised(db_url, test_prefix):
+    """Standalone-only: under the fork supervisor (supervisor_pid set), a quiet
+    drained worker does not self-exit — it would just be reforked.
+    """
+    qc = quebec.Quebec(db_url, table_name_prefix=test_prefix, quiet_then_exit=True)
+    assert qc.create_tables() is True
+    try:
+        qc.register_worker_process()
+        # Records supervisor_pid from the current parent (non-zero), marking this
+        # as a fork-supervised child.
+        qc.watch_parent_pid()
+        qc.quiet()
+        # Drained, but supervised → must not self-exit.
+        assert qc.should_drain_exit() is False
+    finally:
+        qc.close()
+
+
+def test_should_drain_exit_blocked_by_claim_in_progress(db_url, test_prefix):
+    """A claim transaction in progress blocks self-exit even when otherwise idle.
+
+    Guards the race where a claim that passed the quiet gate is still publishing
+    work: should_drain_exit must wait for it rather than exit mid-claim.
+    """
+    qc = quebec.Quebec(db_url, table_name_prefix=test_prefix, quiet_then_exit=True)
+    assert qc.create_tables() is True
+    try:
+        qc.register_worker_process()
+        qc.quiet()
+        # Idle → would exit.
+        assert qc.should_drain_exit() is True
+        # A claim in progress must block it.
+        qc._set_claim_in_progress(True)
+        assert qc.should_drain_exit() is False
+        # Once the claim finishes, exit is allowed again.
+        qc._set_claim_in_progress(False)
+        assert qc.should_drain_exit() is True
+    finally:
+        qc.close()

--- a/tests/test_quiet_then_exit.py
+++ b/tests/test_quiet_then_exit.py
@@ -1,0 +1,56 @@
+"""Tests for the `quiet_then_exit` option.
+
+When enabled, a quiet signal (SIGUSR1/SIGTSTP) makes the process exit on its own
+once all of this worker's in-flight and claimed jobs have drained — with no
+timeout — instead of waiting for a later SIGTERM. Mirrors Sidekiq Enterprise's
+USR2 rolling restart. `should_drain_exit()` is the predicate the Python wait
+loop polls to decide when to self-shut-down.
+"""
+
+from __future__ import annotations
+
+import quebec
+
+
+def test_should_drain_exit_disabled_by_default(qc_with_sqlalchemy):
+    """Without quiet_then_exit, a quiet idle worker never self-exits."""
+    qc = qc_with_sqlalchemy["qc"]
+    qc.register_worker_process()
+    qc.quiet()
+    assert qc.should_drain_exit() is False
+
+
+def test_should_drain_exit_true_when_drained(db_url, test_prefix):
+    """quiet_then_exit + quiet + nothing in-flight/claimed → exit requested."""
+    qc = quebec.Quebec(db_url, table_name_prefix=test_prefix, quiet_then_exit=True)
+    assert qc.create_tables() is True
+    try:
+        qc.register_worker_process()
+        # Enabled but not quiet yet → no exit.
+        assert qc.should_drain_exit() is False
+        qc.quiet()
+        # Quiet and fully drained → exit requested.
+        assert qc.should_drain_exit() is True
+    finally:
+        qc.close()
+
+
+def test_should_drain_exit_false_with_claimed_job(db_url, test_prefix):
+    """A claimed-but-not-yet-run job blocks self-exit until it drains."""
+    qc = quebec.Quebec(db_url, table_name_prefix=test_prefix, quiet_then_exit=True)
+    assert qc.create_tables() is True
+
+    class IdleJob(quebec.ActiveJob):
+        def perform(self, *args, **kwargs):
+            return True
+
+    try:
+        qc.register_job(IdleJob)
+        qc.register_worker_process()
+        qc.quiet()
+        IdleJob.perform_later(qc)
+        qc.drain_one()  # claimed, not performed
+        # Still has a claimed job → must not self-exit.
+        assert qc.should_drain_exit() is False
+    finally:
+        qc.close()


### PR DESCRIPTION
> **Stacked on #76** (`fix/shutdown-release-in-flight`). Reuses the `in_flight_executions` set and `claim_in_progress` barrier from that branch. GitHub will retarget this PR to `master` once #76 merges.

## Summary

Opt-in `quiet_then_exit` config (default false). When a quiet signal (SIGUSR1/SIGTSTP) is received with it enabled, the process exits on its own once this worker's in-flight and claimed jobs have all drained — **with no time limit** — instead of waiting for a later SIGTERM. Mirrors Sidekiq Enterprise's USR2 rolling restart.

Lets a deploy become: **send SIGUSR1 → start new process → old process exits when done**, dropping the fixed "wait N seconds then kill" step that either truncates long jobs (causing reruns) or wastes time.

## How it works

- `should_drain_exit()` (polled by the Python wait loop every 0.5s) returns true only when: `quiet_then_exit` enabled, quiet signalled, not supervised, no claim transaction in progress, `in_flight_executions` empty, and `claimed_executions` count for this process is 0. Quiet has already stopped new claims, so an empty result is terminal.
- Reuses the in-flight tracking from #76; a `claim_in_progress` barrier (RAII guard over the claim transaction) prevents exiting mid-claim.

## Constraints

- **Standalone-only.** Under the fork supervisor a self-exited child would just be reforked, so `should_drain_exit` returns false when `supervisor_pid` is set. Supervised deployments should use a supervisor-level rolling restart. Documented on the config field.
- Independent of `shutdown_timeout` (which still bounds the SIGTERM path). The drain here is unbounded by design.

## Review

Two Codex review passes: the first found a claim-in-progress race (could subject a freshly-claimed batch to the bounded SIGTERM drain) and the supervisor churn issue — both fixed (`0545c3f`). The second pass found no new correctness issues.

## Test plan

- [x] `cargo clippy --all-targets --all-features` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `uv run pytest --ignore=tests/step_defs` — 169 passed
- [x] `tests/test_quiet_then_exit.py` (5 tests): disabled by default, exits when drained, blocked by a claimed job, disabled when supervised, blocked by claim-in-progress
- [ ] Manual: SIGUSR1 a standalone worker with a long job in flight, confirm it exits only after the job completes (no timeout)