### PR TITLE
Confirm single-row discard and cancel actions in control plane

### DIFF
--- a/src/control_plane/templates/blocked-jobs.html
+++ b/src/control_plane/templates/blocked-jobs.html
@@ -109,7 +109,7 @@
                 <span class="hidden sm:inline">Unblock</span>
               </button>
             </form>
-            <form action="{{ base_path }}/blocked-jobs/{{ job.id }}/cancel" method="post" class="inline" data-turbo-frame="_top">
+            <form action="{{ base_path }}/blocked-jobs/{{ job.id }}/cancel" method="post" class="inline" data-turbo-frame="_top" data-turbo-confirm="Cancel this blocked job?">
               <button type="submit" aria-label="Cancel" title="Cancel" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-3 py-1">
                 <svg class="h-4 w-4 sm:hidden" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" aria-hidden="true">
                   <line x1="18" x2="6" y1="6" y2="18"></line>

--- a/src/control_plane/templates/failed-jobs.html
+++ b/src/control_plane/templates/failed-jobs.html
@@ -117,7 +117,7 @@
                 <span class="hidden sm:inline">Retry</span>
               </button>
             </form>
-            <form action="{{ base_path }}/failed-jobs/{{ job.id }}/delete" method="post" class="inline" data-turbo-frame="_top">
+            <form action="{{ base_path }}/failed-jobs/{{ job.id }}/delete" method="post" class="inline" data-turbo-frame="_top" data-turbo-confirm="Discard this failed job?">
               <button type="submit" aria-label="Discard" title="Discard" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-600 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-red-300 bg-white text-red-700 hover:bg-red-50 h-8 px-3 py-1">
                 <svg class="h-4 w-4 sm:hidden" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" aria-hidden="true">
                   <polyline points="3 6 5 6 21 6"></polyline>

--- a/src/control_plane/templates/job-details.html
+++ b/src/control_plane/templates/job-details.html
@@ -36,13 +36,13 @@
             Retry
           </button>
         </form>
-        <form action="{{ base_path }}/failed-jobs/{{ job.id }}/delete" method="post" data-turbo-frame="_top">
+        <form action="{{ base_path }}/failed-jobs/{{ job.id }}/delete" method="post" data-turbo-frame="_top" data-turbo-confirm="Discard this failed job?">
           <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-600 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-red-300 bg-white text-red-700 hover:bg-red-50 h-8 px-4 py-1.5">
             Discard
           </button>
         </form>
       {% elif job.status == 'scheduled' %}
-        <form action="{{ base_path }}/scheduled-jobs/{{ job.execution_id }}/cancel" method="post" data-turbo-frame="_top">
+        <form action="{{ base_path }}/scheduled-jobs/{{ job.execution_id }}/cancel" method="post" data-turbo-frame="_top" data-turbo-confirm="Cancel this scheduled job?">
           <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-4 py-1.5">
             Cancel
           </button>

--- a/src/control_plane/templates/scheduled-jobs.html
+++ b/src/control_plane/templates/scheduled-jobs.html
@@ -88,7 +88,7 @@
             <div class="text-sm text-gray-900"><span data-controller="localtime" data-localtime-datetime-value="{{ job.created_at }}">{{ job.created_at }}</span></div>
           </td>
           <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap text-right text-sm font-medium">
-            <form action="{{ base_path }}/scheduled-jobs/{{ job.id }}/cancel" method="post" class="inline" data-turbo-frame="_top">
+            <form action="{{ base_path }}/scheduled-jobs/{{ job.id }}/cancel" method="post" class="inline" data-turbo-frame="_top" data-turbo-confirm="Cancel this scheduled job?">
               <button type="submit" aria-label="Cancel" title="Cancel" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-xs font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-3 py-1">
                 <svg class="h-4 w-4 sm:hidden" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" aria-hidden="true">
                   <line x1="18" x2="6" y1="6" y2="18"></line>


### PR DESCRIPTION
## Summary

Adds a `data-turbo-confirm` prompt to the **single-row destructive actions** in the control plane, matching the existing confirmation on bulk "Discard all". Previously only the bulk discard-all confirmed; single-row irreversible actions submitted immediately on click.

Covered (irreversible single-row actions):
- Discard a failed job — `failed-jobs.html`, `job-details.html`
- Cancel a scheduled job — `scheduled-jobs.html`, `job-details.html`
- Cancel a blocked job — `blocked-jobs.html`

Left unchanged (non-destructive): Retry, Unblock, and bulk Retry-all/Unblock-all.

This makes confirmation consistent across irreversible deletes/cancels (no more "discard confirms but cancel doesn't"), with friction reserved for actions that cannot be undone.

## Test plan

- [x] `cargo check` passes (templates are askama compile-time embedded)
- [ ] Browser: click a single Discard / Cancel and confirm the Turbo dialog appears before submission (mirrors the already-working bulk Discard-all prompt)