### PR TITLE
feat(worker): recycle on RSS soft limit via quiet/drain and supervisor refork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1136,7 +1136,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1458,6 +1458,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
 dependencies = [
  "rand 0.8.5",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -2062,6 +2071,7 @@ dependencies = [
  "serde_yaml",
  "signal-hook",
  "sqlx-postgres",
+ "sysinfo",
  "tera",
  "thiserror 1.0.69",
  "tokio",
@@ -3015,6 +3025,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.31.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "355dbe4f8799b304b05e1b0f05fc59b2a18d36645cf169607da45bde2f69a1be"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "windows",
+]
+
+[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3694,16 +3717,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
 ]
 
 [[package]]
@@ -3711,6 +3767,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.112",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3733,6 +3800,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-result"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ serde_yaml = "0.9.34"
 serde = { version = "1.0.214", features = ["derive"] }
 nanoid = "0.4"
 hostname = "0.4.0"
+sysinfo = { version = "0.31.4", default-features = false, features = ["system"] }
 async-trait = "0.1.83"
 humantime = "2.1.0"
 tokio-util = "0.7.12"

--- a/python/quebec/supervisor.py
+++ b/python/quebec/supervisor.py
@@ -24,6 +24,7 @@ ROLE_WORKER = "worker"
 ROLE_DISPATCHER = "dispatcher"
 ROLE_SCHEDULER = "scheduler"
 VALID_ROLES = {ROLE_WORKER, ROLE_DISPATCHER, ROLE_SCHEDULER}
+RECYCLE_EXIT_CODE = 75
 
 Plan = Dict[str, Union[int, List]]
 
@@ -35,12 +36,47 @@ class _ChildInfo:
     pid: int
 
 
+@dataclass(frozen=True)
+class _ExitStatus:
+    exited: bool
+    exit_code: Optional[int]
+    signaled: bool
+    signal: Optional[int]
+
+
 @dataclass
 class _SlotState:
     """Restart history for a (role, index) slot."""
 
     spawn_times: List[float] = field(default_factory=list)
+    crash_times: List[float] = field(default_factory=list)
     disabled: bool = False
+
+
+def _decode_status(status: int) -> _ExitStatus:
+    if os.WIFEXITED(status):
+        return _ExitStatus(
+            exited=True,
+            exit_code=os.WEXITSTATUS(status),
+            signaled=False,
+            signal=None,
+        )
+    if os.WIFSIGNALED(status):
+        return _ExitStatus(
+            exited=False,
+            exit_code=None,
+            signaled=True,
+            signal=os.WTERMSIG(status),
+        )
+    return _ExitStatus(exited=False, exit_code=None, signaled=False, signal=None)
+
+
+def _status_description(status: _ExitStatus) -> str:
+    if status.exited:
+        return f"exit_code={status.exit_code}"
+    if status.signaled:
+        return f"signal={status.signal}"
+    return "status=unknown"
 
 
 class Supervisor:
@@ -332,20 +368,22 @@ class Supervisor:
 
     def _supervise(self) -> None:
         while not self._stopping:
-            pid = self._reap_one(block=False)
+            pid, status = self._reap_one(block=False)
             if pid == 0:
                 self._interruptible_sleep(1.0)
                 continue
-            self._handle_exit(pid)
+            self._handle_exit(pid, status)
 
-    def _reap_one(self, *, block: bool) -> int:
-        """Return a reaped child pid, or 0 if none (when non-blocking)."""
+    def _reap_one(self, *, block: bool) -> Tuple[int, Optional[_ExitStatus]]:
+        """Return a reaped child pid/status, or ``(0, None)`` if none."""
         flags = 0 if block else os.WNOHANG
         try:
-            pid, _status = os.waitpid(-1, flags)
-            return pid
+            pid, status = os.waitpid(-1, flags)
+            if pid == 0:
+                return 0, None
+            return pid, _decode_status(status)
         except ChildProcessError:
-            return 0
+            return 0, None
 
     def _fail_claimed_for_pid(self, pid: int, info: Optional[_ChildInfo]) -> None:
         """Best-effort: mark any claimed jobs owned by a dead child as failed.
@@ -381,31 +419,59 @@ class Supervisor:
             else:
                 logger.exception("Failed to mark claimed jobs for pid=%d", pid)
 
-    def _handle_exit(self, pid: int) -> None:
+    def _handle_exit(self, pid: int, status: Optional[_ExitStatus]) -> None:
+        status = status or _ExitStatus(
+            exited=False, exit_code=None, signaled=False, signal=None
+        )
         info = self._children.pop(pid, None)
         if info is None:
             logger.warning("Reaped unknown pid=%d", pid)
             return
-        logger.warning(
-            "Child %s[%d] (pid=%d) exited unexpectedly", info.role, info.index, pid
+
+        planned_recycle = (
+            info.role == ROLE_WORKER
+            and status.exited
+            and status.exit_code == RECYCLE_EXIT_CODE
         )
+        if planned_recycle:
+            if self._stopping:
+                return
+            logger.info(
+                "Child %s[%d] (pid=%d) exited for planned memory recycle; reforking",
+                info.role,
+                info.index,
+                pid,
+            )
+            self._fork_child(info.role, info.index)
+            return
 
         self._fail_claimed_for_pid(pid, info)
 
         if self._stopping:
             return
 
+        logger.warning(
+            "Child %s[%d] (pid=%d) exited unexpectedly (%s)",
+            info.role,
+            info.index,
+            pid,
+            _status_description(status),
+        )
+
         slot = self._slots.get((info.role, info.index))
         if slot is not None:
             now = time.monotonic()
-            recent = [t for t in slot.spawn_times if now - t <= self.crash_loop_window]
-            if len(recent) >= self.crash_loop_max:
+            slot.crash_times = [
+                t for t in slot.crash_times if now - t <= self.crash_loop_window
+            ]
+            slot.crash_times.append(now)
+            if len(slot.crash_times) >= self.crash_loop_max:
                 slot.disabled = True
                 logger.error(
                     "Slot (%s, %d) crashed %d times in %.0fs; disabling auto-restart",
                     info.role,
                     info.index,
-                    len(recent),
+                    len(slot.crash_times),
                     self.crash_loop_window,
                 )
                 return
@@ -458,7 +524,7 @@ class Supervisor:
                 pass
 
         while self._children:
-            pid = self._reap_one(block=True)
+            pid, _status = self._reap_one(block=True)
             if pid == 0:
                 break
             info = self._children.pop(pid, None)
@@ -474,7 +540,7 @@ class Supervisor:
 
     def _reap_until(self, *, deadline: float) -> None:
         while self._children and time.monotonic() < deadline:
-            pid = self._reap_one(block=False)
+            pid, _status = self._reap_one(block=False)
             if pid == 0:
                 time.sleep(0.1)
                 continue

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,12 +1,13 @@
 use crate::error::{QuebecError, Result};
+use crate::query_builder;
 use croner::Cron;
 use english_to_cron::str_cron_syntax;
 use sea_orm::{ConnectOptions, Database, DatabaseConnection, DbErr};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
-use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
-use std::sync::{Arc, RwLock};
-use std::time::Duration;
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, RwLock};
+use std::time::{Duration, Instant};
 use tokio::runtime::Handle;
 use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
@@ -14,6 +15,8 @@ use tokio_util::sync::CancellationToken;
 use crate::database_url::DatabaseUrl;
 
 use tracing::{debug, error, trace, warn};
+
+pub const WORKER_MEMORY_RECYCLE_EXIT_CODE: i32 = 75;
 
 #[cfg(feature = "python")]
 use pyo3::exceptions::PyException;
@@ -339,6 +342,13 @@ pub struct AppContext {
     pub dispatcher_concurrency_maintenance_interval: Duration,
     pub worker_polling_interval: Duration,
     pub worker_threads: u64,
+    /// Optional worker RSS soft limit. When set, a worker that stays above the
+    /// limit for `worker_memory_recycle_confirmations` consecutive samples
+    /// enters quiet mode, drains, and exits with the planned recycle exit code.
+    pub worker_max_rss_bytes: Option<u64>,
+    pub worker_memory_check_interval: Duration,
+    pub worker_memory_graceful_timeout: Duration,
+    pub worker_memory_recycle_confirmations: u64,
     pub control_plane_sse_interval: Duration,
     pub worker_queues: Option<crate::config::QueueSelector>, // Queue configuration for worker
     pub graceful_shutdown: CancellationToken,
@@ -391,6 +401,9 @@ pub struct AppContext {
     /// `Mutex<HashSet>`: the guarded section is a single
     /// insert/remove/contains, never held across an await.
     pub in_flight_executions: Arc<std::sync::Mutex<HashSet<i64>>>,
+    pub worker_memory_recycle_requested: AtomicBool,
+    pub worker_memory_recycle_started_at: Mutex<Option<Instant>>,
+    pub worker_last_rss_bytes: AtomicU64,
 }
 
 /// RAII guard that marks a claimed_execution as in-flight for the lifetime of
@@ -698,6 +711,27 @@ impl AppContext {
             if let Some(v) = get_u64("worker_threads") {
                 ctx.worker_threads = v;
             }
+            if let Some(v) = get_u64("worker_max_rss_mb") {
+                ctx.worker_max_rss_bytes = if v == 0 {
+                    None
+                } else {
+                    Some(v.saturating_mul(1024 * 1024))
+                };
+            }
+            if let Some(v) = get_duration("worker_memory_check_interval") {
+                ctx.worker_memory_check_interval = v;
+            }
+            if let Some(v) = get_duration("worker_memory_graceful_timeout") {
+                ctx.worker_memory_graceful_timeout = v;
+            }
+            if let Some(v) = get_u64("worker_memory_recycle_confirmations") {
+                if v == 0 {
+                    warn!("worker_memory_recycle_confirmations=0 ignored; using 1");
+                    ctx.worker_memory_recycle_confirmations = 1;
+                } else {
+                    ctx.worker_memory_recycle_confirmations = v;
+                }
+            }
             // EXPERIMENTAL: per-queue concurrency overrides via a Python dict
             // {queue_name: limit}. Invalid entries are skipped with a warning;
             // the whole field is opt-in so leaving it unset preserves prior
@@ -835,6 +869,10 @@ impl AppContext {
             dispatcher_concurrency_maintenance_interval: Duration::from_secs(600),
             worker_polling_interval: Duration::from_millis(100),
             worker_threads: 3,
+            worker_max_rss_bytes: None,
+            worker_memory_check_interval: Duration::from_secs(5),
+            worker_memory_graceful_timeout: Duration::from_secs(300),
+            worker_memory_recycle_confirmations: 3,
             control_plane_sse_interval: Duration::from_secs(5),
             worker_queues: None, // Default to all queues
             graceful_shutdown: CancellationToken::new(),
@@ -851,7 +889,66 @@ impl AppContext {
             claim_in_progress: AtomicBool::new(false),
             proc_slot: None,
             in_flight_executions: Arc::new(std::sync::Mutex::new(HashSet::new())),
+            worker_memory_recycle_requested: AtomicBool::new(false),
+            worker_memory_recycle_started_at: Mutex::new(None),
+            worker_last_rss_bytes: AtomicU64::new(0),
         }
+    }
+
+    pub fn update_worker_rss(&self, rss_bytes: u64) {
+        self.worker_last_rss_bytes
+            .store(rss_bytes, Ordering::Relaxed);
+    }
+
+    pub fn request_worker_memory_recycle(&self, rss_bytes: u64) -> bool {
+        self.update_worker_rss(rss_bytes);
+        {
+            let mut started_at = self
+                .worker_memory_recycle_started_at
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            if started_at.is_none() {
+                *started_at = Some(Instant::now());
+            }
+        }
+        !self
+            .worker_memory_recycle_requested
+            .swap(true, Ordering::SeqCst)
+    }
+
+    pub fn worker_memory_recycle_elapsed(&self) -> Option<Duration> {
+        self.worker_memory_recycle_started_at
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .map(|started_at| started_at.elapsed())
+    }
+
+    pub async fn worker_drained(&self, process_id: i64) -> bool {
+        if self.claim_in_progress.load(Ordering::SeqCst) {
+            return false;
+        }
+
+        let in_flight_empty = self
+            .in_flight_executions
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .is_empty();
+        if !in_flight_empty {
+            return false;
+        }
+
+        let Ok(db) = self.get_db().await else {
+            return false;
+        };
+        matches!(
+            query_builder::claimed_executions::count_by_process_id(
+                db.as_ref(),
+                &self.table_config,
+                process_id,
+            )
+            .await,
+            Ok(0)
+        )
     }
 
     /// Record the current parent PID so role loops can detect supervisor death.
@@ -928,6 +1025,10 @@ impl AppContext {
                 .dispatcher_concurrency_maintenance_interval,
             worker_polling_interval: self.worker_polling_interval,
             worker_threads: self.worker_threads,
+            worker_max_rss_bytes: self.worker_max_rss_bytes,
+            worker_memory_check_interval: self.worker_memory_check_interval,
+            worker_memory_graceful_timeout: self.worker_memory_graceful_timeout,
+            worker_memory_recycle_confirmations: self.worker_memory_recycle_confirmations,
             control_plane_sse_interval: self.control_plane_sse_interval,
             worker_queues: self.worker_queues.clone(),
             graceful_shutdown: CancellationToken::new(),
@@ -950,6 +1051,9 @@ impl AppContext {
             // dispatch channel, so in-flight ids must not be shared with the
             // parent (whose claims belong to a different process record).
             in_flight_executions: Arc::new(std::sync::Mutex::new(HashSet::new())),
+            worker_memory_recycle_requested: AtomicBool::new(false),
+            worker_memory_recycle_started_at: Mutex::new(None),
+            worker_last_rss_bytes: AtomicU64::new(0),
             use_listen_notify: self.use_listen_notify,
             notify_throttle_interval: self.notify_throttle_interval,
             force_override_queue: self.force_override_queue.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod database_url;
 mod dispatcher;
 pub mod entities;
 mod error;
+mod memory;
 mod notify;
 mod process;
 #[cfg(target_os = "macos")]

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,0 +1,17 @@
+use std::cell::RefCell;
+
+thread_local! {
+    static SYSTEM: RefCell<sysinfo::System> = RefCell::new(sysinfo::System::new());
+}
+
+pub fn current_rss_bytes() -> Option<u64> {
+    let pid = sysinfo::get_current_pid().ok()?;
+    SYSTEM.with(|system| {
+        let mut system = system.borrow_mut();
+        system.refresh_processes_specifics(
+            sysinfo::ProcessesToUpdate::Some(&[pid]),
+            sysinfo::ProcessRefreshKind::new().with_memory(),
+        );
+        system.process(pid).map(|process| process.memory())
+    })
+}

--- a/src/process.rs
+++ b/src/process.rs
@@ -45,11 +45,19 @@ pub fn process_revision() -> Option<&'static str> {
 /// Build the JSON metadata blob written to the `processes.metadata` column
 /// each heartbeat. Includes ``revision`` whenever :func:`process_revision`
 /// returns a value, plus ``quiet:true`` when the caller passes ``quiet =
-/// true``. Returns ``None`` when both fields would be absent so the column
+/// true``. Returns ``None`` when all fields would be absent so the column
 /// stays untouched.
 pub fn build_runtime_metadata(quiet: bool) -> Option<String> {
+    build_runtime_metadata_with_memory(quiet, None, None)
+}
+
+pub fn build_runtime_metadata_with_memory(
+    quiet: bool,
+    recycle_reason: Option<&str>,
+    rss_bytes: Option<u64>,
+) -> Option<String> {
     let revision = process_revision();
-    if !quiet && revision.is_none() {
+    if !quiet && revision.is_none() && recycle_reason.is_none() && rss_bytes.is_none() {
         return None;
     }
     let mut obj = serde_json::Map::new();
@@ -61,6 +69,17 @@ pub fn build_runtime_metadata(quiet: bool) -> Option<String> {
             "revision".to_string(),
             serde_json::Value::String(s.to_string()),
         );
+    }
+    if let Some(reason) = recycle_reason {
+        obj.insert(
+            "recycle_reason".to_string(),
+            serde_json::Value::String(reason.to_string()),
+        );
+    }
+    if let Some(bytes) = rss_bytes {
+        let mb = bytes.saturating_add(1024 * 1024 - 1) / (1024 * 1024);
+        obj.insert("rss_bytes".to_string(), serde_json::Value::from(bytes));
+        obj.insert("rss_mb".to_string(), serde_json::Value::from(mb));
     }
     serde_json::to_string(&serde_json::Value::Object(obj)).ok()
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1188,22 +1188,6 @@ impl PyQuebec {
         if self.ctx.supervisor_pid.load(Ordering::Relaxed) != 0 {
             return false;
         }
-        // A claim that passed the quiet gate before quiet was signalled may still
-        // be publishing work; wait for it so the idle snapshot below is not taken
-        // mid-claim (which could let the process exit and subject that batch to
-        // graceful_shutdown's bounded drain).
-        if self.ctx.claim_in_progress.load(Ordering::SeqCst) {
-            return false;
-        }
-        let in_flight_empty = self
-            .ctx
-            .in_flight_executions
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .is_empty();
-        if !in_flight_empty {
-            return false;
-        }
         let worker = self.worker.clone();
         let ctx = self.ctx.clone();
         py.detach(|| {
@@ -1212,18 +1196,7 @@ impl PyQuebec {
                     Some(id) => id,
                     None => return false,
                 };
-                let Ok(db) = ctx.get_db().await else {
-                    return false;
-                };
-                matches!(
-                    crate::query_builder::claimed_executions::count_by_process_id(
-                        db.as_ref(),
-                        &ctx.table_config,
-                        process_id,
-                    )
-                    .await,
-                    Ok(0)
-                )
+                ctx.worker_drained(process_id).await
             })
         })
     }
@@ -1233,6 +1206,33 @@ impl PyQuebec {
     /// is still publishing work.
     fn _set_claim_in_progress(&self, value: bool) {
         self.ctx.claim_in_progress.store(value, Ordering::SeqCst);
+    }
+
+    fn _request_worker_memory_recycle(&self, rss_bytes: u64) {
+        self.ctx.request_worker_memory_recycle(rss_bytes);
+        self.ctx.quiet.cancel();
+    }
+
+    fn _should_worker_memory_recycle_exit(&self, py: Python<'_>) -> bool {
+        let worker = self.worker.clone();
+        py.detach(|| {
+            self.rt.block_on(async move {
+                let process_id = match *worker.process_id_handle().lock().await {
+                    Some(id) => id,
+                    None => return false,
+                };
+                worker
+                    .should_exit_for_worker_memory_recycle(process_id)
+                    .await
+            })
+        })
+    }
+
+    #[getter]
+    fn is_worker_memory_recycling(&self) -> bool {
+        self.ctx
+            .worker_memory_recycle_requested
+            .load(Ordering::Relaxed)
     }
 
     fn ping(&self) -> PyResult<bool> {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -14,6 +14,7 @@ use pyo3::prelude::*;
 
 use sea_orm::TransactionTrait;
 use sea_orm::*;
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, RwLock};
 use std::time::Instant;
 use tokio::sync::mpsc::Sender;
@@ -3043,6 +3044,142 @@ impl Worker {
         }
     }
 
+    async fn check_worker_memory_recycle(
+        &self,
+        process: &crate::entities::quebec_processes::Model,
+        over_limit_count: &mut u64,
+        rss_unsupported_logged: &mut bool,
+        quiet_announced: &mut bool,
+    ) {
+        let Some(limit_bytes) = self.ctx.worker_max_rss_bytes else {
+            return;
+        };
+
+        let Some(rss_bytes) = crate::memory::current_rss_bytes() else {
+            if !*rss_unsupported_logged {
+                warn!(
+                    "worker_max_rss_mb is configured, but current RSS is unavailable \
+                     on this platform; worker memory recycle is disabled"
+                );
+                *rss_unsupported_logged = true;
+            }
+            return;
+        };
+
+        self.ctx.update_worker_rss(rss_bytes);
+        if rss_bytes <= limit_bytes {
+            *over_limit_count = 0;
+            return;
+        }
+
+        *over_limit_count = (*over_limit_count).saturating_add(1);
+        let confirmations = self.ctx.worker_memory_recycle_confirmations.max(1);
+        if *over_limit_count < confirmations {
+            debug!(
+                "Worker RSS {} MiB exceeds configured limit {} MiB ({}/{})",
+                rss_bytes / (1024 * 1024),
+                limit_bytes / (1024 * 1024),
+                *over_limit_count,
+                confirmations
+            );
+            return;
+        }
+
+        let newly_requested = self.ctx.request_worker_memory_recycle(rss_bytes);
+        if newly_requested {
+            warn!(
+                "Worker RSS {} MiB exceeded configured limit {} MiB for {} consecutive check(s); \
+                 entering quiet mode for planned recycle",
+                rss_bytes / (1024 * 1024),
+                limit_bytes / (1024 * 1024),
+                confirmations
+            );
+        }
+
+        if !self.ctx.quiet.is_cancelled() {
+            self.ctx.quiet.cancel();
+        }
+
+        *quiet_announced = true;
+        if let Ok(db) = self.ctx.get_db().await {
+            if let Err(e) = self.heartbeat(&db, process).await {
+                warn!("Failed to flush memory recycle heartbeat: {}", e);
+            }
+        }
+    }
+
+    pub(crate) async fn should_exit_for_worker_memory_recycle(&self, process_id: i64) -> bool {
+        if !self
+            .ctx
+            .worker_memory_recycle_requested
+            .load(Ordering::Relaxed)
+            || !self.ctx.quiet.is_cancelled()
+        {
+            return false;
+        }
+
+        if self
+            .ctx
+            .worker_memory_recycle_elapsed()
+            .is_some_and(|elapsed| elapsed >= self.ctx.worker_memory_graceful_timeout)
+        {
+            warn!(
+                "Worker memory recycle graceful timeout {:?} reached; exiting planned recycle",
+                self.ctx.worker_memory_graceful_timeout
+            );
+            return true;
+        }
+
+        self.ctx.worker_drained(process_id).await
+    }
+
+    async fn shutdown_worker_process(
+        &self,
+        process: &crate::entities::quebec_processes::Model,
+        drain_budget: std::time::Duration,
+    ) -> Result<()> {
+        // Call worker stop handlers before exiting.
+        Python::attach(|py| {
+            let handlers = self.stop_handlers.read().expect("Lock poisoned");
+            for handler in handlers.iter() {
+                match handler.bind(py).call0() {
+                    Ok(_) => debug!("Worker stop handler executed successfully in main loop"),
+                    Err(e) => error!("Error calling worker stop handler in main loop: {:?}", e),
+                }
+            }
+        });
+
+        let drain_deadline = tokio::time::Instant::now() + drain_budget;
+        loop {
+            let in_flight_empty = self
+                .ctx
+                .in_flight_executions
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .is_empty();
+            if in_flight_empty {
+                break;
+            }
+            if drain_budget.is_zero() || tokio::time::Instant::now() >= drain_deadline {
+                warn!(
+                    "Shutdown drain timed out with jobs still inside perform(); \
+                     leaving them claimed to avoid a double-execution race"
+                );
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+
+        if let Err(e) = self.release_all_claimed_executions(process.id).await {
+            warn!("Failed to release claimed executions on shutdown: {}", e);
+        }
+
+        let stop_db = self.ctx.get_db().await?;
+        self.on_stop(&stop_db, process).await?;
+
+        Ok(())
+    }
+
     pub async fn run_main_loop(&self) -> Result<()> {
         // Don't acquire long-term connections here, get them when needed
         let mut polling_interval = tokio::time::interval(self.ctx.worker_polling_interval);
@@ -3060,6 +3197,17 @@ impl Worker {
             std::time::Duration::from_secs(3600) // dummy interval when disabled
         };
         let mut cleanup_interval = tokio::time::interval(cleanup_duration);
+        let memory_check_enabled = self.ctx.worker_max_rss_bytes.is_some();
+        let memory_check_duration = if memory_check_enabled {
+            self.ctx
+                .worker_memory_check_interval
+                .max(std::time::Duration::from_secs(1))
+        } else {
+            std::time::Duration::from_secs(3600)
+        };
+        let mut memory_check_interval = tokio::time::interval(memory_check_duration);
+        let mut memory_over_limit_count = 0u64;
+        let mut memory_unsupported_logged = false;
         // Orphan check: detect supervisor death via ppid change (Solid Queue parity).
         // Only enabled when running as a supervisor-managed child so the old
         // single-process threaded mode is unaffected.
@@ -3137,6 +3285,22 @@ impl Worker {
                         }
                     }
                 }
+                _ = memory_check_interval.tick(), if memory_check_enabled => {
+                    if self.ctx.worker_memory_recycle_requested.load(Ordering::Relaxed) {
+                        if self.should_exit_for_worker_memory_recycle(process.id).await {
+                            info!("Worker memory recycle drained or timed out; exiting with planned recycle status");
+                            self.shutdown_worker_process(&process, std::time::Duration::ZERO).await?;
+                            std::process::exit(WORKER_MEMORY_RECYCLE_EXIT_CODE);
+                        }
+                    } else {
+                        self.check_worker_memory_recycle(
+                            &process,
+                            &mut memory_over_limit_count,
+                            &mut memory_unsupported_logged,
+                            &mut quiet_announced,
+                        ).await;
+                    }
+                }
                 // Periodic maintenance: prune dead processes and fail their claimed jobs
                 _ = maintenance_interval.tick() => {
                     if let Err(e) = self.prune_dead_processes(Some(process.id)).await {
@@ -3161,17 +3325,6 @@ impl Worker {
                 _ = quit.cancelled() => {
                     info!("Graceful shutdown, stop polling");
 
-                    // Call worker stop handlers before exiting
-                    Python::attach(|py| {
-                        let handlers = self.stop_handlers.read().expect("Lock poisoned");
-                        for handler in handlers.iter() {
-                            match handler.bind(py).call0() {
-                                Ok(_) => debug!("Worker stop handler executed successfully in main loop"),
-                                Err(e) => error!("Error calling worker stop handler in main loop: {:?}", e)
-                            }
-                        }
-                    });
-
                     // Wait for jobs already handed to the Python side to finish
                     // before releasing anything. pick_job stops feeding the
                     // Python work queue once shutdown begins (it returns Err on
@@ -3181,44 +3334,10 @@ impl Worker {
                     // fraction of shutdown_timeout so the outer graceful_shutdown
                     // block_on still has budget to run the release and on_stop
                     // below before its own timeout fires.
-                    let drain_deadline = tokio::time::Instant::now()
-                        + self.ctx.shutdown_timeout.mul_f64(0.8);
-                    loop {
-                        let in_flight_empty = self
-                            .ctx
-                            .in_flight_executions
-                            .lock()
-                            .unwrap_or_else(|e| e.into_inner())
-                            .is_empty();
-                        if in_flight_empty {
-                            break;
-                        }
-                        if tokio::time::Instant::now() >= drain_deadline {
-                            warn!(
-                                "Shutdown drain timed out with jobs still inside perform(); \
-                                 leaving them claimed to avoid a double-execution race"
-                            );
-                            break;
-                        }
-                        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-                    }
-
-                    // Release jobs that never started running (still queued in the
-                    // mpsc channel or the Python work queue) back to ready so the
-                    // dispatcher can re-claim them. Jobs that finished perform()
-                    // during the drain above are already gone from
-                    // claimed_executions. If the drain timed out, rows still
-                    // in_flight are skipped (release_all_claimed_executions filters
-                    // them) to avoid handing a running job to a neighbour; those are
-                    // reaped later by the supervisor's orphan sweep or a restarting
-                    // worker's fail_orphaned_executions.
-                    if let Err(e) = self.release_all_claimed_executions(process.id).await {
-                        warn!("Failed to release claimed executions on shutdown: {}", e);
-                    }
-
-                    // Clean up process record
-                    let stop_db = self.ctx.get_db().await?;
-                    self.on_stop(&stop_db, &process).await?;
+                    self.shutdown_worker_process(
+                        &process,
+                        self.ctx.shutdown_timeout.mul_f64(0.8),
+                    ).await?;
 
                     return Ok(());
                 }
@@ -3543,6 +3662,14 @@ impl ProcessTrait for Worker {
     }
 
     fn runtime_metadata(&self) -> Option<String> {
-        crate::process::build_runtime_metadata(self.ctx.quiet.is_cancelled())
+        let rss_bytes = self.ctx.worker_last_rss_bytes.load(Ordering::Relaxed);
+        crate::process::build_runtime_metadata_with_memory(
+            self.ctx.quiet.is_cancelled(),
+            self.ctx
+                .worker_memory_recycle_requested
+                .load(Ordering::Relaxed)
+                .then_some("rss_limit"),
+            (rss_bytes > 0).then_some(rss_bytes),
+        )
     }
 }

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -17,6 +17,16 @@ import socket
 import pytest
 from sqlalchemy import text
 
+from quebec.supervisor import (
+    RECYCLE_EXIT_CODE,
+    ROLE_WORKER,
+    Supervisor,
+    _ChildInfo,
+    _ExitStatus,
+    _SlotState,
+    _decode_status,
+)
+
 
 def _insert_claimed(session, prefix: str, process_id: int, job_class: str = "TestJob"):
     """Insert a minimal job + claimed_execution row for a given process_id.
@@ -179,6 +189,56 @@ class TestCurrentProcessIds:
         assert qc.current_worker_process_id() is None
         assert qc.current_dispatcher_process_id() is None
         assert qc.current_scheduler_process_id() is None
+
+
+class TestSupervisorExitStatus:
+    def test_decode_exited_status(self):
+        status = _decode_status(RECYCLE_EXIT_CODE << 8)
+
+        assert status.exited is True
+        assert status.exit_code == RECYCLE_EXIT_CODE
+        assert status.signaled is False
+        assert status.signal is None
+
+    def test_planned_recycle_reforks_without_crash_loop_accounting(self, qc):
+        sup = Supervisor(qc, {ROLE_WORKER: 1}, crash_loop_max=1)
+        sup._children[123] = _ChildInfo(role=ROLE_WORKER, index=0, pid=123)
+        sup._slots[(ROLE_WORKER, 0)] = _SlotState()
+        swept = []
+        spawned = []
+        sup._fail_claimed_for_pid = lambda pid, info: swept.append((pid, info.role))
+        sup._fork_child = lambda role, index: spawned.append((role, index))
+
+        sup._handle_exit(
+            123,
+            _ExitStatus(
+                exited=True,
+                exit_code=RECYCLE_EXIT_CODE,
+                signaled=False,
+                signal=None,
+            ),
+        )
+
+        assert swept == []
+        assert spawned == [(ROLE_WORKER, 0)]
+        assert sup._slots[(ROLE_WORKER, 0)].disabled is False
+        assert sup._slots[(ROLE_WORKER, 0)].crash_times == []
+
+    def test_unexpected_exit_counts_toward_crash_loop(self, qc):
+        sup = Supervisor(qc, {ROLE_WORKER: 1}, crash_loop_max=1)
+        sup._children[124] = _ChildInfo(role=ROLE_WORKER, index=0, pid=124)
+        sup._slots[(ROLE_WORKER, 0)] = _SlotState()
+        spawned = []
+        sup._fail_claimed_for_pid = lambda pid, info: None
+        sup._fork_child = lambda role, index: spawned.append((role, index))
+
+        sup._handle_exit(
+            124,
+            _ExitStatus(exited=True, exit_code=1, signaled=False, signal=None),
+        )
+
+        assert sup._slots[(ROLE_WORKER, 0)].disabled is True
+        assert spawned == []
 
 
 class TestApplyConfig:

--- a/tests/test_worker_memory_recycle.py
+++ b/tests/test_worker_memory_recycle.py
@@ -1,0 +1,71 @@
+"""Tests for worker RSS soft-limit recycle state."""
+
+from __future__ import annotations
+
+import quebec
+
+
+def test_memory_recycle_exits_when_drained_under_supervisor(db_url, test_prefix):
+    qc = quebec.Quebec(db_url, table_name_prefix=test_prefix)
+    assert qc.create_tables() is True
+    try:
+        qc.register_worker_process()
+        qc.watch_parent_pid()
+
+        qc._request_worker_memory_recycle(256 * 1024 * 1024)
+
+        assert qc.is_quiet is True
+        assert qc.is_worker_memory_recycling is True
+        assert qc._should_worker_memory_recycle_exit() is True
+        # Ordinary quiet_then_exit remains disabled under supervisor mode.
+        assert qc.should_drain_exit() is False
+    finally:
+        qc.close()
+
+
+def test_memory_recycle_waits_for_claimed_job_before_timeout(db_url, test_prefix):
+    qc = quebec.Quebec(
+        db_url,
+        table_name_prefix=test_prefix,
+        worker_memory_graceful_timeout=60,
+    )
+    assert qc.create_tables() is True
+
+    class IdleJob(quebec.ActiveJob):
+        def perform(self, *args, **kwargs):
+            return True
+
+    try:
+        qc.register_job(IdleJob)
+        qc.register_worker_process()
+        qc._request_worker_memory_recycle(256 * 1024 * 1024)
+        IdleJob.perform_later(qc)
+        qc.drain_one()
+
+        assert qc._should_worker_memory_recycle_exit() is False
+    finally:
+        qc.close()
+
+
+def test_memory_recycle_timeout_allows_exit_with_claimed_job(db_url, test_prefix):
+    qc = quebec.Quebec(
+        db_url,
+        table_name_prefix=test_prefix,
+        worker_memory_graceful_timeout=0,
+    )
+    assert qc.create_tables() is True
+
+    class IdleJob(quebec.ActiveJob):
+        def perform(self, *args, **kwargs):
+            return True
+
+    try:
+        qc.register_job(IdleJob)
+        qc.register_worker_process()
+        qc._request_worker_memory_recycle(256 * 1024 * 1024)
+        IdleJob.perform_later(qc)
+        qc.drain_one()
+
+        assert qc._should_worker_memory_recycle_exit() is True
+    finally:
+        qc.close()


### PR DESCRIPTION
Adds an opt-in worker RSS soft limit. When RSS stays above the limit for N consecutive checks, the worker enters quiet mode, drains its in-flight/claimed jobs, and exits with code 75; the supervisor recognizes that code and reforks the slot without counting it as a crash. Treats the common "long-lived Python worker accumulates RSS that never falls back" pattern without resorting to hard kills.

**Config** (priority: kwargs > env var `QUEBEC_<KEY_UPPER>` > default; recycle disabled when `worker_max_rss_mb` is unset)

| Key | Env var | Default | Notes |
|-----|---------|---------|-------|
| `worker_max_rss_mb` | `QUEBEC_WORKER_MAX_RSS_MB` | — | Soft limit in MiB |
| `worker_memory_check_interval` | `QUEBEC_WORKER_MEMORY_CHECK_INTERVAL` | 5s | RSS sample tick |
| `worker_memory_graceful_timeout` | `QUEBEC_WORKER_MEMORY_GRACEFUL_TIMEOUT` | 300s | Hard deadline for the drain phase |
| `worker_memory_recycle_confirmations` | `QUEBEC_WORKER_MEMORY_RECYCLE_CONFIRMATIONS` | 3 | Hysteresis against RSS noise |

**Mechanism**
- Worker main loop runs an independent `memory_check_interval` tick (not in the claim path)
- After N over-limit samples → `ctx.quiet.cancel()` + immediate heartbeat flush; metadata gains `recycle_reason` / `rss_bytes` / `rss_mb`
- Drain check (`AppContext::worker_drained`) is shared with `should_drain_exit` so the rule lives in one place
- On drained-OR-timeout: `shutdown_worker_process` runs stop handlers, releases claims, deletes the process row, then `std::process::exit(75)`
- Supervisor decodes `wstatus`; exit code 75 routes to a planned-recycle branch that reforks without `_fail_claimed_for_pid` and without `crash_times` accumulation (crash-loop accounting moved off `spawn_times` so spawns are no longer counted as crashes)

**Drain-timeout contract**
If `worker_memory_graceful_timeout` fires with jobs still in `perform()`, the claimed rows for those in-flight jobs stay in the table while the process row is removed. `supervisor::run_maintenance`'s `find_orphaned` sweep + a restarting worker's `fail_orphaned_executions` retry them — same contract documented at `worker.rs:2569`.

**RSS source**
`sysinfo` 0.31 with `default-features = false, features = ["system"]`; one `System` instance reused per thread via `thread_local!`.

Verified: `cargo clippy --all-targets --all-features` clean; `uv run pytest --ignore=tests/step_defs` passes 180/180, including 3 new tests covering the drained / drain-waits-for-claimed-job / graceful-timeout paths, and the existing `test_supervisor_pruned_race` and `test_shutdown_release` suites that exercise the orphan-sweep contract relied on above.