### PR TITLE
Worker-local claim ledger for claimed-execution lifecycle hardening

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -400,9 +400,10 @@ pub struct AppContext {
     /// claimed row is deleted — or marked `CleanupPending` there if that cleanup
     /// fails — removed on `Execution`'s `Drop` as a backstop for a job that
     /// is picked but never performed (preserving any `CleanupPending` mark), and
-    /// removed on `InFlightGuard`'s `Drop` when `invoke` unwinds on a panic (so
-    /// the InFlight entry can't leak even if the `Execution` is kept alive by
-    /// the Python runner and thus never dropped).
+    /// marked `CleanupPending` by `InFlightGuard`'s `Drop` when `invoke` unwinds
+    /// on a panic (so a possibly-executed InFlight job is never requeued, even
+    /// if the `Execution` is kept alive by the Python runner and thus never
+    /// dropped).
     /// `release_all_claimed_executions` skips in-flight and cleanup-pending ids
     /// during graceful shutdown and the shutdown drain waits for the ledger to
     /// empty, so a running or about-to-run job is never handed back to a
@@ -451,18 +452,26 @@ impl Drop for InFlightGuard {
         // would block the quiet_then_exit drain. The guard is a stack local of
         // `Execution::invoke`, so it is reliably dropped when that frame
         // unwinds (the owning `Execution` may be kept alive on the Python side,
-        // so its own Drop backstop may not fire). Remove the entry ONLY if it
-        // is still InFlight, handing the residual claimed DB row off to the
-        // orphan-sweep (which reads the DB, not the ledger, and marks it
-        // failed). Note: `std::thread::panicking()` detects panic unwinding,
-        // NOT async task cancellation — a dropped future is not a panic, and
-        // that normal-drop case is already covered by `Execution::Drop`.
+        // so its own Drop backstop may not fire). Mark the entry
+        // `CleanupPending` ONLY if it is still InFlight: the job was inside
+        // perform() and may have committed side effects, so it must NOT be
+        // requeued. CleanupPending puts the id in
+        // `release_all_claimed_executions`'s skip-set (a graceful shutdown that
+        // survives the panic will not hand the row to a neighbour → no
+        // duplicate run), counts as non-active so it does not block the drain
+        // (`ledger_has_active` treats CleanupPending as drained), and the
+        // residual claimed DB row is reclaimed by the orphan-sweep once this
+        // process exits. This mirrors `after_executed`'s "cleanup failed →
+        // CleanupPending" semantics. Note: `std::thread::panicking()` detects
+        // panic unwinding, NOT async task cancellation — a dropped future is
+        // not a panic, and that normal-drop case is already covered by
+        // `Execution::Drop`.
         if !std::thread::panicking() {
             return;
         }
         let mut ledger = self.ledger.lock().unwrap_or_else(|e| e.into_inner());
         if matches!(ledger.get(&self.id), Some(ClaimState::InFlight)) {
-            ledger.remove(&self.id);
+            ledger.insert(self.id, ClaimState::CleanupPending);
         }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -41,12 +41,10 @@ pub struct ConcurrencyConstraint {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ClaimState {
     /// Claimed; queued in the mpsc channel / Python work queue; not yet performing.
-    #[allow(dead_code)]
     Dispatched,
     /// Inside perform().
     InFlight,
     /// Performed, but after_executed cleanup failed — already executed, must NOT requeue.
-    #[allow(dead_code)]
     CleanupPending,
 }
 
@@ -398,9 +396,11 @@ pub struct AppContext {
     /// matching the semantics of the previous `in_flight_executions` set:
     /// inserted in `Worker::pick_job` (when a job leaves the dispatch channel
     /// for the Python work queue) and again at the start of `Execution::invoke`
-    /// (idempotent), removed when `perform()` finishes (the `InFlightGuard`),
-    /// and on `Execution`'s `Drop` as a backstop for a job that is picked but
-    /// never performed. `release_all_claimed_executions` skips in-flight ids
+    /// (idempotent, via `InFlightGuard`), removed by `after_executed` once the
+    /// claimed row is deleted — or marked `CleanupPending` there if that cleanup
+    /// fails — and removed on `Execution`'s `Drop` as a backstop for a job that
+    /// is picked but never performed (preserving any `CleanupPending` mark).
+    /// `release_all_claimed_executions` skips in-flight and cleanup-pending ids
     /// during graceful shutdown and the shutdown drain waits for the ledger to
     /// empty, so a running or about-to-run job is never handed back to a
     /// neighbour worker (which would run it a second time). Plain
@@ -409,14 +409,11 @@ pub struct AppContext {
     pub claim_ledger: Arc<std::sync::Mutex<std::collections::HashMap<i64, ClaimState>>>,
 }
 
-/// RAII guard that marks a claimed_execution as in-flight for the lifetime of
-/// a `perform()` call. Inserts the id on construction and removes it on drop,
-/// so the entry is cleared on every exit path — normal completion, error, or a
-/// panic propagating out of `Execution::invoke`.
-pub struct InFlightGuard {
-    ledger: Arc<std::sync::Mutex<std::collections::HashMap<i64, ClaimState>>>,
-    id: i64,
-}
+/// Marks a claimed_execution as in-flight at the start of a `perform()` call.
+/// Construction inserts the id as `ClaimState::InFlight`; removal is NOT done
+/// here. The ledger entry is cleared by `after_executed`, which tracks the real
+/// DB cleanup outcome (remove on success, mark `CleanupPending` on failure).
+pub struct InFlightGuard;
 
 impl InFlightGuard {
     pub fn new(
@@ -430,18 +427,14 @@ impl InFlightGuard {
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .insert(id, ClaimState::InFlight);
-        Self { ledger, id }
+        Self
     }
 }
 
-impl Drop for InFlightGuard {
-    fn drop(&mut self) {
-        self.ledger
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .remove(&self.id);
-    }
-}
+// No Drop impl: ledger removal is owned by `after_executed`, which tracks the
+// real DB cleanup outcome (remove on success, CleanupPending on failure).
+// Removing the entry here would wipe a CleanupPending mark, because the guard
+// drops immediately after `after_executed` returns.
 
 /// Parse env var string as bool: true/1/yes → true, false/0/no → false
 fn parse_bool_env(s: &str) -> Option<bool> {

--- a/src/context.rs
+++ b/src/context.rs
@@ -37,6 +37,19 @@ pub struct ConcurrencyConstraint {
     pub on_conflict: ConcurrencyConflict,
 }
 
+/// Lifecycle state of a claimed execution owned by this worker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClaimState {
+    /// Claimed; queued in the mpsc channel / Python work queue; not yet performing.
+    #[allow(dead_code)]
+    Dispatched,
+    /// Inside perform().
+    InFlight,
+    /// Performed, but after_executed cleanup failed — already executed, must NOT requeue.
+    #[allow(dead_code)]
+    CleanupPending,
+}
+
 /// Concurrency conflict strategy - what to do when concurrency limit is reached
 /// Matches Solid Queue's concurrency_on_conflict option
 #[cfg_attr(feature = "python", pyclass(eq, eq_int, from_py_object))]
@@ -379,18 +392,21 @@ pub struct AppContext {
     /// (non-supervised) runs, the supervisor parent itself, and the
     /// scheduler (which is always a single process).
     pub proc_slot: Option<(usize, usize)>,
-    /// claimed_execution ids that have been handed to the Python side and have
-    /// not finished yet. Inserted in `Worker::pick_job` (when a job leaves the
-    /// dispatch channel for the Python work queue) and again at the start of
-    /// `Execution::invoke` (idempotent). Removed when `perform()` finishes (the
-    /// `InFlightGuard`), and on `Execution`'s `Drop` as a backstop for a job
-    /// that is picked but never performed. `release_all_claimed_executions`
-    /// skips these during graceful shutdown and the shutdown drain waits for
-    /// the set to empty, so a running or about-to-run job is never handed back
-    /// to a neighbour worker (which would run it a second time). Plain
-    /// `Mutex<HashSet>`: the guarded section is a single
-    /// insert/remove/contains, never held across an await.
-    pub in_flight_executions: Arc<std::sync::Mutex<HashSet<i64>>>,
+    /// Authoritative ledger of claimed_execution ids owned by this worker,
+    /// keyed by `claimed_executions.id` and mapped to their lifecycle
+    /// `ClaimState`. As of Task 1 the only state used is `ClaimState::InFlight`,
+    /// matching the semantics of the previous `in_flight_executions` set:
+    /// inserted in `Worker::pick_job` (when a job leaves the dispatch channel
+    /// for the Python work queue) and again at the start of `Execution::invoke`
+    /// (idempotent), removed when `perform()` finishes (the `InFlightGuard`),
+    /// and on `Execution`'s `Drop` as a backstop for a job that is picked but
+    /// never performed. `release_all_claimed_executions` skips in-flight ids
+    /// during graceful shutdown and the shutdown drain waits for the ledger to
+    /// empty, so a running or about-to-run job is never handed back to a
+    /// neighbour worker (which would run it a second time). Plain
+    /// `Mutex<HashMap>`: the guarded section is a single
+    /// insert/remove/contains/clone, never held across an await.
+    pub claim_ledger: Arc<std::sync::Mutex<std::collections::HashMap<i64, ClaimState>>>,
 }
 
 /// RAII guard that marks a claimed_execution as in-flight for the lifetime of
@@ -398,24 +414,29 @@ pub struct AppContext {
 /// so the entry is cleared on every exit path — normal completion, error, or a
 /// panic propagating out of `Execution::invoke`.
 pub struct InFlightGuard {
-    set: Arc<std::sync::Mutex<HashSet<i64>>>,
+    ledger: Arc<std::sync::Mutex<std::collections::HashMap<i64, ClaimState>>>,
     id: i64,
 }
 
 impl InFlightGuard {
-    pub fn new(set: Arc<std::sync::Mutex<HashSet<i64>>>, id: i64) -> Self {
-        // Recover from poisoning: the set is a plain HashSet that stays
-        // consistent even if a holder panicked, and silently skipping the
-        // insert would let the shutdown release treat a running job as
-        // releasable.
-        set.lock().unwrap_or_else(|e| e.into_inner()).insert(id);
-        Self { set, id }
+    pub fn new(
+        ledger: Arc<std::sync::Mutex<std::collections::HashMap<i64, ClaimState>>>,
+        id: i64,
+    ) -> Self {
+        // Recover from poisoning: the ledger stays consistent even if a holder
+        // panicked, and silently skipping the insert would let the shutdown
+        // release treat a running job as releasable.
+        ledger
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(id, ClaimState::InFlight);
+        Self { ledger, id }
     }
 }
 
 impl Drop for InFlightGuard {
     fn drop(&mut self) {
-        self.set
+        self.ledger
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .remove(&self.id);
@@ -514,6 +535,40 @@ pub struct RunnableDefaults {
 }
 
 impl AppContext {
+    /// Record `id` in the claim ledger with the given state. Poison-recovering;
+    /// never held across an await.
+    pub fn ledger_set(&self, id: i64, state: ClaimState) {
+        self.claim_ledger
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(id, state);
+    }
+
+    /// Remove `id` from the claim ledger. Poison-recovering.
+    pub fn ledger_remove(&self, id: i64) {
+        self.claim_ledger
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&id);
+    }
+
+    /// True when the claim ledger has no tracked entries. Poison-recovering.
+    pub fn ledger_is_empty(&self) -> bool {
+        self.claim_ledger
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .is_empty()
+    }
+
+    /// Snapshot the claim ledger so callers can inspect states without holding
+    /// the lock. Poison-recovering.
+    pub fn ledger_snapshot(&self) -> std::collections::HashMap<i64, ClaimState> {
+        self.claim_ledger
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
+
     #[cfg(feature = "python")]
     pub fn new(
         dsn: DatabaseUrl,
@@ -850,7 +905,7 @@ impl AppContext {
             supervisor_pid: AtomicI32::new(0),
             claim_in_progress: AtomicBool::new(false),
             proc_slot: None,
-            in_flight_executions: Arc::new(std::sync::Mutex::new(HashSet::new())),
+            claim_ledger: Arc::new(std::sync::Mutex::new(HashMap::new())),
         }
     }
 
@@ -947,9 +1002,9 @@ impl AppContext {
             // keep the slot label until explicitly reset by apply_*_config.
             proc_slot: self.proc_slot,
             // Fresh per-process tracking: the child runs its own worker /
-            // dispatch channel, so in-flight ids must not be shared with the
+            // dispatch channel, so claim-ledger ids must not be shared with the
             // parent (whose claims belong to a different process record).
-            in_flight_executions: Arc::new(std::sync::Mutex::new(HashSet::new())),
+            claim_ledger: Arc::new(std::sync::Mutex::new(HashMap::new())),
             use_listen_notify: self.use_listen_notify,
             notify_throttle_interval: self.notify_throttle_interval,
             force_override_queue: self.force_override_queue.clone(),

--- a/src/context.rs
+++ b/src/context.rs
@@ -553,6 +553,20 @@ impl AppContext {
             .is_empty()
     }
 
+    /// True when the ledger holds any `Dispatched` or `InFlight` entry, i.e. work
+    /// that is still pending dispatch or actively executing. `CleanupPending`
+    /// entries do NOT count as active: the job already finished executing and only
+    /// the DB orphan-sweep is left to reclaim the row, so a worker carrying solely
+    /// `CleanupPending` entries (or none at all) is fully drained. Poison-recovering;
+    /// single locked pass, never held across an await.
+    pub fn ledger_has_active(&self) -> bool {
+        self.claim_ledger
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .values()
+            .any(|s| matches!(s, ClaimState::Dispatched | ClaimState::InFlight))
+    }
+
     /// Snapshot the claim ledger so callers can inspect states without holding
     /// the lock. Poison-recovering.
     pub fn ledger_snapshot(&self) -> std::collections::HashMap<i64, ClaimState> {

--- a/src/context.rs
+++ b/src/context.rs
@@ -398,8 +398,11 @@ pub struct AppContext {
     /// for the Python work queue) and again at the start of `Execution::invoke`
     /// (idempotent, via `InFlightGuard`), removed by `after_executed` once the
     /// claimed row is deleted — or marked `CleanupPending` there if that cleanup
-    /// fails — and removed on `Execution`'s `Drop` as a backstop for a job that
-    /// is picked but never performed (preserving any `CleanupPending` mark).
+    /// fails — removed on `Execution`'s `Drop` as a backstop for a job that
+    /// is picked but never performed (preserving any `CleanupPending` mark), and
+    /// removed on `InFlightGuard`'s `Drop` when `invoke` unwinds on a panic (so
+    /// the InFlight entry can't leak even if the `Execution` is kept alive by
+    /// the Python runner and thus never dropped).
     /// `release_all_claimed_executions` skips in-flight and cleanup-pending ids
     /// during graceful shutdown and the shutdown drain waits for the ledger to
     /// empty, so a running or about-to-run job is never handed back to a
@@ -410,10 +413,14 @@ pub struct AppContext {
 }
 
 /// Marks a claimed_execution as in-flight at the start of a `perform()` call.
-/// Construction inserts the id as `ClaimState::InFlight`; removal is NOT done
-/// here. The ledger entry is cleared by `after_executed`, which tracks the real
-/// DB cleanup outcome (remove on success, mark `CleanupPending` on failure).
-pub struct InFlightGuard;
+/// Construction inserts the id as `ClaimState::InFlight`. Normal-path removal is
+/// NOT done here: the ledger entry is cleared by `after_executed`, which tracks
+/// the real DB cleanup outcome (remove on success, mark `CleanupPending` on
+/// failure). The only thing `Drop` does is a panic-only backstop (see below).
+pub struct InFlightGuard {
+    ledger: Arc<std::sync::Mutex<std::collections::HashMap<i64, ClaimState>>>,
+    id: i64,
+}
 
 impl InFlightGuard {
     pub fn new(
@@ -427,14 +434,38 @@ impl InFlightGuard {
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .insert(id, ClaimState::InFlight);
-        Self
+        Self { ledger, id }
     }
 }
 
-// No Drop impl: ledger removal is owned by `after_executed`, which tracks the
-// real DB cleanup outcome (remove on success, CleanupPending on failure).
-// Removing the entry here would wipe a CleanupPending mark, because the guard
-// drops immediately after `after_executed` returns.
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        // Panic-only backstop. On a NORMAL drop do nothing: `after_executed`
+        // owns the normal-path transition (remove on cleanup success,
+        // CleanupPending on failure), and removing here would wipe a
+        // CleanupPending mark since the guard drops right after
+        // `after_executed` returns.
+        //
+        // On a PANIC unwind, however, `after_executed` never ran, so the
+        // InFlight entry would otherwise leak forever and `ledger_has_active`
+        // would block the quiet_then_exit drain. The guard is a stack local of
+        // `Execution::invoke`, so it is reliably dropped when that frame
+        // unwinds (the owning `Execution` may be kept alive on the Python side,
+        // so its own Drop backstop may not fire). Remove the entry ONLY if it
+        // is still InFlight, handing the residual claimed DB row off to the
+        // orphan-sweep (which reads the DB, not the ledger, and marks it
+        // failed). Note: `std::thread::panicking()` detects panic unwinding,
+        // NOT async task cancellation — a dropped future is not a panic, and
+        // that normal-drop case is already covered by `Execution::Drop`.
+        if !std::thread::panicking() {
+            return;
+        }
+        let mut ledger = self.ledger.lock().unwrap_or_else(|e| e.into_inner());
+        if matches!(ledger.get(&self.id), Some(ClaimState::InFlight)) {
+            ledger.remove(&self.id);
+        }
+    }
+}
 
 /// Parse env var string as bool: true/1/yes → true, false/0/no → false
 fn parse_bool_env(s: &str) -> Option<bool> {

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -129,32 +129,47 @@ impl Supervisor {
         // raced or skipped releasing claims.
         let orphaned =
             query_builder::claimed_executions::find_orphaned(db.as_ref(), &table_config).await?;
-        let orphaned_count = orphaned.len();
-        if orphaned_count > 0 {
+        let found_orphaned = orphaned.len();
+        if found_orphaned > 0 {
             info!(
                 "Supervisor maintenance: failing {} orphaned claimed execution(s)",
-                orphaned_count
+                found_orphaned
             );
         }
+        let mut orphaned_count = 0usize;
         for execution in orphaned {
             let ctx = self.ctx.clone();
             let tc = table_config.clone();
             let job_id = execution.job_id;
             let exec_id = execution.id;
-            db.transaction::<_, (), DbErr>(|txn| {
-                Box::pin(async move {
-                    Worker::fail_claimed_execution(
-                        &ctx,
-                        txn,
-                        &tc,
-                        job_id,
-                        exec_id,
-                        "Process crashed or was killed before job completion",
-                    )
-                    .await
+            // Per-row best-effort: a failing row (e.g. an experimental
+            // queue-slot release error) must not abort the sweep of the
+            // remaining orphaned rows. This is the crash-recovery safety net,
+            // so one bad row is logged and skipped, left for the next
+            // maintenance tick / another process to retry.
+            let result = db
+                .transaction::<_, (), DbErr>(|txn| {
+                    Box::pin(async move {
+                        Worker::fail_claimed_execution(
+                            &ctx,
+                            txn,
+                            &tc,
+                            job_id,
+                            exec_id,
+                            "Process crashed or was killed before job completion",
+                        )
+                        .await
+                    })
                 })
-            })
-            .await?;
+                .await;
+
+            match result {
+                Ok(()) => orphaned_count += 1,
+                Err(e) => warn!(
+                    "Supervisor maintenance: failed to reclaim orphaned execution {} (job {}): {}; leaving it for a later sweep",
+                    exec_id, job_id, e
+                ),
+            }
         }
 
         Ok((pruned, orphaned_count))

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -198,43 +198,58 @@ async fn fail_claimed_by_process_id_inner(
         "Child process {process_id} (pid={process_pid}, host={process_hostname:?}) crashed"
     );
 
-    let ctx = ctx.clone();
-    let tc = table_config.clone();
-    let deleted_count = db
-        .transaction::<_, u64, DbErr>(|txn| {
-            let ctx = ctx.clone();
-            let tc = tc.clone();
-            let error_msg = error_msg.clone();
-            Box::pin(async move {
-                let claimed =
-                    query_builder::claimed_executions::find_by_process_id(txn, &tc, process_id)
-                        .await?;
-                let deleted_count = claimed.len() as u64;
+    let claimed =
+        query_builder::claimed_executions::find_by_process_id(db, &table_config, process_id)
+            .await?;
 
-                for execution in &claimed {
-                    Worker::fail_claimed_execution(
-                        &ctx,
-                        txn,
-                        &tc,
-                        execution.job_id,
-                        execution.id,
-                        &error_msg,
-                    )
-                    .await?;
-                }
-
-                query_builder::processes::prune(txn, &tc, process_id).await?;
-                Ok(deleted_count)
+    // Per-row best-effort. We deliberately trade the old single-transaction
+    // atomicity (fail-all-rows + prune as one unit) for best-effort cleanup
+    // backed by the orphan-sweep: each row's `fail_claimed_execution` runs in
+    // its OWN small transaction so a single row's failure (e.g. an experimental
+    // queue-slot release error) rolls back only that row, not its siblings or
+    // the process prune. The process row is pruned regardless of whether some
+    // rows failed — once the row is gone, `fail_orphaned_executions` (which
+    // matches claimed rows whose process row no longer exists) becomes the
+    // safety net that reclaims the leftovers.
+    let mut failed = 0u64;
+    for execution in &claimed {
+        let ctx = ctx.clone();
+        let tc = table_config.clone();
+        let error_msg = error_msg.clone();
+        let job_id = execution.job_id;
+        let execution_id = execution.id;
+        let result = db
+            .transaction::<_, (), DbErr>(|txn| {
+                Box::pin(async move {
+                    Worker::fail_claimed_execution(&ctx, txn, &tc, job_id, execution_id, &error_msg)
+                        .await
+                })
             })
-        })
-        .await?;
+            .await;
+
+        match result {
+            Ok(()) => failed += 1,
+            Err(e) => warn!(
+                "Supervisor: failed to fail claimed execution {} (job {}) for process {}: {}; leaving it for the orphan-sweep",
+                execution_id, job_id, process_id, e
+            ),
+        }
+    }
+
+    // Prune the process row even if some rows failed: this hands the leftovers
+    // to the orphan-sweep.
+    query_builder::processes::prune(db, &table_config, process_id).await?;
 
     warn!(
-        "Supervisor reaped process {} (pid={}, host={:?}), failed {} claimed job(s)",
-        process_id, process_pid, process_hostname, deleted_count
+        "Supervisor reaped process {} (pid={}, host={:?}), failed {} of {} claimed job(s)",
+        process_id,
+        process_pid,
+        process_hostname,
+        failed,
+        claimed.len()
     );
 
-    Ok(deleted_count)
+    Ok(failed)
 }
 
 #[async_trait]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1230,6 +1230,31 @@ impl PyQuebec {
         self.ctx.claim_in_progress.store(value, Ordering::SeqCst);
     }
 
+    /// Test-only: read a claimed execution's ledger state
+    /// (0=Dispatched, 1=InFlight, 2=CleanupPending; None if absent).
+    fn _ledger_state(&self, id: i64) -> Option<u8> {
+        self.ctx
+            .claim_ledger
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(&id)
+            .map(|s| match s {
+                crate::context::ClaimState::Dispatched => 0,
+                crate::context::ClaimState::InFlight => 1,
+                crate::context::ClaimState::CleanupPending => 2,
+            })
+    }
+
+    /// Test-only: force a ledger state (to exercise CleanupPending / Dispatched paths).
+    fn _set_ledger_state(&self, id: i64, state: u8) {
+        let s = match state {
+            0 => crate::context::ClaimState::Dispatched,
+            1 => crate::context::ClaimState::InFlight,
+            _ => crate::context::ClaimState::CleanupPending,
+        };
+        self.ctx.ledger_set(id, s);
+    }
+
     fn ping(&self) -> PyResult<bool> {
         self.rt.block_on(async move {
             let db = self.ctx.get_db().await.map_err(|e| {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1354,6 +1354,31 @@ impl PyQuebec {
         self.ctx.ledger_set(id, s);
     }
 
+    /// Test-only: drive `InFlightGuard`'s panic-only `Drop` for the given id.
+    ///
+    /// Constructs an `InFlightGuard` against the real ledger (which inserts the
+    /// id as InFlight), then drops it. When `panicking` is true the guard is
+    /// dropped while a panic unwinds (mirroring a panic between
+    /// `InFlightGuard::new` and `after_executed` in `Execution::invoke`), so its
+    /// `Drop` must remove the InFlight entry. When `panicking` is false the
+    /// guard is dropped normally, so its `Drop` must leave the entry untouched
+    /// (the normal-path transition belongs to `after_executed`). Caller reads
+    /// `_ledger_state(id)` afterwards to assert the outcome.
+    fn _drop_in_flight_guard(&self, id: i64, panicking: bool) {
+        let ledger = self.ctx.claim_ledger.clone();
+        if panicking {
+            // Drop the guard mid-unwind: construct it inside the unwinding
+            // closure so std::thread::panicking() is true at drop time.
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let _guard = crate::context::InFlightGuard::new(ledger, id);
+                panic!("forced panic to exercise InFlightGuard::drop");
+            }));
+        } else {
+            let _guard = crate::context::InFlightGuard::new(ledger, id);
+            // Normal drop at end of scope.
+        }
+    }
+
     fn ping(&self) -> PyResult<bool> {
         self.rt.block_on(async move {
             let db = self.ctx.get_db().await.map_err(|e| {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1055,6 +1055,33 @@ impl PyQuebec {
         })
     }
 
+    /// Drive the private `delete_claimed_by_id` dispatch path (job record is
+    /// gone) for the given claimed_executions id. Test-only hook: asserts the
+    /// ledger entry is cleared after the claimed row is dropped.
+    fn _delete_claimed_by_id(&self, py: Python<'_>, execution_id: i64) {
+        let worker = self.worker.clone();
+        py.detach(|| {
+            self.rt.block_on(async move {
+                worker.delete_claimed_by_id_for_test(execution_id).await;
+            })
+        })
+    }
+
+    /// Drive the private `fail_claimed_by_id` dispatch path (runnable
+    /// unregistered) for the given claimed_executions id. Test-only hook:
+    /// asserts the ledger entry is cleared after the claimed row is failed.
+    fn _fail_claimed_by_id(&self, py: Python<'_>, execution_id: i64, job_id: i64, error_msg: &str) {
+        let worker = self.worker.clone();
+        let error_msg = error_msg.to_string();
+        py.detach(|| {
+            self.rt.block_on(async move {
+                worker
+                    .fail_claimed_by_id_for_test(execution_id, job_id, &error_msg)
+                    .await;
+            })
+        })
+    }
+
     fn bind_queue(&self, _py: Python<'_>, queue: Py<PyAny>) -> PyResult<()> {
         let worker = self.worker.clone();
         let queue = queue.clone();

--- a/src/types.rs
+++ b/src/types.rs
@@ -1195,12 +1195,7 @@ impl PyQuebec {
         if self.ctx.claim_in_progress.load(Ordering::SeqCst) {
             return false;
         }
-        let in_flight_empty = self
-            .ctx
-            .in_flight_executions
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .is_empty();
+        let in_flight_empty = self.ctx.ledger_is_empty();
         if !in_flight_empty {
             return false;
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1275,7 +1275,17 @@ impl PyQuebec {
     /// is idle, with no time limit (Sidekiq Enterprise USR2 rolling-restart
     /// semantics). Quiet has already stopped new claims, so an empty result is
     /// terminal — no new work can arrive to make it non-empty again.
-    fn should_drain_exit(&self, py: Python<'_>) -> bool {
+    ///
+    /// Drain-exit is **ledger-authoritative**: the worker-local ledger is the
+    /// truth about *this* worker's graceful-path work (`Dispatched` = claimed
+    /// but not running, `InFlight` = performing). We deliberately do NOT consult
+    /// `count_by_process_id` here. A claimed row may linger in the DB after its
+    /// ledger entry has gone `CleanupPending` (job executed, only row cleanup
+    /// failed) or dropped entirely (crash/error residue). Those rows are owned
+    /// by the DB orphan-sweep, which can only reclaim them once this process row
+    /// is gone — so waiting on the DB count would hang quiet_then_exit forever.
+    /// Once the four guard checks below pass, the worker is drained.
+    fn should_drain_exit(&self) -> bool {
         if !self.ctx.quiet_then_exit || !self.ctx.quiet.is_cancelled() {
             return false;
         }
@@ -1286,7 +1296,7 @@ impl PyQuebec {
             return false;
         }
         // A claim that passed the quiet gate before quiet was signalled may still
-        // be publishing work; wait for it so the idle snapshot below is not taken
+        // be publishing work; wait for it so the idle snapshot is not taken
         // mid-claim (which could let the process exit and subject that batch to
         // graceful_shutdown's bounded drain).
         if self.ctx.claim_in_progress.load(Ordering::SeqCst) {
@@ -1295,31 +1305,7 @@ impl PyQuebec {
         // CleanupPending entries don't block drain: those jobs already executed and
         // only the DB orphan-sweep owns their leftover rows. The worker is drainable
         // once no Dispatched/InFlight (active) work remains.
-        if self.ctx.ledger_has_active() {
-            return false;
-        }
-        let worker = self.worker.clone();
-        let ctx = self.ctx.clone();
-        py.detach(|| {
-            self.rt.block_on(async move {
-                let process_id = match *worker.process_id_handle().lock().await {
-                    Some(id) => id,
-                    None => return false,
-                };
-                let Ok(db) = ctx.get_db().await else {
-                    return false;
-                };
-                matches!(
-                    crate::query_builder::claimed_executions::count_by_process_id(
-                        db.as_ref(),
-                        &ctx.table_config,
-                        process_id,
-                    )
-                    .await,
-                    Ok(0)
-                )
-            })
-        })
+        !self.ctx.ledger_has_active()
     }
 
     /// Test-only: directly set the claim-in-progress flag so a regression test

--- a/src/types.rs
+++ b/src/types.rs
@@ -1063,8 +1063,11 @@ impl PyQuebec {
 
         self.pyqueue_mode.store(true, Ordering::Relaxed);
 
-        // Use tokio::spawn to start async task
-        self.rt.spawn(async move {
+        // Use tokio::spawn to start async task. Track the handle so
+        // graceful_shutdown / close await the pump's unwind before exiting —
+        // otherwise the process can tear down (Python queue, held Execution, DB
+        // refs) while the pump is still mid-iteration.
+        let pump_handle = self.rt.spawn(async move {
             loop {
                 // pick_job returns Err when the dispatch channel is closed or
                 // graceful shutdown has begun. In both cases the pump stops so
@@ -1095,6 +1098,14 @@ impl PyQuebec {
                 });
             }
         });
+        self.handles
+            .lock()
+            .map_err(|_| {
+                PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                    "Failed to acquire lock for handles",
+                )
+            })?
+            .push(pump_handle);
 
         let handle = self.rt.spawn(async move {
             graceful_shutdown.cancelled().await;

--- a/src/types.rs
+++ b/src/types.rs
@@ -952,24 +952,51 @@ impl PyQuebec {
                 let db = ctx.get_db().await.map_err(|e| {
                     PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string())
                 })?;
+
+                // `claim_jobs` inserted a `Dispatched` ledger entry for every
+                // claimed row. If any post-claim lookup/build below fails we
+                // must clear those entries before returning, or the
+                // worker-local ledger leaks. Capture the claimed ids so the
+                // error path can clean up regardless of how far the loop got.
+                let claimed_ids: Vec<i64> = claimed.iter().map(|c| c.id).collect();
+                let clear_ledger = || {
+                    for id in &claimed_ids {
+                        ctx.ledger_remove(*id);
+                    }
+                };
+
                 let mut out: Vec<Execution> = Vec::with_capacity(claimed.len());
                 for c in claimed {
-                    let job = crate::query_builder::jobs::find_by_id(
+                    let job = match crate::query_builder::jobs::find_by_id(
                         db.as_ref(),
                         &ctx.table_config,
                         c.job_id,
                     )
                     .await
-                    .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?
-                    .ok_or_else(|| {
-                        PyErr::new::<pyo3::exceptions::PyRuntimeError, _>("Job record not found")
-                    })?;
-                    let runnable = Python::attach(|_py| ctx.get_runnable(&job.class_name))
-                        .map_err(|e| {
-                            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
-                                "Job handler not found: {e}"
-                            ))
-                        })?;
+                    {
+                        Ok(Some(job)) => job,
+                        Ok(None) => {
+                            clear_ledger();
+                            return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                                "Job record not found",
+                            ));
+                        }
+                        Err(e) => {
+                            clear_ledger();
+                            return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                                e.to_string(),
+                            ));
+                        }
+                    };
+                    let runnable = match Python::attach(|_py| ctx.get_runnable(&job.class_name)) {
+                        Ok(runnable) => runnable,
+                        Err(e) => {
+                            clear_ledger();
+                            return Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                                format!("Job handler not found: {e}"),
+                            ));
+                        }
+                    };
                     out.push(Execution::new(ctx.clone(), c, job, runnable));
                 }
                 Ok(out)

--- a/src/types.rs
+++ b/src/types.rs
@@ -1292,8 +1292,10 @@ impl PyQuebec {
         if self.ctx.claim_in_progress.load(Ordering::SeqCst) {
             return false;
         }
-        let in_flight_empty = self.ctx.ledger_is_empty();
-        if !in_flight_empty {
+        // CleanupPending entries don't block drain: those jobs already executed and
+        // only the DB orphan-sweep owns their leftover rows. The worker is drainable
+        // once no Dispatched/InFlight (active) work remains.
+        if self.ctx.ledger_has_active() {
             return false;
         }
         let worker = self.worker.clone();

--- a/src/types.rs
+++ b/src/types.rs
@@ -1023,6 +1023,38 @@ impl PyQuebec {
         })
     }
 
+    /// Run exactly the dispatch-failure reconcile the maintenance tick runs:
+    /// drain the dispatch-retry set, retry the requeue, drop the ledger entry
+    /// for each row that now succeeds, and re-stash the rest. Test-only hook so
+    /// a regression test can drive the reconcile without the full main loop.
+    fn _run_dispatch_reconcile_once(&self, py: Python<'_>) {
+        let worker = self.worker.clone();
+        py.detach(|| {
+            self.rt.block_on(async move {
+                worker.run_dispatch_reconcile_once_for_test().await;
+            })
+        })
+    }
+
+    /// Load the persisted `claimed_executions` row by id and push it into the
+    /// dispatch-retry set, simulating a residual whose dispatch-failure requeue
+    /// also failed. Test-only hook for seeding a reconcile scenario.
+    fn _add_dispatch_retry(&self, py: Python<'_>, claimed_id: i64) -> PyResult<()> {
+        let worker = self.worker.clone();
+        py.detach(|| {
+            self.rt.block_on(async move {
+                worker
+                    .add_dispatch_retry_for_test(claimed_id)
+                    .await
+                    .map_err(|e| {
+                        PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
+                            "_add_dispatch_retry failed: {e}"
+                        ))
+                    })
+            })
+        })
+    }
+
     fn bind_queue(&self, _py: Python<'_>, queue: Py<PyAny>) -> PyResult<()> {
         let worker = self.worker.clone();
         let queue = queue.clone();

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1396,35 +1396,44 @@ impl Execution {
                     "Emergency cleanup: after_executed transaction failed after all retries",
                 )
                 .await;
-                let claimed_deleted = if let Err(e) = fail_result {
-                    // Fallback: at minimum delete the claimed record to unblock the worker
+                if let Err(e) = fail_result {
+                    // Fallback: at minimum delete the claimed record to unblock the worker.
+                    // `fail_claimed_execution` can return Err *after* the claimed
+                    // row was already deleted (the post-delete unblock/slot
+                    // release failed), so the fallback delete's row count is not
+                    // a reliable signal of whether the row still exists.
                     warn!(
                     "fail_claimed_execution also failed for job {}: {:?}, falling back to delete claimed only",
                     job_id, e
                 );
-                    query_builder::claimed_executions::delete_by_id(
+                    if let Err(e2) = query_builder::claimed_executions::delete_by_id(
                         cleanup_db.as_ref(),
                         &table_config_orig,
                         claimed_id,
                     )
                     .await
-                    .inspect_err(|e2| {
+                    {
                         error!(
                             "Emergency cleanup also failed for claimed_execution {}: {:?}",
                             claimed_id, e2
                         );
-                    })
-                    .map(|deleted| deleted > 0)
-                    .unwrap_or(false)
-                } else {
-                    // fail_claimed_execution deleted the claimed row.
-                    true
-                };
+                    }
+                }
 
-                // The job already executed. If the claimed row is gone the ledger
-                // entry can be cleared; if it is still present mark CleanupPending
-                // so the shutdown release does NOT requeue an executed job.
-                if claimed_deleted {
+                // The job already executed. Decide CleanupPending vs ledger_remove
+                // on whether the claimed row STILL EXISTS, not on a fallback
+                // delete's row count: if the row is gone the ledger entry can be
+                // cleared; if it is still present mark CleanupPending so the
+                // shutdown release does NOT requeue an executed job.
+                let claimed_gone = query_builder::claimed_executions::find_by_id(
+                    cleanup_db.as_ref(),
+                    &table_config_orig,
+                    claimed_id,
+                )
+                .await
+                .map(|row| row.is_none())
+                .unwrap_or(false);
+                if claimed_gone {
                     self.ctx.ledger_remove(self.claimed.id);
                 } else {
                     self.ctx
@@ -1787,6 +1796,25 @@ impl Worker {
     /// spinning up the full main loop and signalling SIGTERM.
     pub(crate) async fn release_claimed_for_test(&self, process_id: i64) -> Result<usize> {
         self.release_all_claimed_executions(process_id).await
+    }
+
+    /// Test-only wrapper around the private `delete_claimed_by_id` so a
+    /// regression test can assert the ledger entry is cleared after the
+    /// claimed row is dropped (the job-record-missing dispatch path).
+    pub(crate) async fn delete_claimed_by_id_for_test(&self, execution_id: i64) {
+        Self::delete_claimed_by_id(&self.ctx, execution_id).await;
+    }
+
+    /// Test-only wrapper around the private `fail_claimed_by_id` so a
+    /// regression test can assert the ledger entry is cleared after the
+    /// claimed row is failed (the unregistered-runnable dispatch path).
+    pub(crate) async fn fail_claimed_by_id_for_test(
+        &self,
+        execution_id: i64,
+        job_id: i64,
+        error_msg: &str,
+    ) {
+        Self::fail_claimed_by_id(&self.ctx, execution_id, job_id, error_msg).await;
     }
 
     /// Test-only: run exactly the dispatch-failure reconcile the maintenance
@@ -2747,6 +2775,11 @@ impl Worker {
             match result {
                 Ok(()) => {
                     released += 1;
+                    // Claim requeued + row deleted: drop the ledger entry so
+                    // close()/test-hook paths don't leak (the real
+                    // graceful_shutdown exits the process, but those paths
+                    // keep running).
+                    self.ctx.ledger_remove(execution_id);
                     debug!("Released job {} back to ready state", job_id);
                 }
                 Err(e) => {
@@ -2890,17 +2923,24 @@ impl Worker {
             return;
         };
         let table_config = ctx.table_config.clone();
-        if let Err(e) = query_builder::claimed_executions::delete_by_id(
+        match query_builder::claimed_executions::delete_by_id(
             db.as_ref(),
             &table_config,
             execution_id,
         )
         .await
         {
-            warn!(
-                "Failed to delete orphaned claimed execution {}: {:?}",
-                execution_id, e
-            );
+            Ok(_) => {
+                // Claim row gone: drop the ledger entry so it stops counting
+                // against in-flight / blocking drain exit.
+                ctx.ledger_remove(execution_id);
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to delete orphaned claimed execution {}: {:?}",
+                    execution_id, e
+                );
+            }
         }
     }
 
@@ -2918,9 +2958,10 @@ impl Worker {
         };
         let table_config = ctx.table_config.clone();
         let ctx = ctx.clone();
-        if let Err(e) = db
+        match db
             .transaction::<_, (), DbErr>(|txn| {
                 let table_config = table_config.clone();
+                let ctx = ctx.clone();
                 let error_msg = error_msg.to_string();
                 Box::pin(async move {
                     Self::fail_claimed_execution(
@@ -2937,10 +2978,17 @@ impl Worker {
             })
             .await
         {
-            warn!(
-                "Failed to clean up claimed execution {}: {:?}",
-                execution_id, e
-            );
+            Ok(()) => {
+                // Claim row failed + deleted: drop the ledger entry so it stops
+                // counting against in-flight / blocking drain exit.
+                ctx.ledger_remove(execution_id);
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to clean up claimed execution {}: {:?}",
+                    execution_id, e
+                );
+            }
         }
     }
 
@@ -3555,6 +3603,11 @@ impl Worker {
             let Ok(processing_db) = ctx.get_db().await.inspect_err(|e| {
                 warn!("[{}] failed to get DB for processing jobs: {:?}", source, e);
             }) else {
+                // claim_jobs already committed these rows (Dispatched in the
+                // ledger). Returning without requeueing would leak them: the
+                // rows stay claimed + Dispatched forever and the reconcile has
+                // nothing to retry. Stash them so the maintenance tick requeues.
+                self.stash_dispatch_retry(claimed.clone()).await;
                 return;
             };
             // Use a single quick transaction to fetch all job data

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -3460,12 +3460,17 @@ impl Worker {
                                 .instrument(tracing::info_span!("listener", consumed = total_notifies))
                                 .await;
 
-                            let process_future = self.process_available_jobs(worker_threads, &tx, &ctx, &thread_id, "NOTIFY");
-                            let timeout_duration = tokio::time::Duration::from_secs(1);
-
-                            if tokio::time::timeout(timeout_duration, process_future).await.is_err() {
-                                warn!("NOTIFY job processing timed out after {}ms - will rely on polling", timeout_duration.as_millis());
-                            }
+                            // Run to completion: this call claims rows (committing
+                            // claimed_executions + Dispatched ledger entries) before
+                            // sending them to the channel / stashing into
+                            // dispatch_retry. Cancelling it mid-claim would leave rows
+                            // claimed in the DB and Dispatched in the ledger but absent
+                            // from both the channel and dispatch_retry, so reconcile
+                            // could never recover them — leaking ledger entries that
+                            // block should_drain_exit and burn claim capacity. The DB
+                            // ops inside already honour the pool's own timeouts, so a
+                            // slow batch should just take the time it needs.
+                            self.process_available_jobs(worker_threads, &tx, &ctx, &thread_id, "NOTIFY").await;
                         } else {
                             trace!("Ignoring NOTIFY for queue not in worker config");
                         }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -974,19 +974,30 @@ pub struct Execution {
 
 impl Drop for Execution {
     fn drop(&mut self) {
-        // Backstop for the claim ledger: pick_job marks a job in-flight when it
-        // leaves the dispatch channel and after_executed normally clears it. If a
-        // picked Execution is dropped without ever running perform() (e.g. it
-        // failed to enqueue to the Python work queue), clear the entry here so the
-        // shutdown drain is not left waiting on it. A CleanupPending mark (set by
-        // after_executed when the claimed row could not be deleted) is preserved:
-        // the job already ran, so the ledger must keep blocking its requeue.
+        // Backstop for the claim ledger, by state. `release_all_claimed_executions`
+        // is ledger-authoritative: it requeues only `Dispatched` rows.
+        //   * `InFlight` — pick_job marked it in-flight but the Execution is being
+        //     dropped without `after_executed` (e.g. it failed to enqueue to the
+        //     Python work queue). Whether perform() ran is ambiguous, so REMOVE
+        //     the entry: this unblocks the shutdown drain (which waits on InFlight)
+        //     and leaves the claimed row for the orphan-sweep rather than risking a
+        //     double-run by requeuing it.
+        //   * `Dispatched` — the Execution was pulled from the dispatch channel but
+        //     dropped BEFORE pick_job marked it InFlight (the pre-perform shutdown
+        //     race). The job never ran, so LEAVE the entry: graceful release then
+        //     requeues it, honouring the "claimed-but-not-started → released"
+        //     guarantee. (A Dispatched entry is only dropped here during shutdown;
+        //     in normal operation pick_job transitions it to InFlight.)
+        //   * `CleanupPending` — already executed; preserve so requeue stays blocked.
         let mut ledger = self
             .ctx
             .claim_ledger
             .lock()
             .unwrap_or_else(|e| e.into_inner());
-        if ledger.get(&self.claimed.id) != Some(&crate::context::ClaimState::CleanupPending) {
+        if matches!(
+            ledger.get(&self.claimed.id),
+            Some(crate::context::ClaimState::InFlight)
+        ) {
             ledger.remove(&self.claimed.id);
         }
     }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -2823,29 +2823,30 @@ impl Worker {
         )
         .await?;
 
-        // Skip executions that are actively running inside perform()
-        // (`InFlight`) or that already ran but whose claimed-row cleanup failed
-        // (`CleanupPending`); releasing either would create a duplicate-execution
-        // race with a neighbour worker. `ledger_snapshot` recovers from poisoning
-        // rather than treating the ledger as empty, which would let such a job be
-        // released back to ready (double-run). Claimed rows with no ledger entry
-        // (the crash-fallback case) are treated as releasable.
-        let skip: std::collections::HashSet<i64> = self
-            .ctx
-            .ledger_snapshot()
-            .into_iter()
-            .filter(|(_, s)| {
-                matches!(
-                    s,
-                    crate::context::ClaimState::InFlight
-                        | crate::context::ClaimState::CleanupPending
-                )
-            })
-            .map(|(id, _)| id)
-            .collect();
+        // Release is ledger-authoritative: requeue ONLY rows the ledger still
+        // records as `Dispatched` (claimed, queued, never performed). Skip
+        // everything else:
+        //   * `InFlight` — the drain above waits for it to finish;
+        //   * `CleanupPending` — already executed; requeuing would double-run it;
+        //   * no ledger entry — error / `Execution::Drop` residue, NOT a live
+        //     Dispatched claim (`claim_jobs` records every claim as `Dispatched`,
+        //     so a missing entry means some path already removed it). Requeuing a
+        //     missing-entry row is the duplicate-run hazard where an
+        //     executed-but-cleanup-failed claim lost its ledger entry. Leave it
+        //     claimed for the DB orphan-sweep, which reclaims it once `on_stop`
+        //     deletes this process's row.
+        // This mirrors `should_drain_exit`'s ledger-authoritative gate.
+        // `ledger_snapshot` recovers from poisoning rather than treating the
+        // ledger as empty (which would skip a genuine Dispatched claim).
+        let ledger = self.ctx.ledger_snapshot();
         let claimed: Vec<_> = claimed
             .into_iter()
-            .filter(|execution| !skip.contains(&execution.id))
+            .filter(|execution| {
+                matches!(
+                    ledger.get(&execution.id),
+                    Some(crate::context::ClaimState::Dispatched)
+                )
+            })
             .collect();
 
         if claimed.is_empty() {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -975,11 +975,20 @@ pub struct Execution {
 impl Drop for Execution {
     fn drop(&mut self) {
         // Backstop for the claim ledger: pick_job marks a job in-flight when it
-        // leaves the dispatch channel and the InFlightGuard in invoke() normally
-        // clears it. If a picked Execution is dropped without ever running
-        // perform() (e.g. it failed to enqueue to the Python work queue), clear
-        // the entry here so the shutdown drain is not left waiting on it.
-        self.ctx.ledger_remove(self.claimed.id);
+        // leaves the dispatch channel and after_executed normally clears it. If a
+        // picked Execution is dropped without ever running perform() (e.g. it
+        // failed to enqueue to the Python work queue), clear the entry here so the
+        // shutdown drain is not left waiting on it. A CleanupPending mark (set by
+        // after_executed when the claimed row could not be deleted) is preserved:
+        // the job already ran, so the ledger must keep blocking its requeue.
+        let mut ledger = self
+            .ctx
+            .claim_ledger
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        if ledger.get(&self.claimed.id) != Some(&crate::context::ClaimState::CleanupPending) {
+            ledger.remove(&self.claimed.id);
+        }
     }
 }
 
@@ -1357,6 +1366,13 @@ impl Execution {
             }
         }
 
+        // Cleanup succeeded: the transaction committed and the claimed row was
+        // deleted, so the ledger entry is no longer needed. Removal lives here
+        // (not in InFlightGuard::drop) so it tracks the real DB outcome.
+        if transaction_result.is_ok() {
+            self.ctx.ledger_remove(self.claimed.id);
+        }
+
         // Emergency cleanup: if the transaction failed after all retries, mark the job
         // as failed and release the concurrency semaphore to prevent permanent deadlock.
         if transaction_result.is_err() {
@@ -1380,13 +1396,13 @@ impl Execution {
                     "Emergency cleanup: after_executed transaction failed after all retries",
                 )
                 .await;
-                if let Err(e) = fail_result {
+                let claimed_deleted = if let Err(e) = fail_result {
                     // Fallback: at minimum delete the claimed record to unblock the worker
                     warn!(
                     "fail_claimed_execution also failed for job {}: {:?}, falling back to delete claimed only",
                     job_id, e
                 );
-                    let _ = query_builder::claimed_executions::delete_by_id(
+                    query_builder::claimed_executions::delete_by_id(
                         cleanup_db.as_ref(),
                         &table_config_orig,
                         claimed_id,
@@ -1397,8 +1413,28 @@ impl Execution {
                             "Emergency cleanup also failed for claimed_execution {}: {:?}",
                             claimed_id, e2
                         );
-                    });
+                    })
+                    .map(|deleted| deleted > 0)
+                    .unwrap_or(false)
+                } else {
+                    // fail_claimed_execution deleted the claimed row.
+                    true
+                };
+
+                // The job already executed. If the claimed row is gone the ledger
+                // entry can be cleared; if it is still present mark CleanupPending
+                // so the shutdown release does NOT requeue an executed job.
+                if claimed_deleted {
+                    self.ctx.ledger_remove(self.claimed.id);
+                } else {
+                    self.ctx
+                        .ledger_set(self.claimed.id, crate::context::ClaimState::CleanupPending);
                 }
+            } else {
+                // Could not even get a DB handle: the claimed row is still present
+                // and the job already ran. Mark CleanupPending to block requeue.
+                self.ctx
+                    .ledger_set(self.claimed.id, crate::context::ClaimState::CleanupPending);
             }
         }
 
@@ -2560,9 +2596,12 @@ impl Worker {
     /// graceful shutdown. Releases jobs that have not started running — those
     /// still sitting in the dispatch channel — so the dispatcher can re-claim
     /// them immediately. Jobs that have been handed to the Python side (tracked
-    /// as `ClaimState::InFlight` in `ctx.claim_ledger`) are skipped: the
-    /// shutdown drain waits for the ledger to empty first, so in normal
-    /// shutdown there are none left here.
+    /// as `ClaimState::InFlight` in `ctx.claim_ledger`) are skipped, as are jobs
+    /// that already executed but whose claimed-row cleanup failed
+    /// (`ClaimState::CleanupPending`) — releasing either would let a neighbour
+    /// run an in-flight or already-finished job a second time. The shutdown
+    /// drain waits for the ledger to empty first, so in normal shutdown there
+    /// are none left here.
     /// Any that remain (the drain hit `shutdown_timeout`) are left in
     /// `claimed_executions` rather than released, because releasing a job whose
     /// perform thread is still running would let a neighbour run it a second
@@ -2584,21 +2623,29 @@ impl Worker {
         )
         .await?;
 
-        // Skip executions that are actively running inside perform(); releasing
-        // them would create a duplicate-execution race with a neighbour worker.
-        // `ledger_snapshot` recovers from poisoning rather than treating the
-        // ledger as empty, which would let a running job be released back to
-        // ready (double-run).
-        let in_flight: std::collections::HashSet<i64> = self
+        // Skip executions that are actively running inside perform()
+        // (`InFlight`) or that already ran but whose claimed-row cleanup failed
+        // (`CleanupPending`); releasing either would create a duplicate-execution
+        // race with a neighbour worker. `ledger_snapshot` recovers from poisoning
+        // rather than treating the ledger as empty, which would let such a job be
+        // released back to ready (double-run). Claimed rows with no ledger entry
+        // (the crash-fallback case) are treated as releasable.
+        let skip: std::collections::HashSet<i64> = self
             .ctx
             .ledger_snapshot()
             .into_iter()
-            .filter(|(_, state)| *state == crate::context::ClaimState::InFlight)
+            .filter(|(_, s)| {
+                matches!(
+                    s,
+                    crate::context::ClaimState::InFlight
+                        | crate::context::ClaimState::CleanupPending
+                )
+            })
             .map(|(id, _)| id)
             .collect();
         let claimed: Vec<_> = claimed
             .into_iter()
-            .filter(|execution| !in_flight.contains(&execution.id))
+            .filter(|execution| !skip.contains(&execution.id))
             .collect();
 
         if claimed.is_empty() {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -3048,7 +3048,10 @@ impl Worker {
             return Ok(());
         };
         let duration = chrono::Duration::from_std(ctx.default_concurrency_control_period).ok();
-        let _ = release_semaphore(
+        // Propagate failure: every caller runs inside the same transaction that
+        // deletes the claim, so a release error must roll back the whole unit
+        // rather than commit the claim deletion while leaking the queue slot.
+        release_semaphore(
             db,
             table_config,
             format!("queue:{}", queue_name),
@@ -3056,7 +3059,7 @@ impl Worker {
             duration,
         )
         .await
-        .inspect_err(|e| warn!("Failed to release queue:{} semaphore: {:?}", queue_name, e));
+        .inspect_err(|e| warn!("Failed to release queue:{} semaphore: {:?}", queue_name, e))?;
         Ok(())
     }
 
@@ -3322,6 +3325,9 @@ impl Worker {
                     // fraction of shutdown_timeout so the outer graceful_shutdown
                     // block_on still has budget to run the release and on_stop
                     // below before its own timeout fires.
+                    // With a very small or zero shutdown_timeout the deadline is
+                    // effectively now: the loop still checks in_flight once, then
+                    // falls through to release rather than draining.
                     let drain_deadline = tokio::time::Instant::now()
                         + self.ctx.shutdown_timeout.mul_f64(0.8);
                     loop {
@@ -3338,14 +3344,18 @@ impl Worker {
                         if no_in_flight {
                             break;
                         }
-                        if tokio::time::Instant::now() >= drain_deadline {
+                        let now = tokio::time::Instant::now();
+                        if now >= drain_deadline {
                             warn!(
                                 "Shutdown drain timed out with jobs still inside perform(); \
                                  leaving them claimed to avoid a double-execution race"
                             );
                             break;
                         }
-                        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                        // Cap the nap at the remaining budget so we never oversleep
+                        // past the deadline and eat into the release + on_stop time.
+                        let nap = (drain_deadline - now).min(std::time::Duration::from_millis(50));
+                        tokio::time::sleep(nap).await;
                     }
 
                     // Release jobs that never started running (still queued in the

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -2541,7 +2541,7 @@ impl Worker {
             count
         );
 
-        let mut failed = 0usize;
+        let mut reclaimed = 0usize;
         for execution in orphaned {
             let ctx = self.ctx.clone();
             let tc = table_config.clone();
@@ -2573,7 +2573,7 @@ impl Worker {
 
             match result {
                 Ok(()) => {
-                    failed += 1;
+                    reclaimed += 1;
                     debug!(
                         "Marked orphaned job {} as failed (was claimed by process {:?})",
                         job_id, process_id
@@ -2588,7 +2588,7 @@ impl Worker {
             }
         }
 
-        Ok(failed)
+        Ok(reclaimed)
     }
 
     /// Prune dead processes and fail their claimed executions

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -974,16 +974,12 @@ pub struct Execution {
 
 impl Drop for Execution {
     fn drop(&mut self) {
-        // Backstop for the in-flight set: pick_job marks a job in-flight when it
+        // Backstop for the claim ledger: pick_job marks a job in-flight when it
         // leaves the dispatch channel and the InFlightGuard in invoke() normally
         // clears it. If a picked Execution is dropped without ever running
         // perform() (e.g. it failed to enqueue to the Python work queue), clear
         // the entry here so the shutdown drain is not left waiting on it.
-        self.ctx
-            .in_flight_executions
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .remove(&self.claimed.id);
+        self.ctx.ledger_remove(self.claimed.id);
     }
 }
 
@@ -1037,14 +1033,12 @@ impl Execution {
     async fn invoke(&mut self) -> Result<quebec_jobs::Model> {
         // Mark this claimed_execution as in-flight for the whole perform()
         // window. `release_all_claimed_executions` (graceful shutdown) skips
-        // ids still in this set so a job actively inside perform() is never
+        // ids still in this state so a job actively inside perform() is never
         // handed back to a neighbour worker. The guard clears the id when this
         // function returns (after `after_executed` has deleted the claimed
         // row) or unwinds, so the entry never outlives the perform.
-        let _in_flight = crate::context::InFlightGuard::new(
-            self.ctx.in_flight_executions.clone(),
-            self.claimed.id,
-        );
+        let _in_flight =
+            crate::context::InFlightGuard::new(self.ctx.claim_ledger.clone(), self.claimed.id);
 
         self.timer = Instant::now();
         let now = chrono::Utc::now().naive_utc();
@@ -2559,8 +2553,9 @@ impl Worker {
     /// graceful shutdown. Releases jobs that have not started running — those
     /// still sitting in the dispatch channel — so the dispatcher can re-claim
     /// them immediately. Jobs that have been handed to the Python side (tracked
-    /// in `ctx.in_flight_executions`) are skipped: the shutdown drain waits for
-    /// that set to empty first, so in normal shutdown there are none left here.
+    /// as `ClaimState::InFlight` in `ctx.claim_ledger`) are skipped: the
+    /// shutdown drain waits for the ledger to empty first, so in normal
+    /// shutdown there are none left here.
     /// Any that remain (the drain hit `shutdown_timeout`) are left in
     /// `claimed_executions` rather than released, because releasing a job whose
     /// perform thread is still running would let a neighbour run it a second
@@ -2584,14 +2579,16 @@ impl Worker {
 
         // Skip executions that are actively running inside perform(); releasing
         // them would create a duplicate-execution race with a neighbour worker.
-        // Recover from poisoning rather than treating it as an empty set, which
-        // would let a running job be released back to ready (double-run).
+        // `ledger_snapshot` recovers from poisoning rather than treating the
+        // ledger as empty, which would let a running job be released back to
+        // ready (double-run).
         let in_flight: std::collections::HashSet<i64> = self
             .ctx
-            .in_flight_executions
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .clone();
+            .ledger_snapshot()
+            .into_iter()
+            .filter(|(_, state)| *state == crate::context::ClaimState::InFlight)
+            .map(|(id, _)| id)
+            .collect();
         let claimed: Vec<_> = claimed
             .into_iter()
             .filter(|execution| !in_flight.contains(&execution.id))
@@ -3184,12 +3181,7 @@ impl Worker {
                     let drain_deadline = tokio::time::Instant::now()
                         + self.ctx.shutdown_timeout.mul_f64(0.8);
                     loop {
-                        let in_flight_empty = self
-                            .ctx
-                            .in_flight_executions
-                            .lock()
-                            .unwrap_or_else(|e| e.into_inner())
-                            .is_empty();
+                        let in_flight_empty = self.ctx.ledger_is_empty();
                         if in_flight_empty {
                             break;
                         }
@@ -3493,25 +3485,30 @@ impl Worker {
         // shutdown can still begin between recv() and this insert, and a
         // concurrent release could snapshot in_flight without this id. The
         // recheck under the lock closes that window: if shutdown has begun we
-        // bail out, leaving the job's claimed row in the DB and out of
-        // in_flight so the release returns it to ready instead of us handing it
+        // bail out, leaving the job's claimed row in the DB and out of the
+        // ledger so the release returns it to ready instead of us handing it
         // to Python and double-running it. Outside shutdown this is a single
         // insert. The InFlightGuard in Execution::invoke re-inserts (idempotent)
         // and removes the id on completion; Execution's Drop clears it too, so a
         // picked job that never reaches perform() cannot leak its entry.
+        //
+        // The insert and shutdown recheck must happen under the same lock the
+        // release snapshots under, so this takes the ledger lock directly rather
+        // than going through `ledger_set` (which would drop the lock between the
+        // recheck and the insert, reopening the race).
         {
             // Recover from poisoning rather than failing open: returning Ok here
             // would bypass the shutdown recheck and hand a possibly-released job
-            // to Python. The set stays consistent across a panic.
-            let mut set = self
+            // to Python. The ledger stays consistent across a panic.
+            let mut ledger = self
                 .ctx
-                .in_flight_executions
+                .claim_ledger
                 .lock()
                 .unwrap_or_else(|e| e.into_inner());
             if self.ctx.graceful_shutdown.is_cancelled() {
                 return Err(QuebecError::runtime("shutting down"));
             }
-            set.insert(execution.claimed.id);
+            ledger.insert(execution.claimed.id, crate::context::ClaimState::InFlight);
         }
         Ok(execution)
     }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1422,23 +1422,14 @@ impl Execution {
 
                 // The job already executed. Decide CleanupPending vs ledger_remove
                 // on whether the claimed row STILL EXISTS, not on a fallback
-                // delete's row count: if the row is gone the ledger entry can be
-                // cleared; if it is still present mark CleanupPending so the
-                // shutdown release does NOT requeue an executed job.
-                let claimed_gone = query_builder::claimed_executions::find_by_id(
+                // delete's row count.
+                self.resolve_emergency_cleanup_ledger(
                     cleanup_db.as_ref(),
                     &table_config_orig,
+                    job_id,
                     claimed_id,
                 )
-                .await
-                .map(|row| row.is_none())
-                .unwrap_or(false);
-                if claimed_gone {
-                    self.ctx.ledger_remove(self.claimed.id);
-                } else {
-                    self.ctx
-                        .ledger_set(self.claimed.id, crate::context::ClaimState::CleanupPending);
-                }
+                .await;
             } else {
                 // Could not even get a DB handle: the claimed row is still present
                 // and the job already ran. Mark CleanupPending to block requeue.
@@ -1478,6 +1469,48 @@ impl Execution {
             Err(e) => Err(QuebecError::Transaction(format!(
                 "Database error during job processing: {e}"
             ))),
+        }
+    }
+
+    /// Resolve the worker-local ledger after the emergency-cleanup tail of
+    /// `after_executed`. The job has already executed; the fallback delete of
+    /// the claimed row was already attempted. Three outcomes from re-checking
+    /// whether the claimed row still exists:
+    ///
+    /// * `Ok(Some)` — row confirmed present: mark `CleanupPending` so the
+    ///   shutdown release does NOT requeue an already-executed job; the DB
+    ///   orphan-sweep reclaims the lingering row.
+    /// * `Ok(None)` — row confirmed gone: clear the ledger entry.
+    /// * `Err` — verification could not be performed: do NOT mark
+    ///   `CleanupPending`. The fallback delete above may have already removed
+    ///   the row, and even if it didn't the orphan-sweep reclaims it straight
+    ///   from the DB (it never reads the ledger). Marking `CleanupPending` on
+    ///   an unverifiable result would risk a permanent zombie ledger entry that
+    ///   nothing can ever clear, so remove it and defer to the orphan-sweep.
+    async fn resolve_emergency_cleanup_ledger<C>(
+        &self,
+        db: &C,
+        table_config: &crate::context::TableConfig,
+        job_id: i64,
+        claimed_id: i64,
+    ) where
+        C: sea_orm::ConnectionTrait,
+    {
+        match query_builder::claimed_executions::find_by_id(db, table_config, claimed_id).await {
+            Ok(Some(_)) => {
+                self.ctx
+                    .ledger_set(self.claimed.id, crate::context::ClaimState::CleanupPending);
+            }
+            Ok(None) => {
+                self.ctx.ledger_remove(self.claimed.id);
+            }
+            Err(e) => {
+                warn!(
+                    "Could not verify claimed_execution {} after emergency cleanup of job {}: {:?}; removing ledger entry and deferring to orphan-sweep",
+                    claimed_id, job_id, e
+                );
+                self.ctx.ledger_remove(self.claimed.id);
+            }
         }
     }
 }
@@ -1552,6 +1585,39 @@ impl Execution {
         }
 
         Ok(())
+    }
+
+    /// Test-only hook for `after_executed`'s emergency-cleanup verification tail.
+    /// Drives `resolve_emergency_cleanup_ledger` directly so a regression test
+    /// can pin all three decision arms (row present → CleanupPending, row gone →
+    /// remove, verification error → remove), including the `Err` arm that is
+    /// otherwise unreachable from Python without the full triple-failure path.
+    fn _resolve_emergency_cleanup_ledger(&self, py: Python<'_>) -> PyResult<()> {
+        let handle = self.ctx.get_runtime_handle().ok_or_else(|| {
+            PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(
+                "Tokio runtime handle not initialized",
+            )
+        })?;
+        let table_config = self.ctx.table_config.clone();
+        let job_id = self.claimed.job_id;
+        let claimed_id = self.claimed.id;
+        py.detach(|| {
+            handle.block_on(async {
+                let db = self.ctx.get_db().await.map_err(|e| {
+                    PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
+                        "Failed to get DB: {e}"
+                    ))
+                })?;
+                self.resolve_emergency_cleanup_ledger(
+                    db.as_ref(),
+                    &table_config,
+                    job_id,
+                    claimed_id,
+                )
+                .await;
+                Ok(())
+            })
+        })
     }
 
     fn post(&mut self, py: Python, exc: &Bound<'_, PyAny>, traceback: &str) {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -2541,33 +2541,54 @@ impl Worker {
             count
         );
 
+        let mut failed = 0usize;
         for execution in orphaned {
             let ctx = self.ctx.clone();
             let tc = table_config.clone();
             let job_id = execution.job_id;
+            let execution_id = execution.id;
+            let process_id = execution.process_id;
 
-            db.transaction::<_, (), DbErr>(|txn| {
-                Box::pin(async move {
-                    Self::fail_claimed_execution(
-                        &ctx,
-                        txn,
-                        &tc,
-                        job_id,
-                        execution.id,
-                        "Process crashed or was killed before job completion",
-                    )
-                    .await
+            // Per-row best-effort: a failure here (e.g. an experimental
+            // queue-slot release error) must not abort the sweep of the
+            // remaining orphaned rows. The crash-recovery path is the last
+            // line of defense, so one bad row is logged and skipped, left for
+            // the next sweep tick / another process to retry, instead of
+            // propagating and leaving every other orphan un-reclaimed.
+            let result = db
+                .transaction::<_, (), DbErr>(|txn| {
+                    Box::pin(async move {
+                        Self::fail_claimed_execution(
+                            &ctx,
+                            txn,
+                            &tc,
+                            job_id,
+                            execution_id,
+                            "Process crashed or was killed before job completion",
+                        )
+                        .await
+                    })
                 })
-            })
-            .await?;
+                .await;
 
-            debug!(
-                "Marked orphaned job {} as failed (was claimed by process {:?})",
-                job_id, execution.process_id
-            );
+            match result {
+                Ok(()) => {
+                    failed += 1;
+                    debug!(
+                        "Marked orphaned job {} as failed (was claimed by process {:?})",
+                        job_id, process_id
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        "Failed to reclaim orphaned execution {} (job {}, claimed by process {:?}): {:?}; leaving it for a later sweep",
+                        execution_id, job_id, process_id, e
+                    );
+                }
+            }
         }
 
-        Ok(count)
+        Ok(failed)
     }
 
     /// Prune dead processes and fail their claimed executions

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1722,6 +1722,13 @@ pub struct Worker {
     idle_notify: Arc<tokio::sync::Notify>,
     /// Process ID for this worker (set after on_start)
     process_id: Arc<tokio::sync::Mutex<Option<i64>>>,
+    /// Claimed rows whose dispatch-failure requeue (`release_claimed_batch`)
+    /// also failed (e.g. DB transiently down). They stay claimed in the DB and
+    /// `Dispatched` in the ledger, counting against the per-process in-flight
+    /// limit and blocking `should_drain_exit`. The maintenance tick retries
+    /// these so they eventually return to ready while the process is alive,
+    /// rather than waiting for the post-death orphan sweep.
+    dispatch_retry: Arc<tokio::sync::Mutex<Vec<quebec_claimed_executions::Model>>>,
 }
 
 impl Worker {
@@ -1756,6 +1763,7 @@ impl Worker {
             sink_receiver,
             idle_notify,
             process_id: Arc::new(tokio::sync::Mutex::new(None)),
+            dispatch_retry: Arc::new(tokio::sync::Mutex::new(Vec::new())),
         }
     }
 
@@ -1779,6 +1787,30 @@ impl Worker {
     /// spinning up the full main loop and signalling SIGTERM.
     pub(crate) async fn release_claimed_for_test(&self, process_id: i64) -> Result<usize> {
         self.release_all_claimed_executions(process_id).await
+    }
+
+    /// Test-only: run exactly the dispatch-failure reconcile the maintenance
+    /// tick runs (drain the retry set, retry release, drop ledger entries for
+    /// the rows that now requeue, re-stash the rest).
+    pub(crate) async fn run_dispatch_reconcile_once_for_test(&self) {
+        let ctx = self.ctx.clone();
+        self.reconcile_dispatch_retry(&ctx).await;
+    }
+
+    /// Test-only: load the persisted `claimed_executions` row by id and push it
+    /// into the dispatch-retry set so a regression test can seed a residual
+    /// deterministically.
+    pub(crate) async fn add_dispatch_retry_for_test(&self, claimed_id: i64) -> Result<()> {
+        let db = self.ctx.get_db().await?;
+        let row = query_builder::claimed_executions::find_by_id(
+            db.as_ref(),
+            &self.ctx.table_config,
+            claimed_id,
+        )
+        .await?
+        .ok_or_else(|| QuebecError::runtime(format!("claimed execution {claimed_id} not found")))?;
+        self.dispatch_retry.lock().await.push(row);
+        Ok(())
     }
 
     fn register_handler(
@@ -2712,18 +2744,26 @@ impl Worker {
     }
 
     /// Release a batch of claimed executions back to ready state (best-effort).
-    /// Used when a transient error prevents dispatching claimed jobs to worker threads.
+    /// Used when a transient error prevents dispatching claimed jobs to worker
+    /// threads.
+    ///
+    /// For each row that requeues successfully, its ledger entry is removed
+    /// (the claim no longer exists, so it must not count against the in-flight
+    /// limit or block drain). Returns the rows that FAILED to requeue (e.g. DB
+    /// down) so the caller can stash them for a later retry; their ledger
+    /// entries are left intact (still `Dispatched`) until they succeed.
     async fn release_claimed_batch(
         ctx: &Arc<AppContext>,
         claimed: &[quebec_claimed_executions::Model],
-    ) {
+    ) -> Vec<quebec_claimed_executions::Model> {
         let Ok(db) = ctx.get_db().await.inspect_err(|e| {
             warn!("Failed to get DB for release_claimed_batch: {:?}", e);
         }) else {
-            return;
+            // No DB connection: nothing could be released, all rows fail.
+            return claimed.to_vec();
         };
         let table_config = ctx.table_config.clone();
-        let mut released = 0usize;
+        let mut failed: Vec<quebec_claimed_executions::Model> = Vec::new();
         for row in claimed {
             let table_config = table_config.clone();
             let ctx = ctx.clone();
@@ -2764,16 +2804,62 @@ impl Worker {
                     "Failed to release claimed execution {} back to ready: {:?}",
                     execution_id, e
                 );
+                failed.push(row.clone());
             } else {
-                released += 1;
+                // Requeued: the claim is gone, drop it from the ledger so it
+                // stops counting against in-flight / blocking drain exit.
+                ctx.ledger_remove(execution_id);
             }
         }
-        if released > 0 || !claimed.is_empty() {
+        if !claimed.is_empty() {
             info!(
                 "Released {}/{} claimed execution(s) back to ready state",
-                released,
+                claimed.len() - failed.len(),
                 claimed.len()
             );
+        }
+        failed
+    }
+
+    /// Append rows that failed to requeue to the worker-local retry set so the
+    /// maintenance tick can retry them. No-op for an empty list.
+    async fn stash_dispatch_retry(&self, failed: Vec<quebec_claimed_executions::Model>) {
+        if failed.is_empty() {
+            return;
+        }
+        warn!(
+            "Stashing {} claimed execution(s) for dispatch-failure retry",
+            failed.len()
+        );
+        self.dispatch_retry.lock().await.extend(failed);
+    }
+
+    /// Retry requeuing the residual claimed rows that earlier failed to release
+    /// (their dispatch failed AND the requeue failed). Drains the retry set,
+    /// retries `release_claimed_batch` (which removes the ledger entry for each
+    /// row that now succeeds), and puts the still-failing rows back for the next
+    /// tick. Called from the maintenance tick of `run_main_loop` next to
+    /// `prune_dead_processes`. Only touches rows that genuinely failed to
+    /// requeue — normal in-channel `Dispatched` rows never enter this path.
+    async fn reconcile_dispatch_retry(&self, ctx: &Arc<AppContext>) {
+        let pending: Vec<quebec_claimed_executions::Model> = {
+            let mut guard = self.dispatch_retry.lock().await;
+            if guard.is_empty() {
+                return;
+            }
+            std::mem::take(&mut *guard)
+        };
+        let count = pending.len();
+        debug!("Reconciling {} dispatch-failure residual(s)", count);
+        let still_failed = Self::release_claimed_batch(ctx, &pending).await;
+        if !still_failed.is_empty() {
+            warn!(
+                "{}/{} dispatch-failure residual(s) still could not be requeued; \
+                 will retry next maintenance tick",
+                still_failed.len(),
+                count
+            );
+            self.dispatch_retry.lock().await.extend(still_failed);
         }
     }
 
@@ -3193,6 +3279,10 @@ impl Worker {
                     if let Err(e) = self.prune_dead_processes(Some(process.id)).await {
                         warn!("Failed to prune dead processes: {}", e);
                     }
+                    // Retry requeuing claimed rows whose dispatch-failure release
+                    // also failed. Left unhandled they stay claimed + Dispatched,
+                    // counting against in-flight and blocking should_drain_exit.
+                    self.reconcile_dispatch_retry(&ctx).await;
                 }
                 // Periodic cleanup: clear finished jobs older than threshold (if enabled)
                 _ = cleanup_interval.tick(), if cleanup_enabled => {
@@ -3454,8 +3544,11 @@ impl Worker {
                 Err(e) => {
                     error!("Failed to fetch job data: {:?}", e);
                     // Release all claimed executions back to ready state to avoid
-                    // leaving them permanently stuck in claimed_executions
-                    Self::release_claimed_batch(ctx, &claimed).await;
+                    // leaving them permanently stuck in claimed_executions. Rows
+                    // that fail to requeue (release itself errored) are stashed
+                    // for the maintenance tick to retry.
+                    let failed = Self::release_claimed_batch(ctx, &claimed).await;
+                    self.stash_dispatch_retry(failed).await;
                     return;
                 }
             }
@@ -3513,11 +3606,17 @@ impl Worker {
                 Ok(()) => {}
                 Err(tokio::sync::mpsc::error::TrySendError::Full(leaked)) => {
                     warn!("Channel unexpectedly full, releasing claimed execution back to ready");
-                    Self::release_claimed_batch(ctx, std::slice::from_ref(&leaked.claimed)).await;
+                    let failed =
+                        Self::release_claimed_batch(ctx, std::slice::from_ref(&leaked.claimed))
+                            .await;
+                    self.stash_dispatch_retry(failed).await;
                 }
                 Err(tokio::sync::mpsc::error::TrySendError::Closed(leaked)) => {
                     error!("Dispatch channel closed, releasing claimed execution");
-                    Self::release_claimed_batch(ctx, std::slice::from_ref(&leaked.claimed)).await;
+                    let failed =
+                        Self::release_claimed_batch(ctx, std::slice::from_ref(&leaked.claimed))
+                            .await;
+                    self.stash_dispatch_retry(failed).await;
                 }
             }
         }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1043,9 +1043,15 @@ impl Execution {
         // Mark this claimed_execution as in-flight for the whole perform()
         // window. `release_all_claimed_executions` (graceful shutdown) skips
         // ids still in this state so a job actively inside perform() is never
-        // handed back to a neighbour worker. The guard clears the id when this
-        // function returns (after `after_executed` has deleted the claimed
-        // row) or unwinds, so the entry never outlives the perform.
+        // handed back to a neighbour worker. Clearing model:
+        //   * normal path: `after_executed` clears the entry — removes it on
+        //     cleanup success, marks it `CleanupPending` on cleanup failure;
+        //   * `Execution::Drop` is the backstop when a picked Execution is
+        //     dropped before finishing `after_executed`;
+        //   * `InFlightGuard::Drop` clears the entry specifically when this
+        //     frame unwinds on a panic (it does nothing on a normal drop), so
+        //     the InFlight entry can't leak even if the owning `Execution` is
+        //     kept alive by the Python runner and thus never dropped.
         let _in_flight =
             crate::context::InFlightGuard::new(self.ctx.claim_ledger.clone(), self.claimed.id);
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1048,10 +1048,11 @@ impl Execution {
         //     cleanup success, marks it `CleanupPending` on cleanup failure;
         //   * `Execution::Drop` is the backstop when a picked Execution is
         //     dropped before finishing `after_executed`;
-        //   * `InFlightGuard::Drop` clears the entry specifically when this
-        //     frame unwinds on a panic (it does nothing on a normal drop), so
-        //     the InFlight entry can't leak even if the owning `Execution` is
-        //     kept alive by the Python runner and thus never dropped.
+        //   * `InFlightGuard::Drop` marks the entry `CleanupPending` when this
+        //     frame unwinds on a panic (it does nothing on a normal drop), so a
+        //     possibly-executed InFlight job is skipped by graceful shutdown's
+        //     release (never requeued) rather than leaking, even if the owning
+        //     `Execution` is kept alive by the Python runner and never dropped.
         let _in_flight =
             crate::context::InFlightGuard::new(self.ctx.claim_ledger.clone(), self.claimed.id);
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -2684,63 +2684,81 @@ impl Worker {
             return Ok(0);
         }
 
-        let count = claimed.len();
-        info!("Releasing {} claimed job(s) back to ready state", count);
+        let total = claimed.len();
+        info!("Releasing {} claimed job(s) back to ready state", total);
 
+        let mut released = 0usize;
         for execution in claimed {
             let table_config = table_config.clone();
             let ctx = self.ctx.clone();
             let job_id = execution.job_id;
             let execution_id = execution.id;
 
-            db.transaction::<_, (), DbErr>(|txn| {
-                let ctx = ctx.clone();
-                Box::pin(async move {
-                    if let Some(job) =
-                        query_builder::jobs::find_by_id(txn, &table_config, job_id).await?
-                    {
-                        // Bypass class-level concurrency limits: the job
-                        // already holds the class-level semaphore slot from
-                        // when it was dispatched. Put it back to ready
-                        // directly so the dispatcher can re-claim it
-                        // without re-acquiring. Matches Solid Queue's
-                        // `dispatch_bypassing_concurrency_limits`.
-                        query_builder::ready_executions::insert(
+            let result = db
+                .transaction::<_, (), DbErr>(|txn| {
+                    let ctx = ctx.clone();
+                    Box::pin(async move {
+                        if let Some(job) =
+                            query_builder::jobs::find_by_id(txn, &table_config, job_id).await?
+                        {
+                            // Bypass class-level concurrency limits: the job
+                            // already holds the class-level semaphore slot from
+                            // when it was dispatched. Put it back to ready
+                            // directly so the dispatcher can re-claim it
+                            // without re-acquiring. Matches Solid Queue's
+                            // `dispatch_bypassing_concurrency_limits`.
+                            query_builder::ready_executions::insert(
+                                txn,
+                                &table_config,
+                                job.id,
+                                &job.queue_name,
+                                job.priority,
+                            )
+                            .await?;
+                            // EXPERIMENTAL queue-level slot was acquired at
+                            // claim time and must be released here — the next
+                            // worker that re-claims this job will re-acquire.
+                            Worker::release_queue_slot(&ctx, txn, &table_config, &job.queue_name)
+                                .await?;
+                        } else {
+                            warn!(
+                                "Job {} not found, dropping claimed execution {}",
+                                job_id, execution_id
+                            );
+                        }
+
+                        query_builder::claimed_executions::delete_by_id(
                             txn,
                             &table_config,
-                            job.id,
-                            &job.queue_name,
-                            job.priority,
+                            execution_id,
                         )
                         .await?;
-                        // EXPERIMENTAL queue-level slot was acquired at
-                        // claim time and must be released here — the next
-                        // worker that re-claims this job will re-acquire.
-                        Worker::release_queue_slot(&ctx, txn, &table_config, &job.queue_name)
-                            .await?;
-                    } else {
-                        warn!(
-                            "Job {} not found, dropping claimed execution {}",
-                            job_id, execution_id
-                        );
-                    }
 
-                    query_builder::claimed_executions::delete_by_id(
-                        txn,
-                        &table_config,
-                        execution_id,
-                    )
-                    .await?;
-
-                    Ok(())
+                        Ok(())
+                    })
                 })
-            })
-            .await?;
+                .await;
 
-            debug!("Released job {} back to ready state", job_id);
+            // Per-row best-effort: a failure here must not abort the release of
+            // the remaining rows. A row left claimed is recovered later by the
+            // orphan sweep / restarting worker's `fail_orphaned_executions`,
+            // whereas aborting would orphan every still-claimed row once
+            // `on_stop` deletes this process's row.
+            match result {
+                Ok(()) => {
+                    released += 1;
+                    debug!("Released job {} back to ready state", job_id);
+                }
+                Err(e) => {
+                    warn!(
+                        "Failed to release claimed execution {} (job {}) on shutdown: {:?}; leaving it claimed for recovery",
+                        execution_id, job_id, e
+                    );
+                }
+            }
         }
 
-        Ok(count)
+        Ok(released)
     }
 
     /// Release a batch of claimed executions back to ready state (best-effort).

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -2297,6 +2297,13 @@ impl Worker {
             })
             .await?;
 
+        // Record each claimed row as Dispatched. It stays Dispatched until
+        // `pick_job` hands it to the Python side and flips it to InFlight.
+        for row in &jobs {
+            self.ctx
+                .ledger_set(row.id, crate::context::ClaimState::Dispatched);
+        }
+
         trace!("elpased: {:?}", timer.elapsed());
         Ok(jobs)
     }
@@ -3181,8 +3188,17 @@ impl Worker {
                     let drain_deadline = tokio::time::Instant::now()
                         + self.ctx.shutdown_timeout.mul_f64(0.8);
                     loop {
-                        let in_flight_empty = self.ctx.ledger_is_empty();
-                        if in_flight_empty {
+                        // pick_job stops once shutdown begins, so Dispatched
+                        // rows never advance to InFlight. Drain only waits for
+                        // rows already inside perform() (InFlight); the
+                        // un-started Dispatched rows are requeued by
+                        // release_all_claimed_executions immediately below.
+                        let no_in_flight = self
+                            .ctx
+                            .ledger_snapshot()
+                            .values()
+                            .all(|s| *s != crate::context::ClaimState::InFlight);
+                        if no_in_flight {
                             break;
                         }
                         if tokio::time::Instant::now() >= drain_deadline {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -2920,6 +2920,9 @@ impl Worker {
         let Ok(db) = ctx.get_db().await.inspect_err(|e| {
             warn!("Failed to get DB for delete_claimed_by_id: {:?}", e);
         }) else {
+            // Terminal row: hand off the residual claim to the DB orphan-sweep
+            // and stop tracking it locally so it can't block drain forever.
+            ctx.ledger_remove(execution_id);
             return;
         };
         let table_config = ctx.table_config.clone();
@@ -2940,6 +2943,10 @@ impl Worker {
                     "Failed to delete orphaned claimed execution {}: {:?}",
                     execution_id, e
                 );
+                // Delete failed: leave the residual claimed row for the DB
+                // orphan-sweep, but drop the ledger entry so it stops blocking
+                // drain. This row is terminal and must never be requeued.
+                ctx.ledger_remove(execution_id);
             }
         }
     }
@@ -2954,6 +2961,9 @@ impl Worker {
         let Ok(db) = ctx.get_db().await.inspect_err(|e| {
             warn!("Failed to get DB for fail_claimed_by_id: {:?}", e);
         }) else {
+            // Terminal row: hand off the residual claim to the DB orphan-sweep
+            // and stop tracking it locally so it can't block drain forever.
+            ctx.ledger_remove(execution_id);
             return;
         };
         let table_config = ctx.table_config.clone();
@@ -2988,6 +2998,11 @@ impl Worker {
                     "Failed to clean up claimed execution {}: {:?}",
                     execution_id, e
                 );
+                // Transaction failed: leave the residual claimed row for the DB
+                // orphan-sweep, but drop the ledger entry so it stops blocking
+                // drain. This row is terminal (unregistered runnable) and must
+                // never be requeued.
+                ctx.ledger_remove(execution_id);
             }
         }
     }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -2628,8 +2628,19 @@ impl Worker {
             count, threshold
         );
 
+        // Per-row AND per-process best-effort. We deliberately trade the old
+        // single-transaction atomicity (fail-all-rows + prune as one unit) for
+        // best-effort cleanup backed by the orphan-sweep: each row's
+        // `fail_claimed_execution` runs in its OWN small transaction so a single
+        // row's failure (e.g. an experimental queue-slot release error) rolls
+        // back only that row, not its siblings or the process prune. The process
+        // row is pruned regardless of whether some rows failed — once the row is
+        // gone, `fail_orphaned_executions` (which matches claimed rows whose
+        // process row no longer exists) becomes the safety net that reclaims the
+        // leftovers. A failure pruning one process is logged and skipped so it
+        // does not block pruning the remaining stale processes.
+        let mut pruned = 0usize;
         for process in stale_processes {
-            let table_config = table_config.clone();
             let process_id = process.id;
             let process_pid = process.pid;
             let process_hostname = process.hostname.clone();
@@ -2642,44 +2653,79 @@ impl Worker {
             })
             .to_string();
 
-            let ctx = self.ctx.clone();
-            let tc = table_config.clone();
-            let deleted_count = db
-                .transaction::<_, u64, DbErr>(|txn| {
-                    let tc = tc.clone();
-                    let error_msg = error_msg.clone();
-                    Box::pin(async move {
-                        let claimed = query_builder::claimed_executions::find_by_process_id(
-                            txn, &tc, process_id,
-                        )
-                        .await?;
-                        let deleted_count = claimed.len() as u64;
+            let claimed = match query_builder::claimed_executions::find_by_process_id(
+                db.as_ref(),
+                &table_config,
+                process_id,
+            )
+            .await
+            {
+                Ok(claimed) => claimed,
+                Err(e) => {
+                    warn!(
+                        "Failed to list claimed jobs for stale process {} (pid={}, host={:?}): {:?}; skipping this process for now",
+                        process_id, process_pid, process_hostname, e
+                    );
+                    continue;
+                }
+            };
 
-                        for execution in &claimed {
+            let mut failed = 0u64;
+            for execution in &claimed {
+                let ctx = self.ctx.clone();
+                let tc = table_config.clone();
+                let error_msg = error_msg.clone();
+                let job_id = execution.job_id;
+                let execution_id = execution.id;
+                let result = db
+                    .transaction::<_, (), DbErr>(|txn| {
+                        Box::pin(async move {
                             Self::fail_claimed_execution(
                                 &ctx,
                                 txn,
                                 &tc,
-                                execution.job_id,
-                                execution.id,
+                                job_id,
+                                execution_id,
                                 &error_msg,
                             )
-                            .await?;
-                        }
-
-                        query_builder::processes::prune(txn, &tc, process_id).await?;
-                        Ok(deleted_count)
+                            .await
+                        })
                     })
-                })
-                .await?;
+                    .await;
 
+                match result {
+                    Ok(()) => failed += 1,
+                    Err(e) => warn!(
+                        "Failed to fail claimed execution {} (job {}) for stale process {}: {:?}; leaving it for the orphan-sweep",
+                        execution_id, job_id, process_id, e
+                    ),
+                }
+            }
+
+            // Prune the process row even if some rows failed: this hands the
+            // leftovers to the orphan-sweep.
+            if let Err(e) =
+                query_builder::processes::prune(db.as_ref(), &table_config, process_id).await
+            {
+                warn!(
+                    "Failed to prune stale process {} (pid={}, host={:?}): {:?}; will retry next tick",
+                    process_id, process_pid, process_hostname, e
+                );
+                continue;
+            }
+
+            pruned += 1;
             warn!(
-                "Pruned stale process {} (pid={}, host={:?}), failed {} claimed job(s)",
-                process_id, process_pid, process_hostname, deleted_count
+                "Pruned stale process {} (pid={}, host={:?}), failed {} of {} claimed job(s)",
+                process_id,
+                process_pid,
+                process_hostname,
+                failed,
+                claimed.len()
             );
         }
 
-        Ok(count)
+        Ok(pruned)
     }
 
     /// Clear finished jobs older than the configured threshold.

--- a/tests/test_claim_ledger.py
+++ b/tests/test_claim_ledger.py
@@ -323,15 +323,18 @@ def test_dispatch_reconcile_requeues_residual(qc_with_sqlalchemy, db_assert):
     assert qc._ledger_state(claimed_id) is None
 
 
-def test_missing_ledger_entry_is_released_on_shutdown(qc_with_sqlalchemy, db_assert):
-    """A claimed row with NO ledger entry is treated as releasable Dispatched.
+def test_missing_ledger_entry_is_skipped_on_shutdown(qc_with_sqlalchemy, db_assert):
+    """A claimed row with NO ledger entry is NOT requeued by graceful release.
 
-    The ledger is worker-local and lost on a hard crash. The REAL crash path
-    reclaims orphaned DB claimed rows via ``fail_orphaned_executions`` (purely
-    DB-based, ledger-independent), not this graceful release. This test only
-    pins that the graceful release does not silently SKIP a claimed row just
-    because it has no ledger entry: a missing entry must be treated as a
-    releasable Dispatched claim, never as InFlight/CleanupPending.
+    Release is ledger-authoritative: it requeues ONLY rows the ledger still
+    records as ``Dispatched``. ``claim_jobs`` records every claim as
+    ``Dispatched``, so a claimed row with no ledger entry is error /
+    ``Execution::Drop`` residue, never a live Dispatched claim. Requeuing it is
+    the duplicate-run hazard where an executed-but-cleanup-failed claim lost its
+    ledger entry. So graceful release SKIPS it and leaves it claimed for the DB
+    orphan-sweep, which reclaims it once ``on_stop`` deletes the process row.
+    (The real crash path is handled entirely by ``fail_orphaned_executions``,
+    not this graceful release.)
     """
     ctx = qc_with_sqlalchemy
     qc = ctx["qc"]
@@ -341,7 +344,7 @@ def test_missing_ledger_entry_is_released_on_shutdown(qc_with_sqlalchemy, db_ass
     process_id = qc.register_worker_process()
 
     # Seed the claim directly (no drain_batch), so the worker-local ledger has
-    # no entry for it — the crash-fallback shape.
+    # no entry for it — the error/Drop-residue shape.
     claimed_id = _seed_claimed(session, prefix, process_id)
     assert qc._ledger_state(claimed_id) is None
     assert db_assert.count_claimed_executions() == 1
@@ -349,10 +352,12 @@ def test_missing_ledger_entry_is_released_on_shutdown(qc_with_sqlalchemy, db_ass
 
     released = qc.release_claimed_for_shutdown(process_id)
 
-    assert released == 1
+    # Not requeued: the row stays claimed (left for the orphan-sweep), nothing
+    # goes back to ready.
+    assert released == 0
     session.expire_all()
-    assert db_assert.count_claimed_executions() == 0
-    assert db_assert.count_ready_executions() == 1
+    assert db_assert.count_claimed_executions() == 1
+    assert db_assert.count_ready_executions() == 0
 
 
 def test_dispatched_release_clears_ledger_on_shutdown(qc_with_sqlalchemy, db_assert):

--- a/tests/test_claim_ledger.py
+++ b/tests/test_claim_ledger.py
@@ -32,6 +32,37 @@ def _claimed_id(session, prefix: str, job_id: int) -> int:
     ).scalar()
 
 
+def _seed_claimed(session, prefix: str, process_id: int) -> int:
+    """Seed a job + claimed_executions row directly (no ledger entry).
+
+    Mirrors the seeding in test_supervisor.py / test_supervisor_pruned_race.py:
+    bypassing ``drain_batch`` means the worker-local ledger never learns about
+    this claim, reproducing the crash-fallback case where the in-process ledger
+    was lost. Returns the new claimed_executions.id.
+    """
+    now_sql = "CURRENT_TIMESTAMP"
+    session.execute(
+        text(
+            f"INSERT INTO {prefix}_jobs "
+            f"(queue_name, class_name, arguments, priority, active_job_id, "
+            f"scheduled_at, finished_at, concurrency_key, created_at, updated_at) "
+            f"VALUES ('default', 'CrashJob', '[]', 0, 'ajid', NULL, NULL, NULL, "
+            f"{now_sql}, {now_sql})"
+        )
+    )
+    job_id = session.execute(text("SELECT last_insert_rowid()")).scalar()
+    session.execute(
+        text(
+            f"INSERT INTO {prefix}_claimed_executions "
+            f"(job_id, process_id, created_at) "
+            f"VALUES (:job_id, :process_id, {now_sql})"
+        ),
+        {"job_id": job_id, "process_id": process_id},
+    )
+    session.commit()
+    return _claimed_id(session, prefix, job_id)
+
+
 class _IdleJob(quebec.ActiveJob):
     def perform(self, *args, **kwargs):
         return True
@@ -203,6 +234,38 @@ def test_dispatch_reconcile_requeues_residual(qc_with_sqlalchemy, db_assert):
     assert db_assert.count_claimed_executions() == 0
     assert db_assert.count_ready_executions() == 1
     assert qc._ledger_state(claimed_id) is None
+
+
+def test_missing_ledger_entry_is_released_on_shutdown(qc_with_sqlalchemy, db_assert):
+    """A claimed row with NO ledger entry is treated as releasable Dispatched.
+
+    The ledger is worker-local and lost on a hard crash. The REAL crash path
+    reclaims orphaned DB claimed rows via ``fail_orphaned_executions`` (purely
+    DB-based, ledger-independent), not this graceful release. This test only
+    pins that the graceful release does not silently SKIP a claimed row just
+    because it has no ledger entry: a missing entry must be treated as a
+    releasable Dispatched claim, never as InFlight/CleanupPending.
+    """
+    ctx = qc_with_sqlalchemy
+    qc = ctx["qc"]
+    session = ctx["session"]
+    prefix = ctx["prefix"]
+
+    process_id = qc.register_worker_process()
+
+    # Seed the claim directly (no drain_batch), so the worker-local ledger has
+    # no entry for it — the crash-fallback shape.
+    claimed_id = _seed_claimed(session, prefix, process_id)
+    assert qc._ledger_state(claimed_id) is None
+    assert db_assert.count_claimed_executions() == 1
+    assert db_assert.count_ready_executions() == 0
+
+    released = qc.release_claimed_for_shutdown(process_id)
+
+    assert released == 1
+    session.expire_all()
+    assert db_assert.count_claimed_executions() == 0
+    assert db_assert.count_ready_executions() == 1
 
 
 def test_should_drain_exit_tracks_ledger_emptiness(db_url, test_prefix):

--- a/tests/test_claim_ledger.py
+++ b/tests/test_claim_ledger.py
@@ -1,0 +1,178 @@
+# coding: utf-8
+"""Regression tests for the claim ledger that tracks a worker's owned claims.
+
+The ledger maps ``claimed_executions.id`` to a lifecycle state:
+
+* ``Dispatched`` (0) — claimed and queued, not yet performing.
+* ``InFlight`` (1)   — inside ``perform()``.
+* ``CleanupPending`` (2) — performed, but ``after_executed`` cleanup failed.
+
+The batch-claim path (exercised here via ``drain_batch``) records each claim as
+``Dispatched``; the single-claim ``drain_one`` test helper bypasses the ledger,
+so these tests claim via ``drain_batch(1)`` to drive the real transition.
+
+The shutdown release path (``release_claimed_for_shutdown``) only requeues
+``Dispatched`` claims; ``InFlight`` and ``CleanupPending`` are skipped because
+the job either is still running (kill-after-exit would duplicate it) or has
+already executed. ``should_drain_exit`` self-exits only when the ledger is
+empty. These tests pin those transitions deterministically.
+"""
+
+from __future__ import annotations
+
+import quebec
+from sqlalchemy import text
+
+
+def _claimed_id(session, prefix: str, job_id: int) -> int:
+    """Return the claimed_executions.id for a given job_id."""
+    return session.execute(
+        text(f"SELECT id FROM {prefix}_claimed_executions WHERE job_id = :jid"),
+        {"jid": job_id},
+    ).scalar()
+
+
+class _IdleJob(quebec.ActiveJob):
+    def perform(self, *args, **kwargs):
+        return True
+
+
+def test_claim_sets_dispatched(qc_with_sqlalchemy, db_assert):
+    """Claiming a job records it as Dispatched in the ledger."""
+    ctx = qc_with_sqlalchemy
+    qc = ctx["qc"]
+    session = ctx["session"]
+    prefix = ctx["prefix"]
+
+    qc.register_job(_IdleJob)
+    qc.register_worker_process()
+
+    enqueued = _IdleJob.perform_later(qc)
+    # Hold the Execution: dropping it would clear its (non-CleanupPending)
+    # ledger entry via Execution::Drop before we can observe it.
+    (execution,) = qc.drain_batch(1)
+
+    session.expire_all()
+    assert db_assert.count_claimed_executions() == 1
+    claimed_id = _claimed_id(session, prefix, enqueued.id)
+
+    assert qc._ledger_state(claimed_id) == 0
+    del execution
+
+
+def test_perform_removes_from_ledger(qc_with_sqlalchemy, db_assert):
+    """A successful perform() removes the claim from the ledger."""
+    ctx = qc_with_sqlalchemy
+    qc = ctx["qc"]
+    session = ctx["session"]
+    prefix = ctx["prefix"]
+
+    qc.register_job(_IdleJob)
+    qc.register_worker_process()
+
+    enqueued = _IdleJob.perform_later(qc)
+    (execution,) = qc.drain_batch(1)
+
+    session.expire_all()
+    claimed_id = _claimed_id(session, prefix, enqueued.id)
+    assert qc._ledger_state(claimed_id) == 0
+
+    execution.perform()
+
+    assert qc._ledger_state(claimed_id) is None
+
+
+def test_cleanup_pending_not_released_on_shutdown(qc_with_sqlalchemy, db_assert):
+    """CleanupPending claims are skipped by the shutdown release."""
+    ctx = qc_with_sqlalchemy
+    qc = ctx["qc"]
+    session = ctx["session"]
+    prefix = ctx["prefix"]
+
+    qc.register_job(_IdleJob)
+    process_id = qc.register_worker_process()
+
+    enqueued = _IdleJob.perform_later(qc)
+    qc.drain_batch(1)
+
+    session.expire_all()
+    claimed_id = _claimed_id(session, prefix, enqueued.id)
+
+    # Job already executed but cleanup failed: must NOT be requeued.
+    qc._set_ledger_state(claimed_id, 2)
+
+    released = qc.release_claimed_for_shutdown(process_id)
+
+    assert released == 0
+    session.expire_all()
+    assert db_assert.count_claimed_executions() == 1
+    assert db_assert.count_ready_executions() == 0
+
+
+def test_dispatched_released_on_shutdown(qc_with_sqlalchemy, db_assert):
+    """A Dispatched (never-picked) claim IS released back to ready."""
+    ctx = qc_with_sqlalchemy
+    qc = ctx["qc"]
+    session = ctx["session"]
+    prefix = ctx["prefix"]
+
+    qc.register_job(_IdleJob)
+    process_id = qc.register_worker_process()
+
+    enqueued = _IdleJob.perform_later(qc)
+    qc.drain_batch(1)
+
+    session.expire_all()
+    claimed_id = _claimed_id(session, prefix, enqueued.id)
+
+    # Simulate a claim that was dispatched but never picked up by perform().
+    qc._set_ledger_state(claimed_id, 0)
+
+    released = qc.release_claimed_for_shutdown(process_id)
+
+    assert released == 1
+    session.expire_all()
+    assert db_assert.count_claimed_executions() == 0
+    assert db_assert.count_ready_executions() == 1
+
+
+def test_in_flight_not_released_on_shutdown(qc_with_sqlalchemy, db_assert):
+    """An InFlight claim is skipped by the shutdown release."""
+    ctx = qc_with_sqlalchemy
+    qc = ctx["qc"]
+    session = ctx["session"]
+    prefix = ctx["prefix"]
+
+    qc.register_job(_IdleJob)
+    process_id = qc.register_worker_process()
+
+    enqueued = _IdleJob.perform_later(qc)
+    qc.drain_batch(1)
+
+    session.expire_all()
+    claimed_id = _claimed_id(session, prefix, enqueued.id)
+
+    qc._set_ledger_state(claimed_id, 1)
+
+    released = qc.release_claimed_for_shutdown(process_id)
+
+    assert released == 0
+    session.expire_all()
+    assert db_assert.count_claimed_executions() == 1
+    assert db_assert.count_ready_executions() == 0
+
+
+def test_should_drain_exit_tracks_ledger_emptiness(db_url, test_prefix):
+    """should_drain_exit is gated on the ledger being empty."""
+    qc = quebec.Quebec(db_url, table_name_prefix=test_prefix, quiet_then_exit=True)
+    assert qc.create_tables() is True
+    try:
+        qc.register_worker_process()
+        qc.quiet()
+        # Empty ledger → exit requested.
+        assert qc.should_drain_exit() is True
+        # Any Dispatched entry makes the ledger non-empty → must not exit.
+        qc._set_ledger_state(999, 0)
+        assert qc.should_drain_exit() is False
+    finally:
+        qc.close()

--- a/tests/test_claim_ledger.py
+++ b/tests/test_claim_ledger.py
@@ -268,6 +268,96 @@ def test_missing_ledger_entry_is_released_on_shutdown(qc_with_sqlalchemy, db_ass
     assert db_assert.count_ready_executions() == 1
 
 
+def test_dispatched_release_clears_ledger_on_shutdown(qc_with_sqlalchemy, db_assert):
+    """A successful shutdown release of a Dispatched claim clears its ledger entry.
+
+    ``test_dispatched_released_on_shutdown`` pins the DB outcome (row requeued);
+    this pins the ledger outcome so ``release_all_claimed_executions``' success
+    arm does not leak the entry (close()/test-hook paths keep running, so a
+    lingering entry would block ``should_drain_exit`` forever).
+    """
+    ctx = qc_with_sqlalchemy
+    qc = ctx["qc"]
+    session = ctx["session"]
+    prefix = ctx["prefix"]
+
+    qc.register_job(_IdleJob)
+    process_id = qc.register_worker_process()
+
+    enqueued = _IdleJob.perform_later(qc)
+    qc.drain_batch(1)
+
+    session.expire_all()
+    claimed_id = _claimed_id(session, prefix, enqueued.id)
+    qc._set_ledger_state(claimed_id, 0)
+    assert qc._ledger_state(claimed_id) == 0
+
+    released = qc.release_claimed_for_shutdown(process_id)
+
+    assert released == 1
+    assert qc._ledger_state(claimed_id) is None
+
+
+def test_delete_claimed_by_id_clears_ledger(qc_with_sqlalchemy, db_assert):
+    """The job-record-missing dispatch path clears the ledger entry.
+
+    ``process_available_jobs`` calls ``delete_claimed_by_id`` when a claimed
+    row's job record is gone (FK would prevent a failed_executions insert). The
+    claimed row is dropped, so its ledger entry must be cleared too, otherwise
+    it leaks and blocks drain exit.
+    """
+    ctx = qc_with_sqlalchemy
+    qc = ctx["qc"]
+    session = ctx["session"]
+    prefix = ctx["prefix"]
+
+    process_id = qc.register_worker_process()
+    claimed_id = _seed_claimed(session, prefix, process_id)
+
+    # Stand in for the Dispatched ledger entry claim_jobs would have set.
+    qc._set_ledger_state(claimed_id, 0)
+    assert qc._ledger_state(claimed_id) == 0
+    assert db_assert.count_claimed_executions() == 1
+
+    qc._delete_claimed_by_id(claimed_id)
+
+    session.expire_all()
+    assert db_assert.count_claimed_executions() == 0
+    assert qc._ledger_state(claimed_id) is None
+
+
+def test_fail_claimed_by_id_clears_ledger(qc_with_sqlalchemy, db_assert):
+    """The unregistered-runnable dispatch path clears the ledger entry.
+
+    ``process_available_jobs`` calls ``fail_claimed_by_id`` when the job's
+    runnable is not registered: it writes a failed_executions row, deletes the
+    claimed row, and releases the semaphore in one transaction. The ledger
+    entry must be cleared so the now-gone claim stops blocking drain exit.
+    """
+    ctx = qc_with_sqlalchemy
+    qc = ctx["qc"]
+    session = ctx["session"]
+    prefix = ctx["prefix"]
+
+    process_id = qc.register_worker_process()
+    claimed_id = _seed_claimed(session, prefix, process_id)
+    job_id = session.execute(
+        text(f"SELECT job_id FROM {prefix}_claimed_executions WHERE id = :cid"),
+        {"cid": claimed_id},
+    ).scalar()
+
+    qc._set_ledger_state(claimed_id, 0)
+    assert qc._ledger_state(claimed_id) == 0
+    assert db_assert.count_claimed_executions() == 1
+
+    qc._fail_claimed_by_id(claimed_id, job_id, "Job handler not found: CrashJob")
+
+    session.expire_all()
+    assert db_assert.count_claimed_executions() == 0
+    assert db_assert.count_failed_executions() == 1
+    assert qc._ledger_state(claimed_id) is None
+
+
 def test_should_drain_exit_tracks_ledger_emptiness(db_url, test_prefix):
     """should_drain_exit is gated on the ledger being empty."""
     qc = quebec.Quebec(db_url, table_name_prefix=test_prefix, quiet_then_exit=True)

--- a/tests/test_claim_ledger.py
+++ b/tests/test_claim_ledger.py
@@ -372,3 +372,31 @@ def test_should_drain_exit_tracks_ledger_emptiness(db_url, test_prefix):
         assert qc.should_drain_exit() is False
     finally:
         qc.close()
+
+
+def test_should_drain_exit_ignores_cleanup_pending(db_url, test_prefix):
+    """A ledger holding ONLY CleanupPending entries is still drainable.
+
+    CleanupPending means the job already executed successfully and only the DB
+    orphan-sweep is left to reclaim the row; the worker has no active work, so
+    quiet_then_exit must be allowed to exit rather than hang forever waiting for
+    cleanup that may never succeed. A Dispatched or InFlight entry, by contrast,
+    is real pending/active work and must block the exit.
+    """
+    qc = quebec.Quebec(db_url, table_name_prefix=test_prefix, quiet_then_exit=True)
+    assert qc.create_tables() is True
+    try:
+        qc.register_worker_process()
+        qc.quiet()
+        # Only CleanupPending in the ledger → no active work → drainable.
+        qc._set_ledger_state(901, 2)
+        assert qc._ledger_state(901) == 2
+        assert qc.should_drain_exit() is True
+        # Add a Dispatched entry → active work → must not exit.
+        qc._set_ledger_state(902, 0)
+        assert qc.should_drain_exit() is False
+        # Flip it to InFlight → still active work → must not exit.
+        qc._set_ledger_state(902, 1)
+        assert qc.should_drain_exit() is False
+    finally:
+        qc.close()

--- a/tests/test_claim_ledger.py
+++ b/tests/test_claim_ledger.py
@@ -21,7 +21,8 @@ empty. These tests pin those transitions deterministically.
 from __future__ import annotations
 
 import quebec
-from sqlalchemy import text
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
 
 
 def _claimed_id(session, prefix: str, job_id: int) -> int:
@@ -61,6 +62,39 @@ def _seed_claimed(session, prefix: str, process_id: int) -> int:
     )
     session.commit()
     return _claimed_id(session, prefix, job_id)
+
+
+def _seed_orphan(session, prefix: str, *, queue_name: str = "default") -> int:
+    """Seed a job + a process-less (orphaned) claimed_executions row.
+
+    ``process_id`` is NULL, so the DB orphan-sweep (``find_orphaned``) reclaims
+    it as a crashed-worker leftover. The job's ``queue_name`` drives whether the
+    sweep's per-row ``unblock_next_job`` calls the EXPERIMENTAL
+    ``release_queue_slot`` (only for queues in ``experimental_queue_concurrency``).
+    Returns the new job_id.
+    """
+    now_sql = "CURRENT_TIMESTAMP"
+    session.execute(
+        text(
+            f"INSERT INTO {prefix}_jobs "
+            f"(queue_name, class_name, arguments, priority, active_job_id, "
+            f"scheduled_at, finished_at, concurrency_key, created_at, updated_at) "
+            f"VALUES (:queue, 'CrashJob', '[]', 0, 'ajid', NULL, NULL, NULL, "
+            f"{now_sql}, {now_sql})"
+        ),
+        {"queue": queue_name},
+    )
+    job_id = session.execute(text("SELECT last_insert_rowid()")).scalar()
+    session.execute(
+        text(
+            f"INSERT INTO {prefix}_claimed_executions "
+            f"(job_id, process_id, created_at) "
+            f"VALUES (:job_id, NULL, {now_sql})"
+        ),
+        {"job_id": job_id},
+    )
+    session.commit()
+    return job_id
 
 
 class _IdleJob(quebec.ActiveJob):
@@ -571,4 +605,104 @@ def test_should_drain_exit_ignores_cleanup_pending(db_url, test_prefix):
         qc._set_ledger_state(902, 1)
         assert qc.should_drain_exit() is False
     finally:
+        qc.close()
+
+
+def test_orphan_sweep_reclaims_remaining_rows_when_one_row_fails(db_url, test_prefix):
+    """The DB orphan-sweep is per-row best-effort (F4 regression).
+
+    The crash-path safety net (``fail_orphaned_executions`` in the worker, and
+    the equivalent loop in ``Supervisor::run_maintenance``) must keep reclaiming
+    the remaining orphaned ``claimed_executions`` rows even when one row's
+    cleanup raises. A sibling fix made the EXPERIMENTAL ``release_queue_slot``
+    propagate semaphore-release errors with ``?``; the orphan loop used ``?`` on
+    the per-row ``fail_claimed_execution`` call, so a single failing row aborted
+    the whole sweep and left every OTHER orphan un-reclaimed — weakening the
+    last line of defense. After the fix the failing row is logged and skipped
+    while the others are still reclaimed.
+
+    Deterministic single-row failure of exactly the guarded class (a queue-slot
+    release error inside the per-row transaction): with
+    ``experimental_queue_concurrency={"locked": 1}`` set, an orphan on the
+    "locked" queue makes the sweep's ``unblock_next_job`` call
+    ``release_queue_slot`` → ``release_semaphore``; dropping the ``semaphores``
+    table out from under the Rust query makes that UPDATE error and rolls back
+    that row. An orphan on the unthrottled "free" queue skips
+    ``release_queue_slot`` entirely and is reclaimed cleanly. This mirrors the
+    table-drop injection idiom used by the emergency-cleanup/on-db-error tests
+    above; no production injection flag is added.
+    """
+    qc = quebec.Quebec(
+        db_url,
+        table_name_prefix=test_prefix,
+        experimental_queue_concurrency={"locked": 1},
+    )
+    assert qc.create_tables() is True
+
+    sa_url = db_url.split("?")[0] if db_url.startswith("sqlite:") else db_url
+    engine = create_engine(sa_url)
+    session = sessionmaker(bind=engine)()
+    try:
+        bad_job = _seed_orphan(session, test_prefix, queue_name="locked")
+        good_job = _seed_orphan(session, test_prefix, queue_name="free")
+        assert (
+            session.execute(
+                text(f"SELECT COUNT(*) FROM {test_prefix}_claimed_executions")
+            ).scalar()
+            == 2
+        )
+
+        # Drop the semaphores table so the "locked"-queue orphan's
+        # release_queue_slot errors, rolling back its per-row transaction; the
+        # "free"-queue orphan never touches the experimental queue slot.
+        session.execute(text(f"DROP TABLE {test_prefix}_semaphores"))
+        session.commit()
+
+        # Global orphan-sweep. The bad row aborts its own transaction; the sweep
+        # must NOT propagate — it returns Ok and reports only the
+        # successfully-reclaimed count.
+        pruned, orphaned = qc.supervisor_run_maintenance(None)
+        assert orphaned == 1, (
+            "the sweep must reclaim the free-queue orphan even though the "
+            "locked-queue orphan's cleanup failed; per-row best-effort, not "
+            "abort-on-first-error"
+        )
+
+        session.expire_all()
+        # Good orphan: claimed row gone, failure recorded so it can be retried.
+        assert (
+            session.execute(
+                text(
+                    f"SELECT COUNT(*) FROM {test_prefix}_claimed_executions "
+                    f"WHERE job_id = :j"
+                ),
+                {"j": good_job},
+            ).scalar()
+            == 0
+        )
+        assert (
+            session.execute(
+                text(
+                    f"SELECT COUNT(*) FROM {test_prefix}_failed_executions "
+                    f"WHERE job_id = :j"
+                ),
+                {"j": good_job},
+            ).scalar()
+            == 1
+        )
+        # Bad orphan: its transaction rolled back, so the claimed row is still
+        # there, left for the next sweep tick / another process to retry.
+        assert (
+            session.execute(
+                text(
+                    f"SELECT COUNT(*) FROM {test_prefix}_claimed_executions "
+                    f"WHERE job_id = :j"
+                ),
+                {"j": bad_job},
+            ).scalar()
+            == 1
+        )
+    finally:
+        session.close()
+        engine.dispose()
         qc.close()

--- a/tests/test_claim_ledger.py
+++ b/tests/test_claim_ledger.py
@@ -564,27 +564,33 @@ def test_emergency_cleanup_verify_error_removes_ledger(qc_with_sqlalchemy, db_as
     del execution
 
 
-def test_in_flight_guard_clears_entry_on_panic(db_url, test_prefix):
-    """InFlightGuard's Drop clears the InFlight entry when invoke unwinds (F3).
+def test_in_flight_guard_marks_cleanup_pending_on_panic(db_url, test_prefix):
+    """InFlightGuard's Drop marks the InFlight entry CleanupPending on unwind (F3).
 
     A Rust panic between ``InFlightGuard::new`` and the completion of
-    ``after_executed`` skips the normal ledger clearing. ``Execution::Drop`` only
-    covers this if the ``Execution`` is dropped during unwinding, but the Python
-    runner may keep it alive, so the InFlight entry would leak forever and
+    ``after_executed`` skips the normal ledger transition. ``Execution::Drop``
+    only covers this if the ``Execution`` is dropped during unwinding, but the
+    Python runner may keep it alive, so the InFlight entry would leak forever and
     ``ledger_has_active`` would block the quiet_then_exit drain. ``InFlightGuard``
-    is a stack local of ``invoke``, so its panic-only ``Drop`` reliably removes
-    the InFlight entry on a panic unwind, handing the residual claimed row off to
-    the DB orphan-sweep. The hook builds a real guard against the live ledger and
-    drops it inside a genuine ``catch_unwind`` panic.
+    is a stack local of ``invoke``, so its panic-only ``Drop`` reliably handles
+    the entry on a panic unwind. It must NOT remove it: the job was inside
+    ``perform()`` and may have committed side effects, and a removed entry leaves
+    no ledger record — so if this process survives the panic and later gets a
+    graceful shutdown, ``release_all_claimed_executions`` would treat the claimed
+    row as releasable and requeue it (duplicate run). Instead it marks the entry
+    ``CleanupPending``, which is skipped by the shutdown release, counts as
+    non-active so it does not block drain, and leaves the DB row for the
+    orphan-sweep. The hook builds a real guard against the live ledger and drops
+    it inside a genuine ``catch_unwind`` panic.
     """
     qc = quebec.Quebec(db_url, table_name_prefix=test_prefix, quiet_then_exit=True)
     assert qc.create_tables() is True
     try:
         qc.register_worker_process()
         # Guard inserts id=777 as InFlight, then a real panic unwinds through
-        # its Drop, which must remove the InFlight entry.
+        # its Drop, which must mark the entry CleanupPending (not remove it).
         qc._drop_in_flight_guard(777, True)
-        assert qc._ledger_state(777) is None
+        assert qc._ledger_state(777) == 2
     finally:
         qc.close()
 

--- a/tests/test_claim_ledger.py
+++ b/tests/test_claim_ledger.py
@@ -358,6 +358,72 @@ def test_fail_claimed_by_id_clears_ledger(qc_with_sqlalchemy, db_assert):
     assert qc._ledger_state(claimed_id) is None
 
 
+def test_delete_claimed_by_id_clears_ledger_on_db_error(qc_with_sqlalchemy, db_assert):
+    """The job-record-missing path clears the ledger even when the DB delete fails.
+
+    If ``delete_claimed_by_id`` cannot delete the residual claimed row (DB
+    hiccup), the row is correctly left for the DB orphan-sweep — but the
+    worker-local ledger entry must still be dropped, otherwise it stays
+    Dispatched forever and blocks ``should_drain_exit``. We force the failure
+    deterministically by dropping the claimed_executions table out from under
+    the Rust query.
+    """
+    ctx = qc_with_sqlalchemy
+    qc = ctx["qc"]
+    session = ctx["session"]
+    prefix = ctx["prefix"]
+
+    process_id = qc.register_worker_process()
+    claimed_id = _seed_claimed(session, prefix, process_id)
+
+    qc._set_ledger_state(claimed_id, 0)
+    assert qc._ledger_state(claimed_id) == 0
+
+    # Drop the table so the Rust delete_by_id errors → failure arm runs.
+    session.execute(text(f"DROP TABLE {prefix}_claimed_executions"))
+    session.commit()
+
+    qc._delete_claimed_by_id(claimed_id)
+
+    # The delete could not complete, but the ledger entry is cleared so it no
+    # longer blocks drain; the residual is left for the orphan-sweep.
+    assert qc._ledger_state(claimed_id) is None
+
+
+def test_fail_claimed_by_id_clears_ledger_on_db_error(qc_with_sqlalchemy, db_assert):
+    """The unregistered-runnable path clears the ledger even when the txn fails.
+
+    If ``fail_claimed_by_id``'s transaction cannot complete (DB hiccup), the
+    claimed row is left for the DB orphan-sweep — but the ledger entry must
+    still be dropped so it stops blocking drain. We force the failure by
+    dropping the failed_executions table so the in-transaction insert errors.
+    """
+    ctx = qc_with_sqlalchemy
+    qc = ctx["qc"]
+    session = ctx["session"]
+    prefix = ctx["prefix"]
+
+    process_id = qc.register_worker_process()
+    claimed_id = _seed_claimed(session, prefix, process_id)
+    job_id = session.execute(
+        text(f"SELECT job_id FROM {prefix}_claimed_executions WHERE id = :cid"),
+        {"cid": claimed_id},
+    ).scalar()
+
+    qc._set_ledger_state(claimed_id, 0)
+    assert qc._ledger_state(claimed_id) == 0
+
+    # Drop failed_executions so the transaction's insert errors → failure arm.
+    session.execute(text(f"DROP TABLE {prefix}_failed_executions"))
+    session.commit()
+
+    qc._fail_claimed_by_id(claimed_id, job_id, "Job handler not found: CrashJob")
+
+    # The transaction rolled back, but the ledger entry is cleared so it no
+    # longer blocks drain; the residual is left for the orphan-sweep.
+    assert qc._ledger_state(claimed_id) is None
+
+
 def test_should_drain_exit_tracks_ledger_emptiness(db_url, test_prefix):
     """should_drain_exit is gated on the ledger being empty."""
     qc = quebec.Quebec(db_url, table_name_prefix=test_prefix, quiet_then_exit=True)

--- a/tests/test_claim_ledger.py
+++ b/tests/test_claim_ledger.py
@@ -97,6 +97,59 @@ def _seed_orphan(session, prefix: str, *, queue_name: str = "default") -> int:
     return job_id
 
 
+def _seed_stale_process(session, prefix: str) -> int:
+    """Insert a Worker process row whose heartbeat is far in the past.
+
+    ``find_prunable`` selects rows with ``last_heartbeat_at`` older than
+    ``now - process_alive_threshold`` (default 300s), so a year-2000 heartbeat
+    is reliably stale. Returns the new processes.id.
+    """
+    session.execute(
+        text(
+            f"INSERT INTO {prefix}_processes "
+            f"(kind, last_heartbeat_at, pid, hostname, metadata, created_at, name) "
+            f"VALUES ('Worker', '2000-01-01 00:00:00', 4242, 'stale-host', NULL, "
+            f"'2000-01-01 00:00:00', 'Worker-4242')"
+        )
+    )
+    process_id = session.execute(text("SELECT last_insert_rowid()")).scalar()
+    session.commit()
+    return process_id
+
+
+def _seed_claimed_for_process(
+    session, prefix: str, process_id: int, *, queue_name: str = "default"
+) -> int:
+    """Seed a job + a claimed_executions row owned by ``process_id``.
+
+    The job's ``queue_name`` drives whether the prune path's per-row
+    ``unblock_next_job`` calls the EXPERIMENTAL ``release_queue_slot`` (only for
+    queues in ``experimental_queue_concurrency``). Returns the new job_id.
+    """
+    now_sql = "CURRENT_TIMESTAMP"
+    session.execute(
+        text(
+            f"INSERT INTO {prefix}_jobs "
+            f"(queue_name, class_name, arguments, priority, active_job_id, "
+            f"scheduled_at, finished_at, concurrency_key, created_at, updated_at) "
+            f"VALUES (:queue, 'CrashJob', '[]', 0, 'ajid', NULL, NULL, NULL, "
+            f"{now_sql}, {now_sql})"
+        ),
+        {"queue": queue_name},
+    )
+    job_id = session.execute(text("SELECT last_insert_rowid()")).scalar()
+    session.execute(
+        text(
+            f"INSERT INTO {prefix}_claimed_executions "
+            f"(job_id, process_id, created_at) "
+            f"VALUES (:job_id, :process_id, {now_sql})"
+        ),
+        {"job_id": job_id, "process_id": process_id},
+    )
+    session.commit()
+    return job_id
+
+
 class _IdleJob(quebec.ActiveJob):
     def perform(self, *args, **kwargs):
         return True
@@ -785,6 +838,115 @@ def test_orphan_sweep_reclaims_remaining_rows_when_one_row_fails(db_url, test_pr
         )
         # Bad orphan: its transaction rolled back, so the claimed row is still
         # there, left for the next sweep tick / another process to retry.
+        assert (
+            session.execute(
+                text(
+                    f"SELECT COUNT(*) FROM {test_prefix}_claimed_executions "
+                    f"WHERE job_id = :j"
+                ),
+                {"j": bad_job},
+            ).scalar()
+            == 1
+        )
+    finally:
+        session.close()
+        engine.dispose()
+        qc.close()
+
+
+def test_stale_process_pruning_is_per_row_best_effort(db_url, test_prefix):
+    """Stale-process pruning is per-row AND per-process best-effort (Finding C).
+
+    ``prune_dead_processes`` (worker) and ``fail_claimed_by_process_id_inner``
+    (supervisor, driven here via ``supervisor_run_maintenance``) used to fail a
+    stale process's claimed rows + prune the process row inside a SINGLE
+    transaction with ``?`` on each row. One row's cleanup error (e.g. an
+    experimental queue-slot release error) rolled back the WHOLE transaction:
+    none of the rows were failed AND the process row was NOT pruned. Because the
+    orphan-sweep only reclaims rows whose process row is gone, that un-pruned
+    process wedged crash-recovery for itself and every later stale process.
+
+    The fix runs each row's cleanup in its own small transaction and prunes the
+    process row regardless of partial row failure — handing the leftovers to the
+    orphan-sweep (which now reclaims them once the process row is gone). This
+    test pins both halves: the process is STILL pruned and the good row is
+    failed, while the bad row is left for the orphan-sweep.
+
+    Same deterministic injection idiom as the F4 orphan-sweep test: with
+    ``experimental_queue_concurrency={"locked": 1}`` a row on the "locked" queue
+    makes the per-row ``unblock_next_job`` call ``release_queue_slot`` →
+    ``release_semaphore``; dropping the ``semaphores`` table makes that UPDATE
+    error. The "free"-queue row skips ``release_queue_slot`` and is reclaimed.
+    """
+    qc = quebec.Quebec(
+        db_url,
+        table_name_prefix=test_prefix,
+        experimental_queue_concurrency={"locked": 1},
+    )
+    assert qc.create_tables() is True
+
+    sa_url = db_url.split("?")[0] if db_url.startswith("sqlite:") else db_url
+    engine = create_engine(sa_url)
+    session = sessionmaker(bind=engine)()
+    try:
+        process_id = _seed_stale_process(session, test_prefix)
+        bad_job = _seed_claimed_for_process(
+            session, test_prefix, process_id, queue_name="locked"
+        )
+        good_job = _seed_claimed_for_process(
+            session, test_prefix, process_id, queue_name="free"
+        )
+        assert (
+            session.execute(
+                text(f"SELECT COUNT(*) FROM {test_prefix}_claimed_executions")
+            ).scalar()
+            == 2
+        )
+
+        # Drop the semaphores table so the "locked"-queue row's
+        # release_queue_slot errors, rolling back only that row's transaction.
+        session.execute(text(f"DROP TABLE {test_prefix}_semaphores"))
+        session.commit()
+
+        # Prune stale processes (no excluded id). One bad row must NOT abort the
+        # whole process cleanup: the process is still pruned and the good row is
+        # failed; the call must NOT raise.
+        pruned, orphaned = qc.supervisor_run_maintenance(None)
+        assert pruned == 1, "the stale process must still be pruned despite a bad row"
+
+        session.expire_all()
+        # The stale process row is gone — this is what lets the orphan-sweep
+        # reclaim the leftover bad row on a later tick.
+        assert (
+            session.execute(
+                text(f"SELECT COUNT(*) FROM {test_prefix}_processes WHERE id = :p"),
+                {"p": process_id},
+            ).scalar()
+            == 0
+        )
+        # Good row: failed + claimed row removed.
+        assert (
+            session.execute(
+                text(
+                    f"SELECT COUNT(*) FROM {test_prefix}_claimed_executions "
+                    f"WHERE job_id = :j"
+                ),
+                {"j": good_job},
+            ).scalar()
+            == 0
+        )
+        assert (
+            session.execute(
+                text(
+                    f"SELECT COUNT(*) FROM {test_prefix}_failed_executions "
+                    f"WHERE job_id = :j"
+                ),
+                {"j": good_job},
+            ).scalar()
+            == 1
+        )
+        # Bad row: its transaction rolled back, so the claimed row is still there,
+        # now orphaned (process row gone) and left for the orphan-sweep.
         assert (
             session.execute(
                 text(

--- a/tests/test_claim_ledger.py
+++ b/tests/test_claim_ledger.py
@@ -653,6 +653,48 @@ def test_should_drain_exit_ignores_cleanup_pending(db_url, test_prefix):
         qc.close()
 
 
+def test_should_drain_exit_with_lingering_claimed_row(db_url, test_prefix):
+    """Drain-exit is ledger-authoritative even when a claimed row lingers in DB.
+
+    Regression for the quiet_then_exit hang: a CleanupPending ledger entry is
+    created precisely when the job executed but its claimed-row cleanup failed,
+    so the claimed_executions row is intentionally left in the DB for the
+    orphan-sweep to reclaim. The sweep can only reclaim it once this process row
+    is gone, so a DB-count gate (the old ``count_by_process_id`` query) would see
+    the lingering row, report non-empty, and hang the drain-exit forever. The
+    ledger says no active work, so should_drain_exit must return True.
+    """
+    qc = quebec.Quebec(db_url, table_name_prefix=test_prefix, quiet_then_exit=True)
+    assert qc.create_tables() is True
+
+    sa_url = db_url.split("?")[0] if db_url.startswith("sqlite:") else db_url
+    engine = create_engine(sa_url)
+    session = sessionmaker(bind=engine)()
+    try:
+        process_id = qc.register_worker_process()
+        qc.quiet()
+
+        # Seed a real claimed row owned by THIS worker's process, then mark its
+        # ledger entry CleanupPending — the exact shape of a failed-cleanup job.
+        claimed_id = _seed_claimed(session, test_prefix, process_id)
+        qc._set_ledger_state(claimed_id, 2)
+        assert qc._ledger_state(claimed_id) == 2
+
+        # Confirm the lingering row is really present and owned by this process.
+        count = session.execute(
+            text(f"SELECT COUNT(*) FROM {test_prefix}_claimed_executions"),
+        ).scalar()
+        assert count == 1
+
+        # Old behaviour: count_by_process_id == 1 → False (hang). Now: ledger has
+        # no active work → drainable.
+        assert qc.should_drain_exit() is True
+    finally:
+        qc.close()
+        session.close()
+        engine.dispose()
+
+
 def test_orphan_sweep_reclaims_remaining_rows_when_one_row_fails(db_url, test_prefix):
     """The DB orphan-sweep is per-row best-effort (F4 regression).
 

--- a/tests/test_claim_ledger.py
+++ b/tests/test_claim_ledger.py
@@ -162,6 +162,49 @@ def test_in_flight_not_released_on_shutdown(qc_with_sqlalchemy, db_assert):
     assert db_assert.count_ready_executions() == 0
 
 
+def test_dispatch_reconcile_requeues_residual(qc_with_sqlalchemy, db_assert):
+    """A residual whose dispatch-failure requeue also failed is requeued by the
+    maintenance reconcile, its ledger entry cleared, and a re-run is a no-op."""
+    ctx = qc_with_sqlalchemy
+    qc = ctx["qc"]
+    session = ctx["session"]
+    prefix = ctx["prefix"]
+
+    qc.register_job(_IdleJob)
+    qc.register_worker_process()
+
+    enqueued = _IdleJob.perform_later(qc)
+    # Claim the job so a claimed_executions row exists for this process.
+    qc.drain_batch(1)
+
+    session.expire_all()
+    claimed_id = _claimed_id(session, prefix, enqueued.id)
+    assert db_assert.count_claimed_executions() == 1
+    assert db_assert.count_ready_executions() == 0
+
+    # Simulate a dispatch failure whose requeue also failed: the row is still
+    # claimed + Dispatched in the ledger and stashed in the dispatch-retry set.
+    qc._set_ledger_state(claimed_id, 0)
+    qc._add_dispatch_retry(claimed_id)
+    assert qc._ledger_state(claimed_id) == 0
+
+    # The maintenance reconcile retries the requeue.
+    qc._run_dispatch_reconcile_once()
+
+    session.expire_all()
+    assert db_assert.count_claimed_executions() == 0
+    assert db_assert.count_ready_executions() == 1
+    assert qc._ledger_state(claimed_id) is None
+
+    # A second reconcile is a no-op: the retry set is empty and nothing changes.
+    qc._run_dispatch_reconcile_once()
+
+    session.expire_all()
+    assert db_assert.count_claimed_executions() == 0
+    assert db_assert.count_ready_executions() == 1
+    assert qc._ledger_state(claimed_id) is None
+
+
 def test_should_drain_exit_tracks_ledger_emptiness(db_url, test_prefix):
     """should_drain_exit is gated on the ledger being empty."""
     qc = quebec.Quebec(db_url, table_name_prefix=test_prefix, quiet_then_exit=True)

--- a/tests/test_claim_ledger.py
+++ b/tests/test_claim_ledger.py
@@ -564,6 +564,51 @@ def test_emergency_cleanup_verify_error_removes_ledger(qc_with_sqlalchemy, db_as
     del execution
 
 
+def test_in_flight_guard_clears_entry_on_panic(db_url, test_prefix):
+    """InFlightGuard's Drop clears the InFlight entry when invoke unwinds (F3).
+
+    A Rust panic between ``InFlightGuard::new`` and the completion of
+    ``after_executed`` skips the normal ledger clearing. ``Execution::Drop`` only
+    covers this if the ``Execution`` is dropped during unwinding, but the Python
+    runner may keep it alive, so the InFlight entry would leak forever and
+    ``ledger_has_active`` would block the quiet_then_exit drain. ``InFlightGuard``
+    is a stack local of ``invoke``, so its panic-only ``Drop`` reliably removes
+    the InFlight entry on a panic unwind, handing the residual claimed row off to
+    the DB orphan-sweep. The hook builds a real guard against the live ledger and
+    drops it inside a genuine ``catch_unwind`` panic.
+    """
+    qc = quebec.Quebec(db_url, table_name_prefix=test_prefix, quiet_then_exit=True)
+    assert qc.create_tables() is True
+    try:
+        qc.register_worker_process()
+        # Guard inserts id=777 as InFlight, then a real panic unwinds through
+        # its Drop, which must remove the InFlight entry.
+        qc._drop_in_flight_guard(777, True)
+        assert qc._ledger_state(777) is None
+    finally:
+        qc.close()
+
+
+def test_in_flight_guard_normal_drop_keeps_entry(db_url, test_prefix):
+    """InFlightGuard's Drop is a no-op on a normal (non-panicking) drop.
+
+    On the normal path ``after_executed`` owns the transition (remove on cleanup
+    success, CleanupPending on failure); a removal in ``Drop`` would wipe a
+    CleanupPending mark since the guard drops right after ``after_executed``
+    returns. So a normal drop must leave the InFlight entry exactly as the guard
+    inserted it.
+    """
+    qc = quebec.Quebec(db_url, table_name_prefix=test_prefix, quiet_then_exit=True)
+    assert qc.create_tables() is True
+    try:
+        qc.register_worker_process()
+        # Guard inserts id=778 as InFlight, then drops normally → entry stays.
+        qc._drop_in_flight_guard(778, False)
+        assert qc._ledger_state(778) == 1
+    finally:
+        qc.close()
+
+
 def test_should_drain_exit_tracks_ledger_emptiness(db_url, test_prefix):
     """should_drain_exit is gated on the ledger being empty."""
     qc = quebec.Quebec(db_url, table_name_prefix=test_prefix, quiet_then_exit=True)

--- a/tests/test_claim_ledger.py
+++ b/tests/test_claim_ledger.py
@@ -424,6 +424,112 @@ def test_fail_claimed_by_id_clears_ledger_on_db_error(qc_with_sqlalchemy, db_ass
     assert qc._ledger_state(claimed_id) is None
 
 
+def test_emergency_cleanup_verify_present_marks_cleanup_pending(
+    qc_with_sqlalchemy, db_assert
+):
+    """after_executed's emergency tail marks CleanupPending when the row remains.
+
+    The job already executed; the normal cleanup and fail_claimed both failed,
+    but the fallback delete left the claimed row in place. The verification
+    re-check confirms the row is still present, so the ledger entry must become
+    CleanupPending: the shutdown release must NOT requeue an already-executed
+    job, and the DB orphan-sweep reclaims the lingering row.
+    """
+    ctx = qc_with_sqlalchemy
+    qc = ctx["qc"]
+    session = ctx["session"]
+    prefix = ctx["prefix"]
+
+    qc.register_job(_IdleJob)
+    qc.register_worker_process()
+
+    enqueued = _IdleJob.perform_later(qc)
+    (execution,) = qc.drain_batch(1)
+
+    session.expire_all()
+    claimed_id = _claimed_id(session, prefix, enqueued.id)
+    assert db_assert.count_claimed_executions() == 1
+
+    # Row is still present → Ok(Some) arm → CleanupPending.
+    execution._resolve_emergency_cleanup_ledger()
+
+    assert qc._ledger_state(claimed_id) == 2
+    del execution
+
+
+def test_emergency_cleanup_verify_gone_removes_ledger(qc_with_sqlalchemy, db_assert):
+    """after_executed's emergency tail removes the ledger entry when the row is gone.
+
+    The fallback delete above succeeded: the verification re-check finds no row
+    (Ok(None)), so the ledger entry must be cleared rather than left dangling.
+    """
+    ctx = qc_with_sqlalchemy
+    qc = ctx["qc"]
+    session = ctx["session"]
+    prefix = ctx["prefix"]
+
+    qc.register_job(_IdleJob)
+    qc.register_worker_process()
+
+    enqueued = _IdleJob.perform_later(qc)
+    (execution,) = qc.drain_batch(1)
+
+    session.expire_all()
+    claimed_id = _claimed_id(session, prefix, enqueued.id)
+
+    # Simulate the fallback delete having removed the claimed row.
+    session.execute(
+        text(f"DELETE FROM {prefix}_claimed_executions WHERE id = :cid"),
+        {"cid": claimed_id},
+    )
+    session.commit()
+    assert db_assert.count_claimed_executions() == 0
+
+    # Row confirmed gone → Ok(None) arm → ledger entry removed.
+    execution._resolve_emergency_cleanup_ledger()
+
+    assert qc._ledger_state(claimed_id) is None
+    del execution
+
+
+def test_emergency_cleanup_verify_error_removes_ledger(qc_with_sqlalchemy, db_assert):
+    """after_executed's emergency tail removes the ledger entry when verify ERRORS.
+
+    This is the F2 regression: if the verification find_by_id itself errors, the
+    old code collapsed to CleanupPending and left a permanent zombie ledger entry
+    (the fallback delete may have already removed the row, so nothing could ever
+    reconcile it). The three-way match must instead remove the entry on Err and
+    defer to the DB orphan-sweep. We force the verification query to error by
+    dropping the claimed_executions table out from under the Rust query, exactly
+    mirroring the delete/fail on_db_error tests.
+    """
+    ctx = qc_with_sqlalchemy
+    qc = ctx["qc"]
+    session = ctx["session"]
+    prefix = ctx["prefix"]
+
+    qc.register_job(_IdleJob)
+    qc.register_worker_process()
+
+    enqueued = _IdleJob.perform_later(qc)
+    (execution,) = qc.drain_batch(1)
+
+    session.expire_all()
+    claimed_id = _claimed_id(session, prefix, enqueued.id)
+    assert qc._ledger_state(claimed_id) == 0
+
+    # Drop the table so the Rust find_by_id verification errors → Err arm.
+    session.execute(text(f"DROP TABLE {prefix}_claimed_executions"))
+    session.commit()
+
+    # Verification could not be performed → Err arm → ledger entry removed
+    # (NOT left as a permanent CleanupPending zombie).
+    execution._resolve_emergency_cleanup_ledger()
+
+    assert qc._ledger_state(claimed_id) is None
+    del execution
+
+
 def test_should_drain_exit_tracks_ledger_emptiness(db_url, test_prefix):
     """should_drain_exit is gated on the ledger being empty."""
     qc = quebec.Quebec(db_url, table_name_prefix=test_prefix, quiet_then_exit=True)

--- a/tests/test_quiet_then_exit.py
+++ b/tests/test_quiet_then_exit.py
@@ -36,7 +36,13 @@ def test_should_drain_exit_true_when_drained(db_url, test_prefix):
 
 
 def test_should_drain_exit_false_with_claimed_job(db_url, test_prefix):
-    """A claimed-but-not-yet-run job blocks self-exit until it drains."""
+    """A claimed-but-not-yet-run job (Dispatched in the ledger) blocks self-exit.
+
+    Drain-exit is ledger-authoritative, so the blocking signal is a Dispatched
+    ledger entry, not a DB row. ``drain_batch`` claims via the real batch path
+    that records the entry (``drain_one`` bypasses the ledger and would no longer
+    block — that DB-only residue is the orphan-sweep's job, not a drain blocker).
+    """
     qc = quebec.Quebec(db_url, table_name_prefix=test_prefix, quiet_then_exit=True)
     assert qc.create_tables() is True
 
@@ -49,9 +55,10 @@ def test_should_drain_exit_false_with_claimed_job(db_url, test_prefix):
         qc.register_worker_process()
         qc.quiet()
         IdleJob.perform_later(qc)
-        qc.drain_one()  # claimed, not performed
+        (execution,) = qc.drain_batch(1)  # Dispatched in the ledger, not performed
         # Still has a claimed job → must not self-exit.
         assert qc.should_drain_exit() is False
+        del execution
     finally:
         qc.close()
 

--- a/tests/test_shutdown_release.py
+++ b/tests/test_shutdown_release.py
@@ -110,8 +110,14 @@ def test_claimed_but_not_started_job_is_released_on_shutdown(qc_with_sqlalchemy)
     process_id = qc.register_worker_process()
 
     IdleJob.perform_later(qc)
-    # Claim it (now in claimed_executions) but do NOT call perform().
-    qc.drain_one()
+    # Claim it via the real batch path so the worker-local ledger records it as
+    # Dispatched, then do NOT perform it. Release is ledger-authoritative, so a
+    # claimed-but-not-started job must carry its Dispatched entry to be released
+    # (drain_one bypasses the ledger and no longer represents a production
+    # claim). Keep the Execution alive so its Drop backstop doesn't clear the
+    # entry before release runs.
+    claimed = qc.drain_batch(1)
+    assert len(claimed) == 1
 
     session.expire_all()
     assert _count(session, prefix, "claimed_executions") == 1
@@ -123,3 +129,4 @@ def test_claimed_but_not_started_job_is_released_on_shutdown(qc_with_sqlalchemy)
     session.expire_all()
     assert _count(session, prefix, "claimed_executions") == 0
     assert _count(session, prefix, "ready_executions") == 1
+    del claimed

--- a/tests/test_shutdown_release.py
+++ b/tests/test_shutdown_release.py
@@ -130,3 +130,50 @@ def test_claimed_but_not_started_job_is_released_on_shutdown(qc_with_sqlalchemy)
     assert _count(session, prefix, "claimed_executions") == 0
     assert _count(session, prefix, "ready_executions") == 1
     del claimed
+
+
+def test_dropped_dispatched_claim_is_still_released_on_shutdown(qc_with_sqlalchemy):
+    """A Dispatched claim whose Execution is dropped before release is requeued.
+
+    Reproduces the pre-perform shutdown race: pick_job pulls an Execution from
+    the dispatch channel (ledger = Dispatched) but is dropped before it marks
+    InFlight (e.g. shutdown observed). ``Execution::Drop`` must LEAVE a Dispatched
+    entry (only an InFlight entry is removed), so ledger-authoritative release
+    still requeues this never-performed job instead of leaving it to be marked
+    failed by the orphan-sweep. Under the old Drop (remove any non-CleanupPending)
+    the entry would be gone and release would skip it (released == 0).
+    """
+    import gc
+
+    ctx = qc_with_sqlalchemy
+    qc = ctx["qc"]
+    session = ctx["session"]
+    prefix = ctx["prefix"]
+
+    class IdleJob(quebec.ActiveJob):
+        def perform(self, *args, **kwargs):
+            return True
+
+    qc.register_job(IdleJob)
+    process_id = qc.register_worker_process()
+
+    IdleJob.perform_later(qc)
+    # Claim via the real batch path (ledger = Dispatched), then DROP the Execution
+    # before release without ever performing it.
+    claimed = qc.drain_batch(1)
+    assert len(claimed) == 1
+    del claimed
+    gc.collect()
+
+    session.expire_all()
+    assert _count(session, prefix, "claimed_executions") == 1
+    assert _count(session, prefix, "ready_executions") == 0
+
+    released = qc.release_claimed_for_shutdown(process_id)
+
+    assert released == 1, (
+        "a dropped-but-never-performed Dispatched claim must still be requeued"
+    )
+    session.expire_all()
+    assert _count(session, prefix, "claimed_executions") == 0
+    assert _count(session, prefix, "ready_executions") == 1


### PR DESCRIPTION
## Summary

Replaces the binary `in_flight_executions` set with a worker-local, three-state **claim ledger** (`Dispatched` / `InFlight` / `CleanupPending`, keyed by `claimed_executions.id`) so the worker has a single authoritative view of which claims it owns and their state. This root-causes a class of graceful-shutdown / error-path bugs that the old binary set could not represent:

- **Duplicate execution** on shutdown when `after_executed` cleanup failed after the job already ran (the row was treated as never-started and requeued).
- **Drain hang** (`quiet_then_exit` never exiting) when a claim succeeded but follow-up DB work failed, leaving residual claimed rows.
- **Cascade orphan** when `release_all_claimed_executions` aborted on the first failing row.

## Design

- **Two layers**: the ledger owns the *graceful* path; the DB orphan-sweep (`fail_orphaned_executions`, reclaims rows whose process row is gone) owns the *crash/error-residue* path. No DB schema change — the ledger is in-memory only.
- **Ledger-authoritative decisions** (symmetric):
  - `release_all_claimed_executions` requeues **only** `Dispatched` rows; `InFlight` / `CleanupPending` / missing-ledger rows are skipped and left for the orphan-sweep.
  - `should_drain_exit` is gated on `ledger_has_active()` (no `Dispatched`/`InFlight`), not a DB count.
- Error paths (dispatch-cleanup helpers, emergency cleanup, panic in `InFlightGuard`, `Execution::Drop`) transition the ledger consistently so an executed job is never requeued and a never-performed job is never silently lost.
- Stale-process pruning and the orphan-sweep are per-row **and** per-process best-effort (one bad row no longer aborts the sweep).

## Behavior changes reviewers should note

- Shutdown release now requeues only `Dispatched` rows (was: also requeued rows with no ledger entry).
- `should_drain_exit` no longer consults `count_by_process_id` — it trusts the ledger.
- `Execution::Drop` keeps a `Dispatched` entry (so a pre-perform shutdown race is still requeued) and only clears `InFlight`.
- `prune_dead_processes` now uses one transaction per claimed row instead of one per process.

## Risk / rollout

- No schema/migration change → clean revert (in-memory ledger only).
- Core path (claim / dispatch / perform / cleanup / shutdown) refactor — broad blast radius.
- Tests are predominantly SQLite in-memory. **Recommend a staging soak on the production DB engine (Postgres/MySQL)** with a real SIGTERM rolling restart and an induced worker kill before promoting, to exercise paths the test harness cannot reproduce (real multi-process races, panic at the PyO3 boundary).

## Test plan

- [x] `cargo clippy --all-targets --all-features` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `QUEBEC_SKIP_IMPORT_HOOK=1 uv run pytest --ignore=tests/step_defs` — 197 passed (+23 new tests, mostly in `tests/test_claim_ledger.py`, covering every ledger transition and error path via fault injection: dropped tables for DB errors, `catch_unwind` for real panics, seeded claimed/stale rows)
- [ ] Staging soak on Postgres/MySQL with rolling restart + induced kill (pre-merge)