### PR TITLE
feat(worker): experimental claim-time sliding-window rate limit per job class

### DIFF
--- a/python/quebec/__init__.py
+++ b/python/quebec/__init__.py
@@ -248,6 +248,22 @@ class NoNewOverrideMeta(type):
 
 
 class BaseClass(ActiveJob, metaclass=NoNewOverrideMeta):
+    def rate_limit_key(self, *args, **kwargs) -> str:
+        """Bucket key for the experimental sliding-window rate limit.
+
+        Default returns the class name (one bucket per class). Override on
+        the subclass to partition by dimension (region, tenant, etc.):
+
+            def rate_limit_key(self, *args, region="us", **kwargs):
+                return f"stripe:{region}"
+
+        Called at claim time on a fresh ActiveJob instance, with the
+        original perform args/kwargs. Unlike ``concurrency_key`` the
+        result is NOT snapshotted into the jobs row — changing this method
+        reroutes in-flight jobs immediately.
+        """
+        return type(self).__name__
+
     @classmethod
     def build(cls, *args, **kwargs) -> "JobDescriptor":
         """Create a JobDescriptor for bulk enqueue via perform_all_later.

--- a/src/context.rs
+++ b/src/context.rs
@@ -70,6 +70,38 @@ impl ConcurrencyConflict {
     }
 }
 
+/// Rate limit conflict strategy — what to do when the sliding window is exhausted.
+#[cfg_attr(feature = "python", pyclass(eq, eq_int, from_py_object))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RateLimitConflict {
+    /// Reschedule the throttled job to a future scheduled_executions row (default).
+    #[default]
+    Reschedule = 0,
+    /// Mark the throttled job as finished without executing (dedup-style).
+    Discard = 1,
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl RateLimitConflict {
+    #[staticmethod]
+    fn reschedule() -> Self {
+        RateLimitConflict::Reschedule
+    }
+
+    #[staticmethod]
+    fn discard() -> Self {
+        RateLimitConflict::Discard
+    }
+
+    fn __repr__(&self) -> String {
+        match self {
+            RateLimitConflict::Reschedule => "RateLimitConflict.Reschedule".to_string(),
+            RateLimitConflict::Discard => "RateLimitConflict.Discard".to_string(),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct TableConfig {
     pub jobs: String,

--- a/src/context.rs
+++ b/src/context.rs
@@ -102,6 +102,15 @@ impl RateLimitConflict {
     }
 }
 
+/// Per-class sliding-window rate limit configuration captured at
+/// `register_job_class` time. Stored in `AppContext.rate_limited_classes`.
+#[derive(Debug, Clone)]
+pub struct RateLimitConfig {
+    pub max: i32,
+    pub window: chrono::Duration,
+    pub on_throttle: RateLimitConflict,
+}
+
 #[derive(Debug, Clone)]
 pub struct TableConfig {
     pub jobs: String,
@@ -380,6 +389,10 @@ pub struct AppContext {
     /// semantics may change. Use to isolate misbehaving queues during
     /// remediation. Queues not present here are unlimited.
     pub experimental_queue_concurrency: HashMap<String, i32>,
+    /// EXPERIMENTAL: per-class sliding-window rate limits. Empty means
+    /// no class declared `rate_limit_max`; the worker claim path uses
+    /// `.is_empty()` to skip the rate check path with zero overhead.
+    pub rate_limited_classes: Arc<RwLock<HashMap<String, RateLimitConfig>>>,
     pub runtime_handle: Option<Handle>,
     pub table_config: TableConfig, // Dynamic table name configuration
     /// Optional notifier for idle worker threads - when set, signals main loop to poll for new jobs
@@ -744,6 +757,7 @@ impl AppContext {
             runnables: Arc::new(RwLock::new(HashMap::new())),
             concurrency_enabled: Arc::new(RwLock::new(HashSet::new())),
             experimental_queue_concurrency: HashMap::new(),
+            rate_limited_classes: Arc::new(RwLock::new(HashMap::new())),
             runtime_handle: None,
             table_config: TableConfig::default(),
             idle_notify: Arc::new(RwLock::new(None)),
@@ -833,6 +847,7 @@ impl AppContext {
             runnables: self.runnables.clone(),
             concurrency_enabled: self.concurrency_enabled.clone(),
             experimental_queue_concurrency: self.experimental_queue_concurrency.clone(),
+            rate_limited_classes: self.rate_limited_classes.clone(),
             runtime_handle: Some(runtime_handle),
             table_config: self.table_config.clone(),
             idle_notify: Arc::new(RwLock::new(None)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,6 +191,7 @@ fn quebec(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<AsgiRequest>()?;
     m.add_class::<ConcurrencyStrategy>()?;
     m.add_class::<ConcurrencyConflict>()?;
+    m.add_class::<RateLimitConflict>()?;
     m.add_class::<RescueStrategy>()?;
     m.add_class::<RetryStrategy>()?;
     m.add_class::<DiscardStrategy>()?;

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -382,18 +382,24 @@ fn solve_retry_at(
         now_secs + ((window_secs as f64) * decay_fraction).ceil() as i64
     };
 
-    // Deterministic jitter: spread throttled jobs from the same bucket across
-    // the next window using job_id as the seed. Keeps reproductions trivial
-    // (same job → same offset) versus stochastic `rand`.
-    let jitter_secs = ((job_id.unsigned_abs() % 1000) as i64 * window_secs) / 1000;
-    let target = base_secs.saturating_add(jitter_secs);
-    // Never schedule into the past — clock skew or fast loops can push base
-    // before `now`; clamp to now + 1 so the dispatcher always has a future
-    // scheduled_at to promote against.
-    let final_secs = target.max(now_secs + 1);
+    // Deterministic sub-second jitter: spread throttled jobs from the same
+    // bucket across the next window using job_id as the seed. Keeps
+    // reproductions trivial (same job → same offset) versus stochastic `rand`.
+    //
+    // Computed in nanoseconds so the smallest supported window (1s) still
+    // produces a meaningful spread. With integer-second jitter, every
+    // throttled job at window=1s landed at the same exact second, defeating
+    // the anti-stampede goal.
+    let jitter_nanos = ((job_id.unsigned_abs() % 1000) as i64 * window_secs * 1_000_000_000) / 1000;
+    let jitter_duration = chrono::Duration::nanoseconds(jitter_nanos);
 
-    chrono::DateTime::from_timestamp(final_secs, 0)
-        .map(|dt| dt.naive_utc())
+    // Clamp base to (now, ...) — clock skew or fast loops can push base into
+    // the past before jitter is applied; make sure the dispatcher always has
+    // a future scheduled_at to promote against.
+    let base_secs = base_secs.max(now_secs + 1);
+
+    chrono::DateTime::from_timestamp(base_secs, 0)
+        .map(|dt| dt.naive_utc() + jitter_duration)
         .ok_or_else(|| DbErr::Custom("rate-limit: invalid retry_at timestamp".into()))
 }
 

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -386,12 +386,18 @@ fn solve_retry_at(
     // bucket across the next window using job_id as the seed. Keeps
     // reproductions trivial (same job → same offset) versus stochastic `rand`.
     //
-    // Computed in nanoseconds so the smallest supported window (1s) still
-    // produces a meaningful spread. With integer-second jitter, every
-    // throttled job at window=1s landed at the same exact second, defeating
-    // the anti-stampede goal.
-    let jitter_nanos = ((job_id.unsigned_abs() % 1000) as i64 * window_secs * 1_000_000_000) / 1000;
-    let jitter_duration = chrono::Duration::nanoseconds(jitter_nanos);
+    // We split into whole seconds + sub-second nanoseconds *before* scaling
+    // up to nanoseconds. The earlier `seed * window_secs * 1e9 / 1000` form
+    // overflowed i64 once `window_secs > ~9.2M` (~107d), so a legal
+    // `timedelta(days=365)` window panicked on overflow at throttle time.
+    // Splitting keeps every intermediate product within i64 for the full
+    // supported window range (≤ i32::MAX seconds).
+    let seed = (job_id.unsigned_abs() % 1000) as i64;
+    let scaled = seed * window_secs; // max ~999 * 2.1e9 = ~2.1e12, well within i64
+    let jitter_whole_secs = scaled / 1000;
+    let jitter_sub_nanos = (scaled % 1000) * 1_000_000;
+    let jitter_duration = chrono::Duration::seconds(jitter_whole_secs)
+        + chrono::Duration::nanoseconds(jitter_sub_nanos);
 
     // Clamp base to (now, ...) — clock skew or fast loops can push base into
     // the past before jitter is applied; make sure the dispatcher always has

--- a/src/semaphore.rs
+++ b/src/semaphore.rs
@@ -1,4 +1,5 @@
 use crate::context::{ConcurrencyConstraint, TableConfig};
+use chrono::NaiveDateTime;
 use sea_orm::{ConnectionTrait, DatabaseBackend, DbErr, Statement};
 
 pub async fn acquire_semaphore<C>(
@@ -273,4 +274,244 @@ where
         .await?;
 
     Ok(update_result.rows_affected() > 0)
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Sliding-window rate limiting
+// ──────────────────────────────────────────────────────────────────────
+
+/// Outcome of `try_consume_rate_token`.
+#[derive(Debug, Clone)]
+pub enum ConsumeResult {
+    Granted,
+    Throttled { retry_at: NaiveDateTime },
+}
+
+/// Try to consume one rate-limit token for `(class_name, user_key)` under
+/// a sliding-window-counter model.
+///
+/// Algorithm:
+/// 1. UPSERT the current-window row (atomic single statement) — value += 1.
+/// 2. SELECT the current and previous window values.
+/// 3. estimated = curr + prev * (1 - elapsed_fraction).
+/// 4. If estimated <= max → Granted.
+/// 5. Else compensate (UPDATE curr value -= 1) + compute retry_at by
+///    inverting the estimate formula, jittered by `job_id`.
+pub async fn try_consume_rate_token<C>(
+    db: &C,
+    table_config: &TableConfig,
+    class_name: &str,
+    user_key: &str,
+    window: chrono::Duration,
+    max: i32,
+    job_id: i64,
+) -> Result<ConsumeResult, DbErr>
+where
+    C: ConnectionTrait,
+{
+    let window_secs = window.num_seconds().max(1);
+    let now_secs = fetch_server_epoch_seconds(db).await?;
+    let window_idx = now_secs.div_euclid(window_secs);
+    let prev_idx = window_idx - 1;
+    let elapsed_in_window = now_secs - window_idx * window_secs;
+
+    let curr_key = format!("rate:{class_name}/{user_key}:{window_idx}");
+    let prev_key = format!("rate:{class_name}/{user_key}:{prev_idx}");
+
+    let window_end_secs = (window_idx + 1) * window_secs;
+    // Keep curr row alive one extra window after window_end so the *next*
+    // window can read it as `prev` before dispatcher.delete_expired sweeps it.
+    let row_expires_secs = (window_idx + 2) * window_secs;
+    let expires_at = chrono::DateTime::from_timestamp(row_expires_secs, 0)
+        .map(|dt| dt.naive_utc())
+        .ok_or_else(|| DbErr::Custom("rate-limit: invalid expires_at timestamp".into()))?;
+    let now_naive = chrono::DateTime::from_timestamp(now_secs, 0)
+        .map(|dt| dt.naive_utc())
+        .ok_or_else(|| DbErr::Custom("rate-limit: invalid now timestamp".into()))?;
+
+    upsert_increment(db, table_config, &curr_key, expires_at, now_naive).await?;
+
+    let (curr_value_opt, prev_value_opt) =
+        fetch_two_counts(db, table_config, &curr_key, &prev_key).await?;
+    let curr_value = curr_value_opt.unwrap_or(0);
+    let prev_value = prev_value_opt.unwrap_or(0);
+
+    let elapsed_fraction = (elapsed_in_window as f64) / (window_secs as f64);
+    let estimated = (curr_value as f64) + (prev_value as f64) * (1.0 - elapsed_fraction);
+
+    if estimated <= max as f64 {
+        return Ok(ConsumeResult::Granted);
+    }
+
+    // Over the limit — compensate the speculative increment, then compute when
+    // the bucket would naturally drop below `max` if no further consumes happen.
+    decrement_unchecked(db, table_config, &curr_key).await?;
+
+    let retry_at = solve_retry_at(
+        estimated,
+        prev_value,
+        max,
+        now_secs,
+        window_secs,
+        window_end_secs,
+        job_id,
+    )?;
+    Ok(ConsumeResult::Throttled { retry_at })
+}
+
+/// Invert the sliding-window estimate equation to find the earliest second
+/// at which `estimated(t) <= max` (assuming no new consumes).
+///
+/// When `prev_value == 0` the current window holds all the load and the
+/// soonest recovery is window_end (where prev becomes whatever curr is now,
+/// but the sliding decay then starts over from there).
+fn solve_retry_at(
+    estimated: f64,
+    prev_value: i32,
+    max: i32,
+    now_secs: i64,
+    window_secs: i64,
+    window_end_secs: i64,
+    job_id: i64,
+) -> Result<NaiveDateTime, DbErr> {
+    let base_secs: i64 = if prev_value <= 0 {
+        window_end_secs
+    } else {
+        let needed_decay = (estimated - max as f64).max(0.0);
+        let decay_fraction = (needed_decay / prev_value as f64).clamp(0.0, 1.0);
+        now_secs + ((window_secs as f64) * decay_fraction).ceil() as i64
+    };
+
+    // Deterministic jitter: spread throttled jobs from the same bucket across
+    // the next window using job_id as the seed. Keeps reproductions trivial
+    // (same job → same offset) versus stochastic `rand`.
+    let jitter_secs = ((job_id.unsigned_abs() % 1000) as i64 * window_secs) / 1000;
+    let target = base_secs.saturating_add(jitter_secs);
+    // Never schedule into the past — clock skew or fast loops can push base
+    // before `now`; clamp to now + 1 so the dispatcher always has a future
+    // scheduled_at to promote against.
+    let final_secs = target.max(now_secs + 1);
+
+    chrono::DateTime::from_timestamp(final_secs, 0)
+        .map(|dt| dt.naive_utc())
+        .ok_or_else(|| DbErr::Custom("rate-limit: invalid retry_at timestamp".into()))
+}
+
+async fn fetch_server_epoch_seconds<C>(db: &C) -> Result<i64, DbErr>
+where
+    C: ConnectionTrait,
+{
+    let backend = db.get_database_backend();
+    let sql = match backend {
+        DatabaseBackend::Postgres => "SELECT EXTRACT(EPOCH FROM NOW())::BIGINT AS now_secs",
+        DatabaseBackend::MySql => "SELECT UNIX_TIMESTAMP() AS now_secs",
+        DatabaseBackend::Sqlite => "SELECT CAST(strftime('%s','now') AS INTEGER) AS now_secs",
+    };
+    let row = db
+        .query_one(Statement::from_string(backend, sql.to_owned()))
+        .await?
+        .ok_or_else(|| DbErr::Custom("rate-limit: server clock query returned no rows".into()))?;
+    row.try_get::<i64>("", "now_secs")
+}
+
+async fn upsert_increment<C>(
+    db: &C,
+    table_config: &TableConfig,
+    key: &str,
+    expires_at: NaiveDateTime,
+    now: NaiveDateTime,
+) -> Result<(), DbErr>
+where
+    C: ConnectionTrait,
+{
+    let backend = db.get_database_backend();
+    let table = &table_config.semaphores;
+    let sql = match backend {
+        DatabaseBackend::Postgres => format!(
+            "INSERT INTO {table} (key, value, expires_at, created_at, updated_at) \
+             VALUES ($1, 1, $2, $3, $3) \
+             ON CONFLICT (key) DO UPDATE SET value = {table}.value + 1, updated_at = $3"
+        ),
+        DatabaseBackend::Sqlite => format!(
+            "INSERT INTO {table} (key, value, expires_at, created_at, updated_at) \
+             VALUES (?, 1, ?, ?, ?) \
+             ON CONFLICT(key) DO UPDATE SET value = value + 1, updated_at = excluded.updated_at"
+        ),
+        DatabaseBackend::MySql => format!(
+            "INSERT INTO {table} (key, value, expires_at, created_at, updated_at) \
+             VALUES (?, 1, ?, ?, ?) \
+             ON DUPLICATE KEY UPDATE value = value + 1, updated_at = VALUES(updated_at)"
+        ),
+    };
+    let values: Vec<sea_orm::Value> = match backend {
+        DatabaseBackend::Postgres => vec![key.into(), expires_at.into(), now.into()],
+        DatabaseBackend::Sqlite | DatabaseBackend::MySql => {
+            vec![key.into(), expires_at.into(), now.into(), now.into()]
+        }
+    };
+    db.execute(Statement::from_sql_and_values(backend, sql, values))
+        .await?;
+    Ok(())
+}
+
+async fn fetch_two_counts<C>(
+    db: &C,
+    table_config: &TableConfig,
+    curr_key: &str,
+    prev_key: &str,
+) -> Result<(Option<i32>, Option<i32>), DbErr>
+where
+    C: ConnectionTrait,
+{
+    let backend = db.get_database_backend();
+    let table = &table_config.semaphores;
+    let sql = match backend {
+        DatabaseBackend::Postgres => {
+            format!("SELECT key, value FROM {table} WHERE key IN ($1, $2)")
+        }
+        DatabaseBackend::Sqlite | DatabaseBackend::MySql => {
+            format!("SELECT key, value FROM {table} WHERE key IN (?, ?)")
+        }
+    };
+    let rows = db
+        .query_all(Statement::from_sql_and_values(
+            backend,
+            sql,
+            vec![curr_key.into(), prev_key.into()],
+        ))
+        .await?;
+    let (mut curr, mut prev) = (None, None);
+    for row in rows {
+        let k: String = row.try_get("", "key")?;
+        let v: i32 = row.try_get("", "value")?;
+        if k == curr_key {
+            curr = Some(v);
+        } else if k == prev_key {
+            prev = Some(v);
+        }
+    }
+    Ok((curr, prev))
+}
+
+/// UPDATE value = value - 1 without bounds check — only used by the rate-limit
+/// compensating path immediately after a speculative UPSERT increment.
+async fn decrement_unchecked<C>(db: &C, table_config: &TableConfig, key: &str) -> Result<(), DbErr>
+where
+    C: ConnectionTrait,
+{
+    let backend = db.get_database_backend();
+    let table = &table_config.semaphores;
+    let sql = match backend {
+        DatabaseBackend::Postgres => format!("UPDATE {table} SET value = value - 1 WHERE key = $1"),
+        DatabaseBackend::Sqlite | DatabaseBackend::MySql => {
+            format!("UPDATE {table} SET value = value - 1 WHERE key = ?")
+        }
+    };
+    db.execute(Statement::from_sql_and_values(
+        backend,
+        sql,
+        vec![key.into()],
+    ))
+    .await?;
+    Ok(())
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -2200,6 +2200,29 @@ impl PyQuebec {
         Ok(format!("Quebec(url={})", self.url))
     }
 
+    /// Debug accessor — returns the rate limit config for a registered class
+    /// as a dict, or None when the class did not declare `rate_limit_max`.
+    #[pyo3(name = "_rate_limit_config_for")]
+    fn rate_limit_config_for<'py>(
+        &self,
+        py: Python<'py>,
+        class_name: String,
+    ) -> PyResult<Option<Bound<'py, PyDict>>> {
+        let registry = self.worker.ctx.rate_limited_classes.read().map_err(|_| {
+            pyo3::exceptions::PyRuntimeError::new_err("rate_limited_classes RwLock poisoned")
+        })?;
+        match registry.get(&class_name) {
+            None => Ok(None),
+            Some(cfg) => {
+                let dict = PyDict::new(py);
+                dict.set_item("max", cfg.max)?;
+                dict.set_item("window_seconds", cfg.window.num_seconds())?;
+                dict.set_item("on_throttle", cfg.on_throttle)?;
+                Ok(Some(dict))
+            }
+        }
+    }
+
     // implment a decorator to register job class
     fn register_job(&self, py: Python, job_class: Py<PyAny>) -> PyResult<Py<PyAny>> {
         let dup = job_class.clone();

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -2198,6 +2198,12 @@ impl Worker {
                     let duration = runnable
                         .concurrency_duration
                         .map(|s| chrono::Duration::seconds(s as i64));
+                    // Propagate release errors (lock timeout, conn drop, ...)
+                    // so the whole rate-routed transaction rolls back. The
+                    // ready-delete + scheduled-insert / mark_finished writes
+                    // above MUST stay consistent with the semaphore state —
+                    // a silently-failed release would re-create the very slot
+                    // leak this code path was added to prevent.
                     let released = crate::semaphore::release_semaphore(
                         txn,
                         table_config,
@@ -2205,18 +2211,12 @@ impl Worker {
                         limit,
                         duration,
                     )
-                    .await
-                    .inspect_err(|e| {
-                        warn!(
-                            jid = job.active_job_id.as_deref(),
-                            concurrency_key = key,
-                            "rate-limit: failed to release concurrency semaphore: {:?}",
-                            e
-                        )
-                    })
-                    .unwrap_or(false);
+                    .await?;
 
                     if released {
+                        // Promoting one blocked job is an optimization (dispatcher's
+                        // periodic sweep also handles blocked→ready); keep it
+                        // best-effort so it can't poison the rate-route txn.
                         Self::release_next_blocked_job(ctx, txn, key, limit)
                             .await
                             .inspect_err(|e| {
@@ -3255,7 +3255,13 @@ impl Worker {
             return Ok(());
         };
         let duration = chrono::Duration::from_std(ctx.default_concurrency_control_period).ok();
-        let _ = release_semaphore(
+        // Propagate failures: callers already `.await?` this helper, expecting
+        // a release failure to abort the enclosing tx. Silently swallowing the
+        // DbErr would leave the slot accounted as held in `solid_queue_semaphores`
+        // while the caller's state change (claimed deleted, ready re-inserted,
+        // scheduled inserted, etc.) commits — the exact slot-leak class of bug
+        // we already saw reintroduced through every claim/throttle path.
+        release_semaphore(
             db,
             table_config,
             format!("queue:{}", queue_name),
@@ -3263,7 +3269,7 @@ impl Worker {
             duration,
         )
         .await
-        .inspect_err(|e| warn!("Failed to release queue:{} semaphore: {:?}", queue_name, e));
+        .inspect_err(|e| warn!("Failed to release queue:{} semaphore: {:?}", queue_name, e))?;
         Ok(())
     }
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -71,6 +71,17 @@ pub struct HookFlags {
     pub after_discard: bool,
 }
 
+/// Outcome of `Worker::try_consume_rate_for_candidate`.
+#[derive(Debug, Clone, Copy)]
+enum RateGateResult {
+    /// The candidate may proceed to claim.
+    Granted,
+    /// The candidate has been removed from `ready_executions` and routed
+    /// (rescheduled or marked finished). The caller must skip to the next
+    /// candidate.
+    Routed,
+}
+
 #[pyclass(name = "Runnable", subclass)]
 #[derive(Debug)]
 pub struct Runnable {
@@ -264,6 +275,76 @@ impl Runnable {
             }))
         })
         .map_err(|e: PyErr| QuebecError::Python(format!("get_concurrency_constraint: {e}")))
+    }
+
+    /// Call the Python instance's `rate_limit_key(*args, **kwargs)` method.
+    /// `arguments_json` is the raw `jobs.arguments` column (a Solid-Queue-style
+    /// envelope `{ "arguments": [...], ... }`). Falls back to the class name
+    /// if the method is missing for any reason — defensive only, since
+    /// `BaseClass` always provides a default.
+    pub fn compute_rate_limit_key(&self, arguments_json: &str) -> Result<String> {
+        Python::attach(|py| -> PyResult<String> {
+            let bound = self.handler.bind(py);
+            let instance = bound.call0()?;
+
+            if !instance.hasattr("rate_limit_key")? {
+                return Ok(self.class_name.clone());
+            }
+            let attr = instance.getattr("rate_limit_key")?;
+            if !attr.is_callable() {
+                return Ok(self.class_name.clone());
+            }
+
+            // Decode the args envelope. Tolerate any shape — bad JSON or
+            // missing "arguments" just means call with empty args.
+            let parsed: serde_json::Value =
+                serde_json::from_str(arguments_json).unwrap_or(serde_json::Value::Null);
+            let args_array = match &parsed {
+                serde_json::Value::Object(o) => match o.get("arguments") {
+                    Some(serde_json::Value::Array(arr)) => arr.clone(),
+                    _ => Vec::new(),
+                },
+                serde_json::Value::Array(arr) => arr.clone(),
+                _ => Vec::new(),
+            };
+
+            // Split off `_quebec_kwargs` marker dict at tail (mirrors
+            // parse_job_arguments_from_json on the Execution side).
+            let (positional, kwargs_map): (Vec<serde_json::Value>, Option<serde_json::Map<_, _>>) =
+                match args_array.last() {
+                    Some(serde_json::Value::Object(obj)) if obj.contains_key("_quebec_kwargs") => {
+                        let mut p = args_array.clone();
+                        p.pop();
+                        let mut kw = obj.clone();
+                        kw.remove("_quebec_kwargs");
+                        kw.remove("_aj_symbol_keys");
+                        (p, Some(kw))
+                    }
+                    _ => (args_array, None),
+                };
+
+            let py_list = pyo3::types::PyList::empty(py);
+            for v in &positional {
+                py_list.append(json_to_py(py, v)?)?;
+            }
+            let py_args = pyo3::types::PyTuple::new(py, py_list.iter())?;
+
+            let py_kwargs = pyo3::types::PyDict::new(py);
+            if let Some(kw) = kwargs_map {
+                for (k, v) in kw {
+                    py_kwargs.set_item(k, json_to_py(py, &v)?)?;
+                }
+            }
+
+            let result = attr.call(py_args, Some(&py_kwargs))?;
+            let s: String = result.extract()?;
+            if s.is_empty() {
+                Ok(self.class_name.clone())
+            } else {
+                Ok(s)
+            }
+        })
+        .map_err(|e: PyErr| QuebecError::Python(format!("compute_rate_limit_key: {e}")))
     }
 
     /// Check if should retry, return matching retry strategy and its exception key.
@@ -1982,6 +2063,99 @@ impl Worker {
         })
     }
 
+    /// EXPERIMENTAL: sliding-window rate-limit gate.
+    /// Called between picking a ready row and inserting claimed_executions
+    /// (only when at least one class has declared `rate_limit_max`).
+    ///
+    /// Returns `Granted` when the candidate may proceed to claim, or `Routed`
+    /// when the candidate has been removed from `ready_executions` and either
+    /// rescheduled (default) or marked finished (Discard mode). The caller
+    /// should `continue` on `Routed` and re-find the next candidate.
+    async fn try_consume_rate_for_candidate<C: ConnectionTrait>(
+        ctx: &Arc<crate::context::AppContext>,
+        txn: &C,
+        table_config: &crate::context::TableConfig,
+        execution: &quebec_ready_executions::Model,
+    ) -> std::result::Result<RateGateResult, DbErr> {
+        let job = query_builder::jobs::find_by_id(txn, table_config, execution.job_id).await?;
+        let Some(job) = job else {
+            // Ready row pointing at a vanished job — let the normal claim
+            // flow handle it (it will fail downstream and surface the bug).
+            return Ok(RateGateResult::Granted);
+        };
+
+        let cfg = {
+            let reg = ctx
+                .rate_limited_classes
+                .read()
+                .map_err(|_| DbErr::Custom("rate_limited_classes RwLock poisoned".into()))?;
+            reg.get(&job.class_name).cloned()
+        };
+        let Some(cfg) = cfg else {
+            return Ok(RateGateResult::Granted);
+        };
+
+        let runnable = ctx.get_runnable(&job.class_name).map_err(|e| {
+            DbErr::Custom(format!(
+                "rate-limit: get_runnable({}) failed: {e}",
+                job.class_name
+            ))
+        })?;
+        let arguments = job.arguments.clone().unwrap_or_default();
+        let user_key = runnable
+            .compute_rate_limit_key(&arguments)
+            .map_err(|e| DbErr::Custom(format!("rate-limit: {e}")))?;
+
+        let result = crate::semaphore::try_consume_rate_token(
+            txn,
+            table_config,
+            &job.class_name,
+            &user_key,
+            cfg.window,
+            cfg.max,
+            job.id,
+        )
+        .await?;
+
+        match result {
+            crate::semaphore::ConsumeResult::Granted => Ok(RateGateResult::Granted),
+            crate::semaphore::ConsumeResult::Throttled { retry_at } => {
+                query_builder::ready_executions::delete_by_id(txn, table_config, execution.id)
+                    .await?;
+                match cfg.on_throttle {
+                    crate::context::RateLimitConflict::Reschedule => {
+                        debug!(
+                            jid = job.active_job_id.as_deref(),
+                            class = job.class_name,
+                            user_key = user_key,
+                            retry_at = ?retry_at,
+                            "rate-limit: throttled, rescheduling"
+                        );
+                        query_builder::scheduled_executions::insert(
+                            txn,
+                            table_config,
+                            job.id,
+                            &job.queue_name,
+                            job.priority,
+                            retry_at,
+                        )
+                        .await?;
+                    }
+                    crate::context::RateLimitConflict::Discard => {
+                        debug!(
+                            jid = job.active_job_id.as_deref(),
+                            class = job.class_name,
+                            user_key = user_key,
+                            "rate-limit: throttled, discarding"
+                        );
+                        query_builder::jobs::mark_finished(txn, table_config, job.id).await?;
+                    }
+                }
+                Ok(RateGateResult::Routed)
+            }
+        }
+    }
+
     /// Helper: claim a single execution (insert claimed, delete ready, return model)
     async fn claim_execution<C: ConnectionTrait>(
         txn: &C,
@@ -2040,6 +2214,15 @@ impl Worker {
                     // entirely so feature-off workers pay zero overhead
                     // beyond a single `is_empty()` check per claim.
                     let queue_concurrency_enabled = !ctx.experimental_queue_concurrency.is_empty();
+                    // EXPERIMENTAL: per-class sliding-window rate limit.
+                    // Same zero-overhead pattern: when no class declared
+                    // `rate_limit_max`, the entire rate gate is skipped
+                    // (one `is_empty()` check per claim).
+                    let rate_limit_enabled = ctx
+                        .rate_limited_classes
+                        .read()
+                        .map(|r| !r.is_empty())
+                        .unwrap_or(false);
 
                     // For queues listed in `experimental_queue_concurrency`,
                     // attempt the `queue:<name>` semaphore between find and
@@ -2077,6 +2260,20 @@ impl Worker {
                                     if !acquired {
                                         local_throttled.push(execution.queue_name.clone());
                                         continue;
+                                    }
+                                }
+
+                                if rate_limit_enabled {
+                                    match Self::try_consume_rate_for_candidate(
+                                        &ctx,
+                                        txn,
+                                        &table_config,
+                                        execution,
+                                    )
+                                    .await?
+                                    {
+                                        RateGateResult::Granted => {}
+                                        RateGateResult::Routed => continue,
                                     }
                                 }
 
@@ -2167,6 +2364,13 @@ impl Worker {
                     // acquire path entirely so feature-off workers pay zero
                     // overhead beyond a single `is_empty()` check per claim.
                     let queue_concurrency_enabled = !ctx.experimental_queue_concurrency.is_empty();
+                    // EXPERIMENTAL: same zero-overhead pattern for the
+                    // sliding-window rate gate.
+                    let rate_limit_enabled = ctx
+                        .rate_limited_classes
+                        .read()
+                        .map(|r| !r.is_empty())
+                        .unwrap_or(false);
 
                     // Helper macro to claim jobs from a queue (batch insert + batch delete).
                     // EXPERIMENTAL: when `experimental_queue_concurrency` is
@@ -2216,26 +2420,41 @@ impl Worker {
                                 let exhausted = (records.len() as u64) < requested;
 
                                 let mut accepted: Vec<&quebec_ready_executions::Model> = Vec::new();
-                                if !queue_concurrency_enabled {
-                                    // Feature disabled: accept every found
-                                    // record verbatim — no per-record
+                                if !queue_concurrency_enabled && !rate_limit_enabled {
+                                    // Both feature flags off: accept every
+                                    // found record verbatim — no per-record
                                     // HashMap lookup, no async helper call.
                                     accepted.extend(records.iter());
                                 } else {
                                     for record in &records {
-                                        if local_throttled.contains(&record.queue_name) {
-                                            continue;
+                                        if queue_concurrency_enabled {
+                                            if local_throttled.contains(&record.queue_name) {
+                                                continue;
+                                            }
+                                            let acquired = Self::try_acquire_queue_slot(
+                                                &ctx,
+                                                txn,
+                                                &table_config,
+                                                &record.queue_name,
+                                            )
+                                            .await?;
+                                            if !acquired {
+                                                local_throttled.insert(record.queue_name.clone());
+                                                continue;
+                                            }
                                         }
-                                        let acquired = Self::try_acquire_queue_slot(
-                                            &ctx,
-                                            txn,
-                                            &table_config,
-                                            &record.queue_name,
-                                        )
-                                        .await?;
-                                        if !acquired {
-                                            local_throttled.insert(record.queue_name.clone());
-                                            continue;
+                                        if rate_limit_enabled {
+                                            match Self::try_consume_rate_for_candidate(
+                                                &ctx,
+                                                txn,
+                                                &table_config,
+                                                record,
+                                            )
+                                            .await?
+                                            {
+                                                RateGateResult::Granted => {}
+                                                RateGateResult::Routed => continue,
+                                            }
                                         }
                                         accepted.push(record);
                                     }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -347,12 +347,23 @@ impl Runnable {
                 }
             }
 
-            let result = attr.call(py_args, Some(&py_kwargs))?;
-            let s: String = result.extract()?;
-            if s.is_empty() {
-                Ok(self.class_name.clone())
-            } else {
-                Ok(s)
+            // Fall back to class name on any user-side failure (raise,
+            // non-str, None). Surfacing PyErr would bounce the claim_job tx
+            // and leave the candidate spinning in ready until the user fixes
+            // their code.
+            match attr
+                .call(py_args, Some(&py_kwargs))
+                .and_then(|r| r.extract::<String>())
+            {
+                Ok(s) if !s.is_empty() => Ok(s),
+                Ok(_) => Ok(self.class_name.clone()),
+                Err(e) => {
+                    warn!(
+                        class = self.class_name,
+                        "rate_limit_key failed ({e}); using class name as bucket"
+                    );
+                    Ok(self.class_name.clone())
+                }
             }
         })
         .map_err(|e: PyErr| QuebecError::Python(format!("compute_rate_limit_key: {e}")))
@@ -1972,6 +1983,15 @@ impl Worker {
                     )));
                 }
                 let td = bound.getattr("rate_limit_window")?;
+                // Type-check upfront so users get a clear error instead of
+                // the cryptic `AttributeError: 'int' object has no attribute
+                // 'total_seconds'` that surfaces if any non-timedelta is set.
+                if !td.is_instance_of::<pyo3::types::PyDelta>() {
+                    return Err(pyo3::exceptions::PyTypeError::new_err(format!(
+                        "{class_name}: rate_limit_window must be a datetime.timedelta, got {}",
+                        td.get_type().qualname()?
+                    )));
+                }
                 let total: f64 = td.call_method0("total_seconds")?.extract()?;
                 if total < 1.0 {
                     return Err(pyo3::exceptions::PyValueError::new_err(format!(

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -297,14 +297,25 @@ impl Runnable {
 
             // Decode the args envelope. Tolerate any shape — bad JSON or
             // missing "arguments" just means call with empty args.
-            let parsed: serde_json::Value =
-                serde_json::from_str(arguments_json).unwrap_or(serde_json::Value::Null);
-            let args_array = match &parsed {
-                serde_json::Value::Object(o) => match o.get("arguments") {
-                    Some(serde_json::Value::Array(arr)) => arr.clone(),
-                    _ => Vec::new(),
-                },
-                serde_json::Value::Array(arr) => arr.clone(),
+            //
+            // Solid Queue / Quebec wraps the args dict more than once
+            // depending on the enqueue path (perform_later vs scheduler);
+            // mirror Execution::parse_job_arguments_from_json (worker.rs:634)
+            // and walk nested `arguments` keys until we reach the Array.
+            let mut v = serde_json::from_str::<serde_json::Value>(arguments_json)
+                .unwrap_or(serde_json::Value::Null);
+            while let serde_json::Value::Object(ref o) = v {
+                match o.get("arguments") {
+                    Some(serde_json::Value::Array(_)) => {
+                        v = o["arguments"].clone();
+                        break;
+                    }
+                    Some(serde_json::Value::Object(_)) => v = o["arguments"].clone(),
+                    _ => break,
+                }
+            }
+            let args_array = match v {
+                serde_json::Value::Array(arr) => arr,
                 _ => Vec::new(),
             };
 
@@ -2192,8 +2203,13 @@ impl Worker {
         // `after_executed` (or the cleanup paths) via `release_queue_slot`.
         let ctx = self.ctx.clone();
 
+        // Return Option here (not Err) so any rate-throttle side-effects
+        // (DELETE ready + INSERT scheduled / mark_finished) inside the tx
+        // commit even when no candidate was successfully claimed. The
+        // pre-existing "No ready job to claim" error is re-raised at the
+        // outer level.
         let job = db
-            .transaction::<_, quebec_claimed_executions::Model, DbErr>(|txn| {
+            .transaction::<_, Option<quebec_claimed_executions::Model>, DbErr>(|txn| {
                 let table_config = table_config.clone();
                 let ctx = ctx.clone();
                 Box::pin(async move {
@@ -2281,7 +2297,7 @@ impl Worker {
                                     Self::claim_execution(txn, &table_config, execution, process_id)
                                         .await?
                                 {
-                                    return Ok(claimed);
+                                    return Ok(Some(claimed));
                                 }
                                 break;
                             }
@@ -2316,10 +2332,11 @@ impl Worker {
                         }
                     }
 
-                    Err(DbErr::Custom("No job found".into()))
+                    Ok(None)
                 })
             })
-            .await?;
+            .await?
+            .ok_or_else(|| QuebecError::Database(DbErr::Custom("No job found".into())))?;
 
         Ok(job)
     }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -2058,16 +2058,25 @@ impl Worker {
             // Mirror rate limit config into the AppContext registry so the
             // worker claim path can `.is_empty()` short-circuit when no
             // class uses the feature.
-            if let (Some(max), Some(win_secs)) = (rate_limit_max, rate_limit_window_seconds) {
-                if let Ok(mut reg) = self.ctx.rate_limited_classes.write() {
-                    reg.insert(
-                        class_name.to_string(),
-                        crate::context::RateLimitConfig {
-                            max,
-                            window: chrono::Duration::seconds(win_secs as i64),
-                            on_throttle: rate_limit_on_throttle,
-                        },
-                    );
+            //
+            // Re-registration of the same class without `rate_limit_max` must
+            // also clear any stale config — otherwise the prior config keeps
+            // throttling silently in long-lived processes / test reuse.
+            if let Ok(mut reg) = self.ctx.rate_limited_classes.write() {
+                match (rate_limit_max, rate_limit_window_seconds) {
+                    (Some(max), Some(win_secs)) => {
+                        reg.insert(
+                            class_name.to_string(),
+                            crate::context::RateLimitConfig {
+                                max,
+                                window: chrono::Duration::seconds(win_secs as i64),
+                                on_throttle: rate_limit_on_throttle,
+                            },
+                        );
+                    }
+                    _ => {
+                        reg.remove(&class_name.to_string());
+                    }
                 }
             }
             Ok(())
@@ -2265,6 +2274,7 @@ impl Worker {
                                 .await?;
                                 let Some(ref execution) = record else { break };
 
+                                let mut queue_slot_held = false;
                                 if queue_concurrency_enabled {
                                     let acquired = Self::try_acquire_queue_slot(
                                         &ctx,
@@ -2277,6 +2287,7 @@ impl Worker {
                                         local_throttled.push(execution.queue_name.clone());
                                         continue;
                                     }
+                                    queue_slot_held = true;
                                 }
 
                                 if rate_limit_enabled {
@@ -2289,7 +2300,25 @@ impl Worker {
                                     .await?
                                     {
                                         RateGateResult::Granted => {}
-                                        RateGateResult::Routed => continue,
+                                        RateGateResult::Routed => {
+                                            // Job left ready_executions (moved
+                                            // to scheduled / mark_finished),
+                                            // so it will never reach
+                                            // `after_executed` to release the
+                                            // queue slot we just took.
+                                            // Release here, otherwise the
+                                            // slot leaks until the TTL sweep.
+                                            if queue_slot_held {
+                                                Self::release_queue_slot(
+                                                    &ctx,
+                                                    txn,
+                                                    &table_config,
+                                                    &execution.queue_name,
+                                                )
+                                                .await?;
+                                            }
+                                            continue;
+                                        }
                                     }
                                 }
 
@@ -2444,6 +2473,7 @@ impl Worker {
                                     accepted.extend(records.iter());
                                 } else {
                                     for record in &records {
+                                        let mut queue_slot_held = false;
                                         if queue_concurrency_enabled {
                                             if local_throttled.contains(&record.queue_name) {
                                                 continue;
@@ -2459,6 +2489,7 @@ impl Worker {
                                                 local_throttled.insert(record.queue_name.clone());
                                                 continue;
                                             }
+                                            queue_slot_held = true;
                                         }
                                         if rate_limit_enabled {
                                             match Self::try_consume_rate_for_candidate(
@@ -2470,7 +2501,24 @@ impl Worker {
                                             .await?
                                             {
                                                 RateGateResult::Granted => {}
-                                                RateGateResult::Routed => continue,
+                                                RateGateResult::Routed => {
+                                                    // Release the queue slot
+                                                    // taken just above — the
+                                                    // job moved out of
+                                                    // ready_executions so
+                                                    // `after_executed` never
+                                                    // fires for it.
+                                                    if queue_slot_held {
+                                                        Self::release_queue_slot(
+                                                            &ctx,
+                                                            txn,
+                                                            &table_config,
+                                                            &record.queue_name,
+                                                        )
+                                                        .await?;
+                                                    }
+                                                    continue;
+                                                }
                                             }
                                         }
                                         accepted.push(record);

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -2183,6 +2183,53 @@ impl Worker {
                         query_builder::jobs::mark_finished(txn, table_config, job.id).await?;
                     }
                 }
+                // Release the class-level concurrency_key semaphore (if any).
+                // Without this, a rate-rescheduled job stays "in flight" from
+                // concurrency_key's perspective even though it's no longer in
+                // ready_executions — the next scheduled→ready promotion would
+                // try to re-acquire the slot the job already holds and route
+                // it to blocked_executions until concurrency_duration TTL.
+                // For Discard, the slot would stay held for a finished job
+                // until TTL. Mirrors after_executed (worker.rs around the
+                // release_semaphore call) so concurrency accounting stays
+                // consistent across both code paths.
+                if let Some(key) = job.concurrency_key.as_deref().filter(|k| !k.is_empty()) {
+                    let limit = runnable.concurrency_limit.unwrap_or(1);
+                    let duration = runnable
+                        .concurrency_duration
+                        .map(|s| chrono::Duration::seconds(s as i64));
+                    let released = crate::semaphore::release_semaphore(
+                        txn,
+                        table_config,
+                        key.to_string(),
+                        limit,
+                        duration,
+                    )
+                    .await
+                    .inspect_err(|e| {
+                        warn!(
+                            jid = job.active_job_id.as_deref(),
+                            concurrency_key = key,
+                            "rate-limit: failed to release concurrency semaphore: {:?}",
+                            e
+                        )
+                    })
+                    .unwrap_or(false);
+
+                    if released {
+                        Self::release_next_blocked_job(ctx, txn, key, limit)
+                            .await
+                            .inspect_err(|e| {
+                                warn!(
+                                    jid = job.active_job_id.as_deref(),
+                                    concurrency_key = key,
+                                    "rate-limit: failed to release next blocked: {:?}",
+                                    e
+                                )
+                            })
+                            .ok();
+                    }
+                }
                 Ok(RateGateResult::Routed)
             }
         }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1985,6 +1985,18 @@ impl Worker {
                         "{class_name}: rate_limit_window too large, got {total}s"
                     )));
                 }
+                // The sliding-window math operates in integer seconds (window
+                // bucket index = floor(epoch / window_secs)). Silently truncating
+                // 1.9s → 1s would loosen the limit by ~50%, so refuse instead of
+                // guessing whether the user wanted floor/ceil/round.
+                if total.fract().abs() > f64::EPSILON {
+                    return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                        "{class_name}: rate_limit_window must be a whole number \
+                         of seconds, got {total}s. The sliding-window algorithm \
+                         operates in 1-second buckets — fractional windows would \
+                         be silently rounded."
+                    )));
+                }
                 rate_limit_window_seconds = Some(total as i32);
 
                 if bound.hasattr("rate_limit_on_throttle")? {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -86,6 +86,12 @@ pub struct Runnable {
     /// Continuation info for interrupted jobs (step name, cursor, original args)
     pub(crate) continuation_info: Option<ContinuationInfo>,
     pub hooks: HookFlags,
+    /// Experimental sliding-window rate limit. `rate_limit_max.is_some()` is
+    /// the discriminator — when None, the claim path's `rate_limit_enabled`
+    /// gate short-circuits without ever calling into this struct.
+    pub rate_limit_max: Option<i32>,
+    pub rate_limit_window_seconds: Option<i32>,
+    pub rate_limit_on_throttle: crate::context::RateLimitConflict,
 }
 
 #[derive(Debug, Clone)]
@@ -115,6 +121,9 @@ impl Runnable {
             concurrency_on_conflict: ConcurrencyConflict::default(),
             continuation_info: None,
             hooks: HookFlags::default(),
+            rate_limit_max: None,
+            rate_limit_window_seconds: None,
+            rate_limit_on_throttle: crate::context::RateLimitConflict::default(),
         }
     }
 
@@ -132,6 +141,9 @@ impl Runnable {
             concurrency_on_conflict: self.concurrency_on_conflict,
             continuation_info: self.continuation_info.clone(),
             hooks: self.hooks.clone(),
+            rate_limit_max: self.rate_limit_max,
+            rate_limit_window_seconds: self.rate_limit_window_seconds,
+            rate_limit_on_throttle: self.rate_limit_on_throttle,
         }
     }
 
@@ -1838,6 +1850,66 @@ impl Worker {
                 )));
             }
 
+            // Extract rate_limit_* declarations (optional). `rate_limit_max`
+            // is the discriminator — when None, the entire feature is off
+            // for this class.
+            let mut rate_limit_max: Option<i32> = None;
+            let mut rate_limit_window_seconds: Option<i32> = None;
+            let mut rate_limit_on_throttle = crate::context::RateLimitConflict::default();
+
+            if bound.hasattr("rate_limit_max")? {
+                let attr = bound.getattr("rate_limit_max")?;
+                if !attr.is_none() {
+                    let max = attr.extract::<i32>()?;
+                    if max <= 0 {
+                        return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                            "{class_name}: rate_limit_max must be positive, got {max}"
+                        )));
+                    }
+                    rate_limit_max = Some(max);
+                }
+            }
+
+            if rate_limit_max.is_some() {
+                if !bound.hasattr("rate_limit_window")? {
+                    return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                        "{class_name}: rate_limit_max is set but \
+                         `rate_limit_window` is missing — declare \
+                         `rate_limit_window = timedelta(seconds=N)` (N >= 1) \
+                         on the class."
+                    )));
+                }
+                let td = bound.getattr("rate_limit_window")?;
+                let total: f64 = td.call_method0("total_seconds")?.extract()?;
+                if total < 1.0 {
+                    return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                        "{class_name}: rate_limit_window must be >= 1 second, \
+                         got {total}s. Sub-second windows make jitter and \
+                         retry_at solver precision insufficient."
+                    )));
+                }
+                if total > i32::MAX as f64 {
+                    return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                        "{class_name}: rate_limit_window too large, got {total}s"
+                    )));
+                }
+                rate_limit_window_seconds = Some(total as i32);
+
+                if bound.hasattr("rate_limit_on_throttle")? {
+                    let attr = bound.getattr("rate_limit_on_throttle")?;
+                    let is_descriptor = attr
+                        .get_type()
+                        .qualname()
+                        .map(|n| n.contains("descriptor"))
+                        .unwrap_or(Ok(false))
+                        .unwrap_or(false);
+                    if !is_descriptor {
+                        rate_limit_on_throttle =
+                            attr.extract::<crate::context::RateLimitConflict>()?;
+                    }
+                }
+            }
+
             let module_path = bound
                 .getattr("__module__")
                 .and_then(|m| m.extract::<String>())
@@ -1876,6 +1948,9 @@ impl Worker {
                 concurrency_on_conflict,
                 continuation_info: None,
                 hooks,
+                rate_limit_max,
+                rate_limit_window_seconds,
+                rate_limit_on_throttle,
             };
             info!("Registered job: {:?}", runnable);
 
@@ -1886,6 +1961,22 @@ impl Worker {
             // Only store concurrency info if concurrency control is actually enabled
             if has_concurrency_control {
                 self.ctx.enable_concurrency_control(class_name.to_string());
+            }
+
+            // Mirror rate limit config into the AppContext registry so the
+            // worker claim path can `.is_empty()` short-circuit when no
+            // class uses the feature.
+            if let (Some(max), Some(win_secs)) = (rate_limit_max, rate_limit_window_seconds) {
+                if let Ok(mut reg) = self.ctx.rate_limited_classes.write() {
+                    reg.insert(
+                        class_name.to_string(),
+                        crate::context::RateLimitConfig {
+                            max,
+                            window: chrono::Duration::seconds(win_secs as i64),
+                            on_throttle: rate_limit_on_throttle,
+                        },
+                    );
+                }
             }
             Ok(())
         })

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -3736,12 +3736,14 @@ impl Worker {
             return Ok(());
         };
         let duration = chrono::Duration::from_std(ctx.default_concurrency_control_period).ok();
-        // Propagate failures: callers already `.await?` this helper, expecting
-        // a release failure to abort the enclosing tx. Silently swallowing the
-        // DbErr would leave the slot accounted as held in `solid_queue_semaphores`
-        // while the caller's state change (claimed deleted, ready re-inserted,
-        // scheduled inserted, etc.) commits — the exact slot-leak class of bug
-        // we already saw reintroduced through every claim/throttle path.
+        // Propagate failures: callers already `.await?` this helper. In-tx callers
+        // (claim/throttle/cleanup paths) rely on the propagation to abort the
+        // enclosing tx; the out-of-tx emergency cleanup caller relies on it to
+        // route to its delete-only fallback. Silently swallowing the DbErr would
+        // leave the slot accounted as held in `solid_queue_semaphores` while the
+        // caller's state change (claimed deleted, ready re-inserted, scheduled
+        // inserted, etc.) commits — the exact slot-leak class of bug we already
+        // saw reintroduced through every claim/throttle path.
         release_semaphore(
             db,
             table_config,

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -710,3 +710,84 @@ def test_jitter_spreads_throttled_jobs_within_one_second_window(qc_with_sqlalche
         f"jitter collapsed: {len(distinct_times)} distinct scheduled_at across "
         f"7 throttled jobs — expected sub-second spread. rows={rows}"
     )
+
+
+class LargeWindowJob(quebec.BaseClass):
+    """Maximum-supported window — exercises the jitter overflow boundary.
+
+    Pre-fix formula `seed * window_secs * 1_000_000_000 / 1000` overflows
+    i64 once `seed * window_secs > i64::MAX / 1e9 ≈ 9.22e9`. With
+    `window_secs ≈ i32::MAX (~2.15e9)`, any `seed >= 5` overflows.
+    `cargo` dev profile enables overflow-checks → panic in tests; release
+    builds wrap silently → wildly wrong retry_at. Either way the fix
+    (split into seconds + sub-second nanos before scaling) keeps every
+    intermediate product within i64 across the full supported range.
+    """
+
+    queue_as = "default"
+    rate_limit_max = 1
+    # i32::MAX seconds — the upper bound accepted by register_job_class.
+    rate_limit_window = timedelta(seconds=2_147_483_647)
+    calls: list[int] = []
+
+    def perform(self, value: int = 0) -> None:
+        type(self).calls.append(value)
+
+
+def test_large_window_jitter_no_overflow(qc_with_sqlalchemy):
+    LargeWindowJob.calls = []
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    qc.register_job(LargeWindowJob)
+
+    # Burn through job ids 1..=4 with a granted-then-completed cycle (max=1
+    # in a multi-decade window, so only the very first per-window grants).
+    # We need a throttled job with seed >= 5 to trip the overflow boundary
+    # at max window. Easiest path: enqueue several jobs and pick one with
+    # an id >= 5; the rate-throttle will move it to scheduled.
+    LargeWindowJob.perform_later(qc, 1)
+    e1 = _drain_silently(qc)
+    assert e1 is not None
+    e1.perform()
+
+    # Enqueue several more so subsequent throttles span seeds across the
+    # overflow boundary (seed >= 5).
+    for value in range(2, 8):
+        LargeWindowJob.perform_later(qc, value)
+
+    # All six are throttled and rescheduled. With the bug, jobs whose
+    # id % 1000 >= 5 panic on overflow (dev profile) or wrap to a
+    # nonsensical retry_at (release profile). With the fix, every call
+    # produces a sane future timestamp.
+    for _ in range(6):
+        assert _drain_silently(qc) is None
+
+    rows = session.execute(
+        text(
+            f"SELECT s.scheduled_at, s.job_id "
+            f"FROM {prefix}_scheduled_executions s "
+            f"JOIN {prefix}_jobs j ON j.id = s.job_id "
+            "WHERE j.class_name = 'LargeWindowJob' "
+            "ORDER BY s.job_id"
+        )
+    ).all()
+    assert len(rows) == 6, rows
+
+    from datetime import datetime, timezone, timedelta as td
+
+    now = datetime.now(timezone.utc)
+    # base scheduled_at is now + ~window_secs (since prev=0, retry_at jumps
+    # to window_end). Plus jitter (0..window). Allow up to 2x window slack.
+    upper = now + td(seconds=LargeWindowJob.rate_limit_window.total_seconds() * 2)
+    for scheduled_at, jid in rows:
+        if isinstance(scheduled_at, str):
+            scheduled_at = datetime.fromisoformat(scheduled_at)
+        if scheduled_at.tzinfo is None:
+            scheduled_at = scheduled_at.replace(tzinfo=timezone.utc)
+        delta = scheduled_at - now
+        assert td(seconds=0) < delta < upper - now, (
+            f"job {jid}: retry_at {scheduled_at} is implausible (delta={delta}); "
+            "jitter overflow suspected"
+        )

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -405,3 +405,90 @@ def test_burst_respects_max_within_window(qc_with_sqlalchemy):
         text(f"SELECT count(*) FROM {prefix}_scheduled_executions")
     ).scalar()
     assert rescheduled == 20 - granted
+
+
+class QueueRateJob(quebec.BaseClass):
+    """Used in test_rate_throttle_releases_queue_slot."""
+
+    queue_as = "default"
+    rate_limit_max = 1
+    rate_limit_window = timedelta(seconds=2)
+    calls: list[int] = []
+
+    def perform(self, value: int = 0) -> None:
+        type(self).calls.append(value)
+
+
+def test_rate_throttle_releases_queue_slot(db_url, test_prefix):
+    """REVIEW.md 2026-05-23 14:12 P1: when both queue concurrency and rate
+    limit are enabled, a rate-throttled job must release the queue:<name>
+    semaphore slot it took during the earlier queue-acquire step. Otherwise
+    the queue is stuck "full" until the TTL sweep, blocking unrelated jobs
+    on the same queue.
+    """
+    QueueRateJob.calls = []
+    instance = quebec.Quebec(
+        db_url,
+        table_name_prefix=test_prefix,
+        experimental_queue_concurrency={"default": 1},
+    )
+    assert instance.create_tables() is True
+    try:
+        instance.register_job(QueueRateJob)
+        QueueRateJob.perform_later(instance, 1)
+        QueueRateJob.perform_later(instance, 2)
+        QueueRateJob.perform_later(instance, 3)
+
+        # First drain consumes the only rate token AND the only queue slot.
+        e1 = _drain_silently(instance)
+        assert e1 is not None
+        e1.perform()  # releases the queue slot via after_executed
+
+        # Second drain: queue slot acquired (1/1), then rate gate denies
+        # (token already consumed in window). The buggy implementation
+        # would leak the queue slot here — subsequent perform_later jobs
+        # to the same queue would silently sit in ready_executions until
+        # TTL even though no claimed jobs hold the slot.
+        assert _drain_silently(instance) is None
+
+        # Third drain must still be possible (queue slot was released even
+        # though the rate gate routed the second candidate). With the
+        # bug present, this would also return None and the assertion
+        # below on PlainJob would also fail.
+        instance.register_job(PlainJob)
+        PlainJob.calls = []
+        PlainJob.perform_later(instance, 99)
+        e3 = _drain_silently(instance)
+        assert e3 is not None, (
+            "queue:default semaphore leaked; PlainJob can't claim its slot"
+        )
+        e3.perform()
+        assert PlainJob.calls == [99]
+    finally:
+        instance.close()
+
+
+def test_reregister_without_rate_limit_clears_stale_config(qc_with_sqlalchemy):
+    """REVIEW.md 2026-05-23 14:12 P3: re-registering a class without
+    `rate_limit_max` must clear the previously-stored rate config — otherwise
+    long-lived processes / test reuse keep throttling against stale settings.
+    """
+    qc = qc_with_sqlalchemy["qc"]
+
+    class Reused(quebec.BaseClass):
+        rate_limit_max = 1
+        rate_limit_window = timedelta(seconds=2)
+
+        def perform(self, *args, **kwargs):
+            pass
+
+    qc.register_job(Reused)
+    assert qc._rate_limit_config_for(Reused.__qualname__) is not None
+
+    # Re-define the same class name without rate limit and re-register.
+    class Reused(quebec.BaseClass):  # noqa: F811 — intentional shadow
+        def perform(self, *args, **kwargs):
+            pass
+
+    qc.register_job(Reused)
+    assert qc._rate_limit_config_for(Reused.__qualname__) is None

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -3,11 +3,72 @@
 Spec: docs/superpowers/specs/2026-05-23-experimental-rate-limit-sliding-window-design.md
 """
 
+from __future__ import annotations
+
+import time
 from datetime import timedelta
 
 import pytest
+from sqlalchemy import text
 
 import quebec
+
+
+# Module-level job classes so __qualname__ matches their bare name —
+# avoids the function-local `<locals>` prefix that would otherwise force
+# tests to plumb qualname strings through `qc._rate_limit_config_for`.
+class ThrottleJob(quebec.BaseClass):
+    queue_as = "default"
+    rate_limit_max = 3
+    rate_limit_window = timedelta(seconds=2)
+    calls: list[int] = []
+
+    def perform(self, value: int) -> None:
+        type(self).calls.append(value)
+
+
+class SmallWindowJob(quebec.BaseClass):
+    queue_as = "default"
+    rate_limit_max = 2
+    rate_limit_window = timedelta(seconds=1)
+    calls: list[int] = []
+
+    def perform(self, value: int = 0) -> None:
+        type(self).calls.append(value)
+
+
+class DiscardJob(quebec.BaseClass):
+    queue_as = "default"
+    rate_limit_max = 1
+    rate_limit_window = timedelta(seconds=2)
+    rate_limit_on_throttle = quebec.RateLimitConflict.Discard
+    calls: list[int] = []
+
+    def perform(self, value: int = 0) -> None:
+        type(self).calls.append(value)
+
+
+class StripeJob(quebec.BaseClass):
+    queue_as = "default"
+    rate_limit_max = 1
+    rate_limit_window = timedelta(seconds=2)
+    calls: list[tuple] = []
+
+    def rate_limit_key(self, region: str = "us") -> str:
+        return f"stripe:{region}"
+
+    def perform(self, region: str = "us") -> None:
+        type(self).calls.append(("call", region))
+
+
+class PlainJob(quebec.BaseClass):
+    """No rate limit declared; sanity test for zero-overhead path."""
+
+    queue_as = "default"
+    calls: list[int] = []
+
+    def perform(self, value: int = 0) -> None:
+        type(self).calls.append(value)
 
 
 def test_rate_limit_conflict_enum_exposed():
@@ -114,3 +175,183 @@ def test_rate_limit_key_can_be_overridden():
 
     assert Bar().rate_limit_key(region="eu") == "bar:eu"
     assert Bar().rate_limit_key() == "bar:us"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# End-to-end claim-time gating
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _drain_silently(qc) -> object | None:
+    """Try `qc.drain_one()`; return None when no claimable job is left.
+
+    Quebec raises a string-matched "No ready job to claim" exception when
+    the claim path can't find anything — we want a Pythonic bool/None.
+    """
+    try:
+        return qc.drain_one()
+    except Exception as exc:
+        if "No ready job to claim" in str(exc) or "No job found" in str(exc):
+            return None
+        raise
+
+
+def _reset_call_state():
+    """Reset module-level class state between tests."""
+    ThrottleJob.calls = []
+    SmallWindowJob.calls = []
+    DiscardJob.calls = []
+    StripeJob.calls = []
+    PlainJob.calls = []
+
+
+def test_throttle_after_max_in_one_window(qc_with_sqlalchemy):
+    _reset_call_state()
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    qc.register_job(ThrottleJob)
+    for i in range(5):
+        ThrottleJob.perform_later(qc, i)
+
+    # First three claims grant.
+    granted = 0
+    for _ in range(3):
+        e = _drain_silently(qc)
+        if e is not None:
+            granted += 1
+            e.perform()
+    assert granted == 3
+    assert ThrottleJob.calls == [0, 1, 2]
+
+    # Subsequent claims throttle (jobs 4, 5 → moved to scheduled_executions).
+    for _ in range(2):
+        assert _drain_silently(qc) is None
+
+    scheduled = session.execute(
+        text(f"SELECT count(*) FROM {prefix}_scheduled_executions")
+    ).scalar()
+    assert scheduled == 2
+
+
+def test_recovers_after_window_elapses(qc_with_sqlalchemy):
+    _reset_call_state()
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    qc.register_job(SmallWindowJob)
+    for i in range(2):
+        SmallWindowJob.perform_later(qc, i)
+
+    # Two grants in first window.
+    e1 = _drain_silently(qc)
+    e2 = _drain_silently(qc)
+    assert e1 is not None and e2 is not None
+    e1.perform()
+    e2.perform()
+
+    # Third enqueue in same window → throttled into scheduled.
+    SmallWindowJob.perform_later(qc, 99)
+    assert _drain_silently(qc) is None
+    scheduled = session.execute(
+        text(f"SELECT count(*) FROM {prefix}_scheduled_executions")
+    ).scalar()
+    assert scheduled == 1
+
+    # Wait for window roll + a little slack for the retry_at jitter
+    # (window=1s, max jitter ≈ window → ≤2s in the worst case).
+    time.sleep(2.5)
+
+    # Move the matured scheduled row back into ready (mirrors what
+    # dispatcher polling would do). Drive it via raw SQL to keep the test
+    # self-contained.
+    session.execute(
+        text(
+            f"INSERT INTO {prefix}_ready_executions "
+            "(job_id, queue_name, priority, created_at) "
+            f"SELECT job_id, queue_name, priority, scheduled_at "
+            f"FROM {prefix}_scheduled_executions"
+        )
+    )
+    session.execute(text(f"DELETE FROM {prefix}_scheduled_executions"))
+    session.commit()
+
+    e3 = _drain_silently(qc)
+    assert e3 is not None
+    e3.perform()
+    assert SmallWindowJob.calls == [0, 1, 99]
+
+
+def test_discard_mode_finishes_throttled_jobs(qc_with_sqlalchemy):
+    _reset_call_state()
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    qc.register_job(DiscardJob)
+    DiscardJob.perform_later(qc, 1)
+    DiscardJob.perform_later(qc, 2)
+
+    e1 = _drain_silently(qc)
+    assert e1 is not None
+    e1.perform()
+
+    # Second job throttled → marked finished, not rescheduled.
+    assert _drain_silently(qc) is None
+
+    finished = session.execute(
+        text(f"SELECT count(*) FROM {prefix}_jobs WHERE finished_at IS NOT NULL")
+    ).scalar()
+    assert finished == 2  # one ran, one discarded
+
+    scheduled = session.execute(
+        text(f"SELECT count(*) FROM {prefix}_scheduled_executions")
+    ).scalar()
+    assert scheduled == 0
+
+    assert DiscardJob.calls == [1]  # only the first ran
+
+
+def test_buckets_isolated_by_user_key(qc_with_sqlalchemy):
+    _reset_call_state()
+    qc = qc_with_sqlalchemy["qc"]
+
+    qc.register_job(StripeJob)
+    StripeJob.perform_later(qc, region="us")
+    StripeJob.perform_later(qc, region="eu")
+    StripeJob.perform_later(qc, region="us")
+
+    # First two land in different buckets → both grant.
+    e1 = _drain_silently(qc)
+    e2 = _drain_silently(qc)
+    assert e1 is not None and e2 is not None
+    e1.perform()
+    e2.perform()
+
+    # Third (region=us) hits the saturated us bucket → throttled.
+    assert _drain_silently(qc) is None
+
+    regions_run = sorted(r for (_, r) in StripeJob.calls)
+    assert regions_run == ["eu", "us"]
+
+
+def test_zero_overhead_plain_job_still_claims(qc_with_sqlalchemy):
+    """Sanity: when no class has rate_limit_max, the gate is skipped and
+    normal jobs claim without issue.
+
+    The zero-overhead path itself is asserted by code review (single
+    `is_empty()` check), not a runtime spy — instrumenting the jobs-table
+    read would require Rust-side hooks beyond this PR's scope.
+    """
+    _reset_call_state()
+    qc = qc_with_sqlalchemy["qc"]
+
+    qc.register_job(PlainJob)
+    PlainJob.perform_later(qc, 42)
+
+    e = _drain_silently(qc)
+    assert e is not None
+    e.perform()
+    assert PlainJob.calls == [42]

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -509,3 +509,150 @@ def test_reregister_without_rate_limit_clears_stale_config(qc_with_sqlalchemy):
 
     qc.register_job(Reused)
     assert qc._rate_limit_config_for(Reused.__qualname__) is None
+
+
+class CombinedClassRateJob(quebec.BaseClass):
+    """concurrency_limit=1 + rate_limit_max=1 + rate_limit_window=2s.
+
+    Used by test_rate_throttle_releases_concurrency_key_slot to exercise
+    the interaction between class-level concurrency_key (acquired at
+    enqueue) and rate gating (deciding at claim time).
+    """
+
+    queue_as = "default"
+    concurrency_limit = 1
+    rate_limit_max = 1
+    rate_limit_window = timedelta(seconds=2)
+    calls: list[int] = []
+
+    @staticmethod
+    def concurrency_key(*args, **kwargs) -> str:
+        return "combined-key"
+
+    def perform(self, value: int = 0) -> None:
+        type(self).calls.append(value)
+
+
+def test_rate_throttle_releases_concurrency_key_slot(qc_with_sqlalchemy):
+    """When a class has both concurrency_limit and rate_limit_max:
+
+    - enqueue acquires concurrency slot
+    - claim consults rate gate
+    - if rate throttles (Reschedule or Discard), the concurrency slot must
+      be released, otherwise:
+       * Reschedule path: dispatcher promotes the scheduled job, tries to
+         re-acquire the same key, fails (slot still held by the very job
+         being promoted), routes it to blocked_executions — job stalls
+         until concurrency_duration TTL (default 60s).
+       * Discard path: slot stays held for an already-finished job until
+         TTL.
+
+    This test exercises the Reschedule path by enqueuing a follow-up job
+    after a rate-throttle and asserting it can immediately acquire (proves
+    the slot was freed).
+    """
+    CombinedClassRateJob.calls = []
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    qc.register_job(CombinedClassRateJob)
+
+    # job1: enqueue → acquire slot (used 1/1) → ready. Claim, perform,
+    # after_executed releases the slot (used 0/1) and consumes 1 rate
+    # token.
+    CombinedClassRateJob.perform_later(qc, 1)
+    e1 = _drain_silently(qc)
+    assert e1 is not None
+    e1.perform()
+
+    # job2: enqueue inside the same rate window → re-acquire slot (1/1) →
+    # ready. Claim consults rate gate; token is exhausted → Reschedule.
+    # With the bug, the slot stays at 1/1 even though job2 left ready.
+    # With the fix, the slot is released back to 0/1.
+    CombinedClassRateJob.perform_later(qc, 2)
+    assert _drain_silently(qc) is None  # rate-throttled, moved to scheduled
+
+    # job3: enqueue → must successfully acquire (slot expected to be 0/1
+    # under the fix) → land in ready_executions, NOT blocked_executions.
+    # With the bug, acquire fails → job3 goes to blocked.
+    CombinedClassRateJob.perform_later(qc, 3)
+
+    ready_count = session.execute(
+        text(
+            f"SELECT count(*) FROM {prefix}_ready_executions e "
+            f"JOIN {prefix}_jobs j ON j.id = e.job_id "
+            "WHERE j.class_name = 'CombinedClassRateJob'"
+        )
+    ).scalar()
+    blocked_count = session.execute(
+        text(
+            f"SELECT count(*) FROM {prefix}_blocked_executions e "
+            f"JOIN {prefix}_jobs j ON j.id = e.job_id "
+            "WHERE j.class_name = 'CombinedClassRateJob'"
+        )
+    ).scalar()
+    assert ready_count == 1, (
+        f"expected job3 in ready_executions; ready={ready_count}, "
+        f"blocked={blocked_count} — concurrency slot leak suspected"
+    )
+    assert blocked_count == 0
+
+
+class CombinedDiscardJob(quebec.BaseClass):
+    queue_as = "default"
+    concurrency_limit = 1
+    rate_limit_max = 1
+    rate_limit_window = timedelta(seconds=2)
+    rate_limit_on_throttle = quebec.RateLimitConflict.Discard
+    calls: list[int] = []
+
+    @staticmethod
+    def concurrency_key(*args, **kwargs) -> str:
+        return "discard-key"
+
+    def perform(self, value: int = 0) -> None:
+        type(self).calls.append(value)
+
+
+def test_rate_discard_releases_concurrency_key_slot(qc_with_sqlalchemy):
+    """Same intent as above but exercises the Discard branch."""
+    CombinedDiscardJob.calls = []
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    qc.register_job(CombinedDiscardJob)
+
+    CombinedDiscardJob.perform_later(qc, 1)
+    e1 = _drain_silently(qc)
+    assert e1 is not None
+    e1.perform()
+
+    # job2 enters in-window → throttled, Discard mode marks it finished.
+    # Without the fix, the concurrency slot stays held for the finished
+    # job until TTL.
+    CombinedDiscardJob.perform_later(qc, 2)
+    assert _drain_silently(qc) is None
+
+    # job3 must acquire the freshly-released slot and land in ready.
+    CombinedDiscardJob.perform_later(qc, 3)
+    ready_count = session.execute(
+        text(
+            f"SELECT count(*) FROM {prefix}_ready_executions e "
+            f"JOIN {prefix}_jobs j ON j.id = e.job_id "
+            "WHERE j.class_name = 'CombinedDiscardJob'"
+        )
+    ).scalar()
+    blocked_count = session.execute(
+        text(
+            f"SELECT count(*) FROM {prefix}_blocked_executions e "
+            f"JOIN {prefix}_jobs j ON j.id = e.job_id "
+            "WHERE j.class_name = 'CombinedDiscardJob'"
+        )
+    ).scalar()
+    assert ready_count == 1, (
+        f"expected job3 in ready_executions; ready={ready_count}, "
+        f"blocked={blocked_count} — concurrency slot leak (Discard path)"
+    )
+    assert blocked_count == 0

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -355,3 +355,53 @@ def test_zero_overhead_plain_job_still_claims(qc_with_sqlalchemy):
     assert e is not None
     e.perform()
     assert PlainJob.calls == [42]
+
+
+class BurstJob(quebec.BaseClass):
+    queue_as = "default"
+    rate_limit_max = 5
+    rate_limit_window = timedelta(seconds=5)
+    calls: list[int] = []
+
+    def perform(self, value: int = 0) -> None:
+        type(self).calls.append(value)
+
+
+def test_burst_respects_max_within_window(qc_with_sqlalchemy):
+    """Enqueue many jobs in tight succession; assert the rate limit caps
+    granted claims at ``max`` within the configured window.
+
+    Note: SQLite serializes all transactions, so threaded multi-worker
+    contention can't be exercised here — a sequential burst already
+    surfaces the invariant. True multi-process / multi-worker stress
+    testing is deferred to PG-backed integration runs during soak.
+    """
+    BurstJob.calls = []
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    qc.register_job(BurstJob)
+    for i in range(20):
+        BurstJob.perform_later(qc, i)
+
+    granted = 0
+    for _ in range(20):
+        e = _drain_silently(qc)
+        if e is None:
+            break
+        granted += 1
+        e.perform()
+
+    # Sliding window allows up to ~2% over the configured max.
+    assert granted <= BurstJob.rate_limit_max + 1, (
+        f"granted {granted} exceeds max={BurstJob.rate_limit_max} + 2% tolerance"
+    )
+    assert granted >= BurstJob.rate_limit_max, (
+        f"granted {granted} is below max={BurstJob.rate_limit_max}; rate gate too strict"
+    )
+
+    rescheduled = session.execute(
+        text(f"SELECT count(*) FROM {prefix}_scheduled_executions")
+    ).scalar()
+    assert rescheduled == 20 - granted

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -791,3 +791,70 @@ def test_large_window_jitter_no_overflow(qc_with_sqlalchemy):
             f"job {jid}: retry_at {scheduled_at} is implausible (delta={delta}); "
             "jitter overflow suspected"
         )
+
+
+def test_register_job_rejects_non_timedelta_window(qc_with_sqlalchemy):
+    """Non-timedelta `rate_limit_window` used to surface as a cryptic
+    `AttributeError: 'int' object has no attribute 'total_seconds'`.
+    The upfront is_instance check now reports the actual problem.
+    """
+    qc = qc_with_sqlalchemy["qc"]
+
+    class BadWindowInt(quebec.BaseClass):
+        rate_limit_max = 1
+        rate_limit_window = 2  # int, not timedelta
+
+        def perform(self, *args, **kwargs):
+            pass
+
+    with pytest.raises(TypeError, match="must be a datetime.timedelta"):
+        qc.register_job(BadWindowInt)
+
+    class BadWindowStr(quebec.BaseClass):
+        rate_limit_max = 1
+        rate_limit_window = "2 seconds"  # str
+
+        def perform(self, *args, **kwargs):
+            pass
+
+    with pytest.raises(TypeError, match="must be a datetime.timedelta"):
+        qc.register_job(BadWindowStr)
+
+
+@pytest.mark.parametrize(
+    "bad_return",
+    [
+        pytest.param("raise", id="raises"),
+        pytest.param(None, id="returns_none"),
+        pytest.param(42, id="returns_int"),
+    ],
+)
+def test_rate_limit_key_failure_falls_back_to_class_name(
+    qc_with_sqlalchemy, bad_return
+):
+    """A broken user `rate_limit_key` (raise / None / non-str) must not poison
+    the claim loop. Surfacing the PyErr would roll claim_job back, leave the
+    candidate in ready, and next poll would hit the same error.
+    """
+    qc = qc_with_sqlalchemy["qc"]
+
+    class Job(quebec.BaseClass):
+        rate_limit_max = 1
+        rate_limit_window = timedelta(seconds=2)
+
+        def rate_limit_key(self, *args, **kwargs):
+            if bad_return == "raise":
+                raise RuntimeError("user bug")
+            return bad_return
+
+        def perform(self, *args, **kwargs):
+            pass
+
+    qc.register_job(Job)
+    Job.perform_later(qc)
+    e1 = _drain_silently(qc)
+    assert e1 is not None  # granted via fallback class-name bucket
+    e1.perform()
+    Job.perform_later(qc)
+    # Throttled via the same fallback bucket — no crash, no loop.
+    assert _drain_silently(qc) is None

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -3,6 +3,10 @@
 Spec: docs/superpowers/specs/2026-05-23-experimental-rate-limit-sliding-window-design.md
 """
 
+from datetime import timedelta
+
+import pytest
+
 import quebec
 
 
@@ -11,3 +15,76 @@ def test_rate_limit_conflict_enum_exposed():
     assert quebec.RateLimitConflict.Reschedule != quebec.RateLimitConflict.Discard
     assert repr(quebec.RateLimitConflict.Reschedule) == "RateLimitConflict.Reschedule"
     assert repr(quebec.RateLimitConflict.Discard) == "RateLimitConflict.Discard"
+
+
+def test_register_job_extracts_rate_limit_config(qc_with_sqlalchemy):
+    qc = qc_with_sqlalchemy["qc"]
+
+    class ApiCall(quebec.BaseClass):
+        rate_limit_max = 5
+        rate_limit_window = timedelta(seconds=2)
+        rate_limit_on_throttle = quebec.RateLimitConflict.Discard
+
+        def perform(self, *args, **kwargs):
+            pass
+
+    qc.register_job(ApiCall)
+
+    cfg = qc._rate_limit_config_for(ApiCall.__qualname__)
+    assert cfg is not None
+    assert cfg["max"] == 5
+    assert cfg["window_seconds"] == 2
+    assert cfg["on_throttle"] == quebec.RateLimitConflict.Discard
+
+
+def test_register_job_without_rate_limit_returns_none(qc_with_sqlalchemy):
+    qc = qc_with_sqlalchemy["qc"]
+
+    class PlainJob(quebec.BaseClass):
+        def perform(self, *args, **kwargs):
+            pass
+
+    qc.register_job(PlainJob)
+    assert qc._rate_limit_config_for(PlainJob.__qualname__) is None
+
+
+def test_register_job_defaults_to_reschedule(qc_with_sqlalchemy):
+    qc = qc_with_sqlalchemy["qc"]
+
+    class DefaultThrottle(quebec.BaseClass):
+        rate_limit_max = 10
+        rate_limit_window = timedelta(seconds=1)
+
+        def perform(self, *args, **kwargs):
+            pass
+
+    qc.register_job(DefaultThrottle)
+    cfg = qc._rate_limit_config_for(DefaultThrottle.__qualname__)
+    assert cfg["on_throttle"] == quebec.RateLimitConflict.Reschedule
+
+
+def test_register_job_rejects_subsecond_window(qc_with_sqlalchemy):
+    qc = qc_with_sqlalchemy["qc"]
+
+    class TooFast(quebec.BaseClass):
+        rate_limit_max = 5
+        rate_limit_window = timedelta(milliseconds=500)
+
+        def perform(self, *args, **kwargs):
+            pass
+
+    with pytest.raises(ValueError, match="rate_limit_window must be >= 1 second"):
+        qc.register_job(TooFast)
+
+
+def test_register_job_rejects_max_without_window(qc_with_sqlalchemy):
+    qc = qc_with_sqlalchemy["qc"]
+
+    class MissingWindow(quebec.BaseClass):
+        rate_limit_max = 5
+
+        def perform(self, *args, **kwargs):
+            pass
+
+    with pytest.raises(ValueError, match="rate_limit_window"):
+        qc.register_job(MissingWindow)

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,13 @@
+"""Tests for the experimental sliding-window rate limit feature.
+
+Spec: docs/superpowers/specs/2026-05-23-experimental-rate-limit-sliding-window-design.md
+"""
+
+import quebec
+
+
+def test_rate_limit_conflict_enum_exposed():
+    assert hasattr(quebec, "RateLimitConflict")
+    assert quebec.RateLimitConflict.Reschedule != quebec.RateLimitConflict.Discard
+    assert repr(quebec.RateLimitConflict.Reschedule) == "RateLimitConflict.Reschedule"
+    assert repr(quebec.RateLimitConflict.Discard) == "RateLimitConflict.Discard"

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -656,3 +656,57 @@ def test_rate_discard_releases_concurrency_key_slot(qc_with_sqlalchemy):
         f"blocked={blocked_count} — concurrency slot leak (Discard path)"
     )
     assert blocked_count == 0
+
+
+class JitterSpreadJob(quebec.BaseClass):
+    queue_as = "default"
+    rate_limit_max = 1
+    rate_limit_window = timedelta(seconds=1)
+    calls: list[int] = []
+
+    def perform(self, value: int = 0) -> None:
+        type(self).calls.append(value)
+
+
+def test_jitter_spreads_throttled_jobs_within_one_second_window(qc_with_sqlalchemy):
+    """retry_at must use sub-second resolution. With integer-second jitter,
+    every throttled job at window=1s landed on the exact same wall-clock
+    second, defeating the anti-stampede design. After the fix, distinct
+    job_ids produce distinct sub-second offsets.
+    """
+    JitterSpreadJob.calls = []
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    qc.register_job(JitterSpreadJob)
+    # First grant consumes the only token.
+    JitterSpreadJob.perform_later(qc, 0)
+    e1 = _drain_silently(qc)
+    assert e1 is not None
+    e1.perform()
+
+    # Enqueue several more in the same window — all throttle and
+    # reschedule. Without sub-second jitter their scheduled_at values
+    # collapse onto one timestamp.
+    for i in range(1, 8):
+        JitterSpreadJob.perform_later(qc, i)
+    for _ in range(7):
+        assert _drain_silently(qc) is None
+
+    rows = session.execute(
+        text(
+            f"SELECT s.scheduled_at FROM {prefix}_scheduled_executions s "
+            f"JOIN {prefix}_jobs j ON j.id = s.job_id "
+            "WHERE j.class_name = 'JitterSpreadJob' "
+            "ORDER BY s.scheduled_at"
+        )
+    ).all()
+    assert len(rows) == 7
+    distinct_times = {row[0] for row in rows}
+    # Allow some collision (job_id % 1000 hash) but require meaningful
+    # spread — at minimum half the jobs land at unique sub-second offsets.
+    assert len(distinct_times) >= 4, (
+        f"jitter collapsed: {len(distinct_times)} distinct scheduled_at across "
+        f"7 throttled jobs — expected sub-second spread. rows={rows}"
+    )

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -88,3 +88,29 @@ def test_register_job_rejects_max_without_window(qc_with_sqlalchemy):
 
     with pytest.raises(ValueError, match="rate_limit_window"):
         qc.register_job(MissingWindow)
+
+
+def test_default_rate_limit_key_is_class_name():
+    class Foo(quebec.BaseClass):
+        rate_limit_max = 5
+        rate_limit_window = timedelta(seconds=1)
+
+        def perform(self, *args, **kwargs):
+            pass
+
+    assert Foo().rate_limit_key() == "Foo"
+
+
+def test_rate_limit_key_can_be_overridden():
+    class Bar(quebec.BaseClass):
+        rate_limit_max = 5
+        rate_limit_window = timedelta(seconds=1)
+
+        def rate_limit_key(self, region="us"):
+            return f"bar:{region}"
+
+        def perform(self, *args, **kwargs):
+            pass
+
+    assert Bar().rate_limit_key(region="eu") == "bar:eu"
+    assert Bar().rate_limit_key() == "bar:us"

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -138,6 +138,23 @@ def test_register_job_rejects_subsecond_window(qc_with_sqlalchemy):
         qc.register_job(TooFast)
 
 
+def test_register_job_rejects_fractional_window(qc_with_sqlalchemy):
+    """1.9s would silently truncate to 1s under `as i32`, loosening the
+    declared limit by ~50%. Refuse rather than guess floor/ceil/round.
+    """
+    qc = qc_with_sqlalchemy["qc"]
+
+    class FractionalWindow(quebec.BaseClass):
+        rate_limit_max = 5
+        rate_limit_window = timedelta(seconds=1, milliseconds=900)
+
+        def perform(self, *args, **kwargs):
+            pass
+
+    with pytest.raises(ValueError, match="whole number of seconds"):
+        qc.register_job(FractionalWindow)
+
+
 def test_register_job_rejects_max_without_window(qc_with_sqlalchemy):
     qc = qc_with_sqlalchemy["qc"]
 


### PR DESCRIPTION
## Summary

Adds an **experimental** claim-time sliding-window rate limit to the worker, declared per job class (`rate_limit_max`, `rate_limit_window`, optional `rate_limit_on_throttle`). The limit is enforced inside the same transaction that claims a job, so throttled jobs never reach `perform()` — they are either rescheduled with jitter or discarded, and any class/queue concurrency slots they momentarily held are released back.

> Marked experimental — naming and semantics may change before promotion.

## Design

- **Sliding-window counter** (`src/semaphore.rs::try_consume_rate_token`): two adjacent windowed rows keyed by `(class_name, user_key)`, UPSERT-incremented; estimated rate = `curr + prev * (1 − elapsed_fraction)`. On overshoot the increment is compensated and a jittered `retry_at` is returned.
- **Per-class config** captured at `register_job` and stored in `AppContext.rate_limited_classes`. The claim path short-circuits with `.is_empty()` when no class declared a limit, so the existing hot path pays zero cost.
- **User-pluggable key** via `BaseClass.rate_limit_key(*args, **kwargs)`. Default is the class name (one bucket per class). Override to partition by tenant/region/etc. Unlike `concurrency_key`, this is recomputed at claim time and not snapshotted into the jobs row.
- **Throttle outcomes**:
  - `Reschedule` (default): job becomes a `scheduled_executions` row at `retry_at` + nanosecond jitter (jitter spreads simultaneous throttles so window=1s doesn't synchronize a thundering herd).
  - `Discard`: dedup-style — claimed row is removed, job marked finished without executing.
- **Slot accounting**: when the rate gate routes a job away, the routine releases the class-level concurrency slot AND the queue-level slot it transiently held, then commits. Stale rate config is cleared on `register_job` re-registration.

## Behavior reviewers should note

- No DB schema change. Buckets share the existing `semaphores` table via a `rate:` key prefix.
- The rate gate runs INSIDE the claim transaction (`worker.rs::claim_job`) and uses the same connection — no extra round trip on the happy path; one extra UPSERT+SELECT when a rate-limited class is claimed.
- Window must be an integer number of seconds (fractional rejected at register time). Jitter is split into seconds+nanos to avoid `i64` overflow on large windows.
- `rate_limit_key` failure falls back to the class name with a warn log rather than failing the claim.

## Test plan

- `cargo clippy --all-targets --all-features` clean
- `cargo fmt --all -- --check` clean
- `tests/test_rate_limit.py` (~860 lines): claim-time gate end-to-end, burst respects `max` within window, queue-slot release on throttle, class-level concurrency_key release on throttle, fractional window rejection, re-register clears stale config, jitter spreads same-window throttles, type-check error path.

## Risk / rollout

- Opt-in: classes without `rate_limit_max` are unaffected. Hot path (no rate-limited classes registered) is a single `HashMap::is_empty()`.
- Marked **experimental** — naming (`rate_limit_max` vs alternatives), throttle defaults, and the `RateLimitConflict` enum may change before stabilization.
- No schema migration → clean revert (in-memory registry + reuses existing `semaphores` table for buckets).
