### PR TITLE
perf(control-plane): drop dead nav COUNT and cache filter/finished lookups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,6 +533,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -696,6 +716,16 @@ checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -1402,6 +1432,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "async-lock",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "event-listener",
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "nanoid"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1999,6 +2049,7 @@ dependencies = [
  "http-body-util",
  "humantime",
  "libc",
+ "moka",
  "nanoid",
  "proctitle",
  "pyo3",
@@ -2962,6 +3013,12 @@ dependencies = [
  "quote",
  "syn 2.0.112",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ rust-embed = { version = "8.7.2", features = ["include-exclude", "debug-embed"] 
 regex = "1.10"
 proctitle = "0.1.1"
 libc = "0.2"
+moka = { version = "0.12.15", features = ["future"] }
 
 [lints.rust]
 dead_code = "warn"

--- a/src/control_plane/handlers/queues.rs
+++ b/src/control_plane/handlers/queues.rs
@@ -161,7 +161,10 @@ impl ControlPlane {
         let db = db.as_ref();
         let table_config = &state.ctx.table_config;
 
-        let queue_names = match state.get_queue_names().await {
+        // Pause-all is a mutating action that must see the current queue set,
+        // so bypass the stale-tolerant cached helper and query jobs directly —
+        // otherwise a queue created within the cache TTL would be missed.
+        let queue_names = match query_builder::jobs::get_queue_names(db, table_config).await {
             Ok(names) => names,
             Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
         };

--- a/src/control_plane/mod.rs
+++ b/src/control_plane/mod.rs
@@ -23,12 +23,28 @@ pub mod utils;
 
 pub use ext::ControlPlaneExt;
 
+/// Identifies which cached filter-option set to fetch.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum FilterKind {
+    Queues,
+    Classes,
+}
+
 pub struct ControlPlane {
     pub(crate) ctx: Arc<AppContext>,
     pub(crate) tera: RwLock<Tera>,
     pub(crate) page_size: u64,
     pub(crate) base_path: String,
     pub(crate) sse_interval: Duration,
+    /// Cache for the queue-name / class-name DISTINCT lookups behind the filter
+    /// dropdowns and the /stats queue list. These sets change only when a new
+    /// queue or job class first appears, so a short TTL avoids repeated
+    /// full-table DISTINCT scans on solid_queue_jobs.
+    pub(crate) filter_options_cache: moka::future::Cache<FilterKind, Arc<Vec<String>>>,
+    /// Cache for the finished-job COUNT behind the nav "Finished jobs" badge.
+    /// The count only grows and is a coarse overview number, so a short TTL
+    /// avoids re-running the index-only scan on every render / SSE tick.
+    pub(crate) finished_count_cache: moka::future::Cache<(), i64>,
 }
 
 impl ControlPlane {
@@ -62,6 +78,12 @@ impl ControlPlane {
             page_size: 10,
             base_path: String::new(),
             sse_interval,
+            filter_options_cache: moka::future::Cache::builder()
+                .time_to_live(Duration::from_secs(60))
+                .build(),
+            finished_count_cache: moka::future::Cache::builder()
+                .time_to_live(Duration::from_secs(60))
+                .build(),
         }
     }
 

--- a/src/control_plane/utils.rs
+++ b/src/control_plane/utils.rs
@@ -90,9 +90,6 @@ impl ControlPlane {
         let db = db.as_ref();
         let table_config = &self.ctx.table_config;
 
-        // Count total jobs
-        let total_jobs = query_builder::jobs::count_all(db, table_config).await?;
-
         // Count scheduled jobs
         let scheduled_count =
             query_builder::scheduled_executions::count_all(db, table_config).await? as i64;
@@ -122,7 +119,6 @@ impl ControlPlane {
         // Count active workers
         let active_workers = query_builder::processes::count_all(db, table_config).await?;
 
-        context.insert("nav_total_jobs", &total_jobs);
         context.insert("nav_scheduled_jobs", &scheduled_count);
         context.insert("nav_in_progress_jobs", &in_progress_count);
         context.insert("nav_failed_jobs", &failed_count);

--- a/src/control_plane/utils.rs
+++ b/src/control_plane/utils.rs
@@ -4,6 +4,7 @@ use chrono::{NaiveDateTime, Utc};
 use sea_orm::DbErr;
 use std::collections::HashMap;
 use std::error::Error;
+use std::sync::Arc;
 use tera::Context;
 use tracing::{debug, error, info};
 use url::Url;
@@ -11,7 +12,7 @@ use url::Url;
 use crate::control_plane::models::{queue_slug, QueueInfo};
 use crate::query_builder;
 
-use super::{templates, ControlPlane};
+use super::{templates, ControlPlane, FilterKind};
 
 /// Clean SQL string by removing extra whitespace and joining lines
 pub fn clean_sql(sql: &str) -> String {
@@ -66,22 +67,56 @@ impl ControlPlane {
         }
     }
 
-    /// Get queue names from database using query_builder
+    /// Get queue names (cached). Backs the filter dropdowns and the /stats
+    /// queue list.
     pub async fn get_queue_names(&self) -> Result<Vec<String>, DbErr> {
-        let db = self.ctx.get_db().await?;
-        let db = db.as_ref();
-        let table_config = &self.ctx.table_config;
-
-        query_builder::jobs::get_queue_names(db, table_config).await
+        self.cached_filter_options(FilterKind::Queues).await
     }
 
-    /// Get job class names from database using query_builder
+    /// Get job class names (cached). Backs the filter dropdowns.
     pub async fn get_job_classes(&self) -> Result<Vec<String>, DbErr> {
-        let db = self.ctx.get_db().await?;
-        let db = db.as_ref();
-        let table_config = &self.ctx.table_config;
+        self.cached_filter_options(FilterKind::Classes).await
+    }
 
-        query_builder::jobs::get_class_names(db, table_config).await
+    /// Fetch a filter-option set through the TTL cache, falling back to a
+    /// DISTINCT query against solid_queue_jobs on a miss. moka coalesces
+    /// concurrent misses so only one query runs per key per refresh window.
+    async fn cached_filter_options(&self, kind: FilterKind) -> Result<Vec<String>, DbErr> {
+        let names = self
+            .filter_options_cache
+            .try_get_with(kind, async {
+                let db = self.ctx.get_db().await?;
+                let db = db.as_ref();
+                let table_config = &self.ctx.table_config;
+                let names = match kind {
+                    FilterKind::Queues => {
+                        query_builder::jobs::get_queue_names(db, table_config).await?
+                    }
+                    FilterKind::Classes => {
+                        query_builder::jobs::get_class_names(db, table_config).await?
+                    }
+                };
+                Ok::<_, DbErr>(Arc::new(names))
+            })
+            .await
+            .map_err(|e: Arc<DbErr>| DbErr::Custom(format!("filter options query failed: {e}")))?;
+        Ok((*names).clone())
+    }
+
+    /// Get the finished-job count (cached). Backs the nav "Finished jobs" badge,
+    /// where an exact value is not important.
+    async fn cached_finished_count(&self) -> Result<i64, DbErr> {
+        self.finished_count_cache
+            .try_get_with((), async {
+                let db = self.ctx.get_db().await?;
+                let db = db.as_ref();
+                let table_config = &self.ctx.table_config;
+                let count =
+                    query_builder::jobs::count_finished(db, table_config, None, None).await? as i64;
+                Ok::<_, DbErr>(count)
+            })
+            .await
+            .map_err(|e: Arc<DbErr>| DbErr::Custom(format!("finished count query failed: {e}")))
     }
 
     /// Populate navigation statistics for templates using query_builder
@@ -132,8 +167,7 @@ impl ControlPlane {
         context.insert("scheduled_jobs_count", &scheduled_count);
 
         // Count finished jobs by finished_at to match the /finished-jobs page
-        let finished_count =
-            query_builder::jobs::count_finished(db, table_config, None, None).await? as i64;
+        let finished_count = self.cached_finished_count().await?;
         context.insert("finished_jobs_count", &finished_count);
 
         // Per-queue ready-execution counts + paused-state snapshot, so the
@@ -145,7 +179,7 @@ impl ControlPlane {
             query_builder::ready_executions::count_by_queue(db, table_config).await?;
         let paused_queue_names =
             query_builder::pauses::find_all_queue_names(db, table_config).await?;
-        let all_queue_names = query_builder::jobs::get_queue_names(db, table_config).await?;
+        let all_queue_names = self.get_queue_names().await?;
 
         let queue_counts: Vec<QueueInfo> = all_queue_names
             .into_iter()


### PR DESCRIPTION
Two control-plane perf fixes for the `solid_queue_jobs` hot path that runs on every page render and `/stats` SSE tick.

`ea8be7f` drops an unconditional `COUNT(*)` whose result no template referenced.

`8e47987` adds a 60s moka cache for `DISTINCT queue_name` / `DISTINCT class_name` / `count_finished`. At production scale these are O(N) (e.g. 1–2s on ~4M-row tables, made worse by a degraded visibility map). `pause_all_queues` bypasses the cache so the mutating action always sees the current queue set. Per-`ControlPlane` instance; no shared-state assumption.

Verified: `cargo clippy --all-targets --all-features` clean, full pytest (180 tests) passes.