### PR TITLE
fix(worker): keep memory recycle on exit-75 path under quiet_then_exit

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -1289,6 +1289,18 @@ impl PyQuebec {
         if !self.ctx.quiet_then_exit || !self.ctx.quiet.is_cancelled() {
             return false;
         }
+        // Memory recycle enters quiet through the same token, but it must exit via
+        // the worker's planned-recycle path (exit code 75) so a supervisor/systemd
+        // relaunches the process. quiet_then_exit's graceful exit (code 0) would
+        // mask that intent and leave a Restart=on-failure deployment without a new
+        // worker, so defer to the recycle path here.
+        if self
+            .ctx
+            .worker_memory_recycle_requested
+            .load(Ordering::Relaxed)
+        {
+            return false;
+        }
         // Standalone-only: under the fork supervisor a self-exited worker child
         // would just be reforked, so quiet_then_exit is a no-op there. Supervised
         // deployments should use a supervisor-level rolling restart instead.

--- a/tests/test_worker_memory_recycle.py
+++ b/tests/test_worker_memory_recycle.py
@@ -23,6 +23,31 @@ def test_memory_recycle_exits_when_drained_under_supervisor(db_url, test_prefix)
         qc.close()
 
 
+def test_memory_recycle_does_not_self_exit_via_quiet_then_exit(db_url, test_prefix):
+    """Standalone (non-supervisor) + quiet_then_exit + memory recycle.
+
+    Memory recycle enters quiet through the shared quiet token, but it must exit
+    via the planned-recycle path (exit code 75) so a supervisor/systemd with
+    Restart=on-failure relaunches the worker. quiet_then_exit's graceful exit
+    (code 0) would hijack that and leave the deployment without a new worker, so
+    should_drain_exit() must refuse while a recycle is requested.
+    """
+    qc = quebec.Quebec(db_url, table_name_prefix=test_prefix, quiet_then_exit=True)
+    assert qc.create_tables() is True
+    try:
+        qc.register_worker_process()
+        qc._request_worker_memory_recycle(256 * 1024 * 1024)
+
+        assert qc.is_quiet is True
+        assert qc.is_worker_memory_recycling is True
+        # quiet_then_exit must NOT claim the exit — the recycle path (exit 75) owns it.
+        assert qc.should_drain_exit() is False
+        # The recycle predicate is the one that should fire.
+        assert qc._should_worker_memory_recycle_exit() is True
+    finally:
+        qc.close()
+
+
 def test_memory_recycle_waits_for_claimed_job_before_timeout(db_url, test_prefix):
     qc = quebec.Quebec(
         db_url,


### PR DESCRIPTION
## Problem

When `quiet_then_exit` is enabled in standalone (non-supervisor) mode and the worker RSS soft-limit triggers a planned memory recycle, the worker exits with **code 0 instead of 75**, so a `Restart=on-failure` supervisor (systemd, etc.) treats it as a clean shutdown and never relaunches — leaving the deployment with no worker until the next deploy.

### Root cause

Memory recycle enters quiet mode through the **same quiet token** as a SIGUSR1 rolling restart (`worker.rs` cancels `ctx.quiet`). `should_drain_exit()` only checked `quiet_then_exit && quiet.is_cancelled()`, so on a recycle quiet the Python wait loop's `graceful_shutdown()` (exit 0) raced ahead of the worker's planned-recycle `exit(75)` path and won.

The two paths have opposite restart semantics:
- **SIGUSR1 rolling restart** -> drain -> exit 0 -> must *not* be restarted (replacement already up)
- **Memory recycle** -> drain -> exit 75 -> *must* be restarted (same instance needs a fresh process)

They were collapsed into exit 0, so the exit code could no longer distinguish them. Only supervisor mode was guarded (`supervisor_pid != 0` short-circuits `should_drain_exit`); standalone + systemd was unguarded.

## Fix

`should_drain_exit()` returns `false` while `worker_memory_recycle_requested` is set, deferring to the worker's planned-recycle path (exit 75, fired on the next memory-check tick, <=5s). SIGUSR1 quiet_then_exit (exit 0) is unaffected.

## Tests

- New: `test_memory_recycle_does_not_self_exit_via_quiet_then_exit` — standalone + quiet_then_exit + recycle -> `should_drain_exit()` is False, `_should_worker_memory_recycle_exit()` is True (red before fix, green after)
- Regression: `test_supervisor*.py`, `test_worker_memory_recycle.py`, `test_quiet_then_exit.py` — 34 passed
- `cargo fmt --check` + `cargo clippy --all-targets --all-features` clean