### PR TITLE
feat(control-plane): worker uptime/memory + job priority columns

### DIFF
--- a/src/control_plane/handlers/blocked_jobs.rs
+++ b/src/control_plane/handlers/blocked_jobs.rs
@@ -80,6 +80,7 @@ impl ControlPlane {
                     job_id: execution.job_id,
                     queue_name: execution.queue_name.clone(),
                     class_name: job.class_name.clone(),
+                    priority: job.priority,
                     concurrency_key: execution.concurrency_key.clone(),
                     created_at: Self::format_naive_datetime(execution.created_at),
                     waiting_time,

--- a/src/control_plane/handlers/failed_jobs.rs
+++ b/src/control_plane/handlers/failed_jobs.rs
@@ -62,6 +62,7 @@ impl ControlPlane {
                     id: job.id,
                     queue_name: job.queue_name.clone(),
                     class_name: job.class_name.clone(),
+                    priority: job.priority,
                     error: execution.error.unwrap_or_default(),
                     failed_at: Self::format_naive_datetime(execution.created_at),
                 });

--- a/src/control_plane/handlers/finished_jobs.rs
+++ b/src/control_plane/handlers/finished_jobs.rs
@@ -74,6 +74,7 @@ impl ControlPlane {
                     id: job.id,
                     queue_name: job.queue_name,
                     class_name: job.class_name,
+                    priority: job.priority,
                     created_at: Self::format_naive_datetime(job.created_at),
                     finished_at: Self::format_naive_datetime(finished_at),
                     runtime,

--- a/src/control_plane/handlers/in_progress_jobs.rs
+++ b/src/control_plane/handlers/in_progress_jobs.rs
@@ -99,6 +99,7 @@ impl ControlPlane {
                     job_id: execution.job_id,
                     queue_name: job.queue_name.clone(),
                     class_name: job.class_name.clone(),
+                    priority: job.priority,
                     worker_info,
                     started_at: Self::format_naive_datetime(execution.created_at),
                     runtime,

--- a/src/control_plane/handlers/queues.rs
+++ b/src/control_plane/handlers/queues.rs
@@ -262,6 +262,7 @@ impl ControlPlane {
                     crate::control_plane::models::QueueJobInfo {
                         id: job.id,
                         class_name: job.class_name.clone(),
+                        priority: job.priority,
                         created_at: Self::format_naive_datetime(job.created_at),
                     }
                 })

--- a/src/control_plane/handlers/scheduled_jobs.rs
+++ b/src/control_plane/handlers/scheduled_jobs.rs
@@ -85,7 +85,7 @@ impl ControlPlane {
         FROM {} s
         JOIN {} j ON s.job_id = j.id
         WHERE {}
-        ORDER BY s.scheduled_at ASC
+        ORDER BY s.scheduled_at ASC, j.priority ASC, s.job_id ASC
         LIMIT {} OFFSET {}",
             table_config.scheduled_executions, table_config.jobs, where_clause, p1, p2
         ));

--- a/src/control_plane/handlers/scheduled_jobs.rs
+++ b/src/control_plane/handlers/scheduled_jobs.rs
@@ -80,6 +80,7 @@ impl ControlPlane {
             s.scheduled_at,
             j.class_name,
             j.queue_name,
+            j.priority,
             j.created_at
         FROM {} s
         JOIN {} j ON s.job_id = j.id
@@ -110,6 +111,7 @@ impl ControlPlane {
             let job_id: i64 = row.try_get("", "job_id").unwrap_or_default();
             let class_name: String = row.try_get("", "class_name").unwrap_or_default();
             let queue_name: String = row.try_get("", "queue_name").unwrap_or_default();
+            let priority: i32 = row.try_get("", "priority").unwrap_or(0);
 
             // Parse creation time
             let created_at_str =
@@ -151,6 +153,7 @@ impl ControlPlane {
                 job_id,
                 queue_name,
                 class_name,
+                priority,
                 created_at: created_at_str,
                 scheduled_at: scheduled_at_str,
                 scheduled_in,

--- a/src/control_plane/handlers/workers.rs
+++ b/src/control_plane/handlers/workers.rs
@@ -66,6 +66,7 @@ impl ControlPlane {
                     kind: worker.kind,
                     hostname: worker.hostname.unwrap_or_else(|| "unknown".to_string()),
                     pid: worker.pid,
+                    created_at: Self::format_naive_datetime(worker.created_at),
                     last_heartbeat_at: Self::format_naive_datetime(last_heartbeat),
                     seconds_since_heartbeat,
                     status: status.to_string(),

--- a/src/control_plane/handlers/workers.rs
+++ b/src/control_plane/handlers/workers.rs
@@ -59,6 +59,10 @@ impl ControlPlane {
                     .as_ref()
                     .and_then(|v| v.get("revision").and_then(|s| s.as_str()))
                     .map(|s| s.to_string());
+                let memory = metadata
+                    .as_ref()
+                    .and_then(|v| v.get("rss_bytes").and_then(|b| b.as_u64()))
+                    .map(Self::format_rss_bytes);
 
                 WorkerInfo {
                     id: worker.id,
@@ -72,6 +76,7 @@ impl ControlPlane {
                     status: status.to_string(),
                     quiet,
                     revision,
+                    memory,
                 }
             })
             .collect();

--- a/src/control_plane/models.rs
+++ b/src/control_plane/models.rs
@@ -108,6 +108,7 @@ pub struct FailedJobInfo {
     pub id: i64,
     pub queue_name: String,
     pub class_name: String,
+    pub priority: i32,
     pub error: String,
     pub failed_at: String,
 }
@@ -118,6 +119,7 @@ pub struct InProgressJobInfo {
     pub job_id: i64,
     pub queue_name: String,
     pub class_name: String,
+    pub priority: i32,
     pub worker_info: String,
     pub started_at: String,
     pub runtime: String,
@@ -127,6 +129,7 @@ pub struct InProgressJobInfo {
 pub struct QueueJobInfo {
     pub id: i64,
     pub class_name: String,
+    pub priority: i32,
     pub created_at: String,
 }
 
@@ -136,6 +139,7 @@ pub struct ScheduledJobInfo {
     pub job_id: i64,
     pub queue_name: String,
     pub class_name: String,
+    pub priority: i32,
     pub created_at: String,
     pub scheduled_at: String,
     pub scheduled_in: String,
@@ -147,6 +151,7 @@ pub struct BlockedJobInfo {
     pub job_id: i64,
     pub queue_name: String,
     pub class_name: String,
+    pub priority: i32,
     pub concurrency_key: String,
     pub created_at: String,
     pub waiting_time: String,
@@ -158,6 +163,7 @@ pub struct FinishedJobInfo {
     pub id: i64,
     pub queue_name: String,
     pub class_name: String,
+    pub priority: i32,
     pub created_at: String,
     pub finished_at: String,
     pub runtime: String,

--- a/src/control_plane/models.rs
+++ b/src/control_plane/models.rs
@@ -60,6 +60,7 @@ pub struct WorkerInfo {
     pub status: String,
     pub quiet: bool,
     pub revision: Option<String>,
+    pub memory: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/control_plane/models.rs
+++ b/src/control_plane/models.rs
@@ -54,6 +54,7 @@ pub struct WorkerInfo {
     pub kind: String,
     pub hostname: String,
     pub pid: i32,
+    pub created_at: String,
     pub last_heartbeat_at: String,
     pub seconds_since_heartbeat: i64,
     pub status: String,

--- a/src/control_plane/templates/blocked-jobs.html
+++ b/src/control_plane/templates/blocked-jobs.html
@@ -69,6 +69,9 @@
           Queue
         </th>
         <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          Priority
+        </th>
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Blocked By
         </th>
         <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
@@ -92,6 +95,9 @@
           </td>
           <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm text-gray-900">{{ job.queue_name }}</div>
+          </td>
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
+            <div class="text-sm text-gray-900">{% if job.priority != 0 %}{{ job.priority }}{% else %}—{% endif %}</div>
           </td>
           <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm text-gray-900">{{ job.concurrency_key }}</div>
@@ -123,7 +129,7 @@
         {% endfor %}
       {% else %}
         <tr>
-          <td colspan="5" class="px-3 py-3 sm:px-6 sm:py-4 text-center text-sm text-gray-500">
+          <td colspan="6" class="px-3 py-3 sm:px-6 sm:py-4 text-center text-sm text-gray-500">
             No blocked jobs found
           </td>
         </tr>

--- a/src/control_plane/templates/blocked-jobs.html
+++ b/src/control_plane/templates/blocked-jobs.html
@@ -97,7 +97,7 @@
             <div class="text-sm text-gray-900">{{ job.queue_name }}</div>
           </td>
           <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
-            <div class="text-sm text-gray-900">{% if job.priority != 0 %}{{ job.priority }}{% else %}—{% endif %}</div>
+            <div class="text-sm {% if job.priority == 0 %}text-gray-400{% else %}text-gray-900{% endif %}">{{ job.priority }}</div>
           </td>
           <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm text-gray-900">{{ job.concurrency_key }}</div>

--- a/src/control_plane/templates/failed-jobs.html
+++ b/src/control_plane/templates/failed-jobs.html
@@ -79,6 +79,9 @@
             Job
           </th>
           <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+            Priority
+          </th>
+          <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
             Error
           </th>
           <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
@@ -96,6 +99,9 @@
             </div>
             <div class="text-sm text-gray-500">ID: {{ job.id }}</div>
             <div class="text-xs text-gray-400">Queue: {{ job.queue_name }}</div>
+          </td>
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
+            <div class="text-sm text-gray-900">{% if job.priority != 0 %}{{ job.priority }}{% else %}—{% endif %}</div>
           </td>
           <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm text-red-600">
@@ -133,7 +139,7 @@
         {% endfor %}
         {% else %}
         <tr>
-          <td colspan="3" class="px-3 py-3 sm:px-6 sm:py-4 text-center text-sm text-gray-500">
+          <td colspan="4" class="px-3 py-3 sm:px-6 sm:py-4 text-center text-sm text-gray-500">
             No failed jobs found.
           </td>
         </tr>

--- a/src/control_plane/templates/failed-jobs.html
+++ b/src/control_plane/templates/failed-jobs.html
@@ -101,7 +101,7 @@
             <div class="text-xs text-gray-400">Queue: {{ job.queue_name }}</div>
           </td>
           <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
-            <div class="text-sm text-gray-900">{% if job.priority != 0 %}{{ job.priority }}{% else %}—{% endif %}</div>
+            <div class="text-sm {% if job.priority == 0 %}text-gray-400{% else %}text-gray-900{% endif %}">{{ job.priority }}</div>
           </td>
           <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm text-red-600">

--- a/src/control_plane/templates/finished-jobs.html
+++ b/src/control_plane/templates/finished-jobs.html
@@ -114,7 +114,7 @@
             <div class="text-sm text-gray-900">{{ job.queue_name }}</div>
           </td>
           <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
-            <div class="text-sm text-gray-900">{% if job.priority != 0 %}{{ job.priority }}{% else %}—{% endif %}</div>
+            <div class="text-sm {% if job.priority == 0 %}text-gray-400{% else %}text-gray-900{% endif %}">{{ job.priority }}</div>
           </td>
           <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm text-gray-900"><span data-controller="localtime" data-localtime-datetime-value="{{ job.created_at }}">{{ job.created_at }}</span></div>

--- a/src/control_plane/templates/finished-jobs.html
+++ b/src/control_plane/templates/finished-jobs.html
@@ -57,6 +57,10 @@
         <div class="text-xs text-gray-500">id {{ job.id }} · {{ job.queue_name }}</div>
       </div>
       <dl class="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
+        {% if job.priority != 0 %}
+        <dt class="text-gray-500">Priority</dt>
+        <dd class="text-gray-900">{{ job.priority }}</dd>
+        {% endif %}
         <dt class="text-gray-500">Created</dt>
         <dd class="text-gray-900"><span data-controller="localtime" data-localtime-datetime-value="{{ job.created_at }}">{{ job.created_at }}</span></dd>
         <dt class="text-gray-500">Finished</dt>
@@ -83,6 +87,9 @@
           Queue
         </th>
         <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          Priority
+        </th>
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Created At
         </th>
         <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
@@ -107,6 +114,9 @@
             <div class="text-sm text-gray-900">{{ job.queue_name }}</div>
           </td>
           <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
+            <div class="text-sm text-gray-900">{% if job.priority != 0 %}{{ job.priority }}{% else %}—{% endif %}</div>
+          </td>
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm text-gray-900"><span data-controller="localtime" data-localtime-datetime-value="{{ job.created_at }}">{{ job.created_at }}</span></div>
           </td>
           <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
@@ -119,7 +129,7 @@
         {% endfor %}
       {% else %}
         <tr>
-          <td colspan="5" class="px-3 py-3 sm:px-6 sm:py-4 text-center text-sm text-gray-500">
+          <td colspan="6" class="px-3 py-3 sm:px-6 sm:py-4 text-center text-sm text-gray-500">
             No finished jobs found
           </td>
         </tr>

--- a/src/control_plane/templates/in-progress-jobs.html
+++ b/src/control_plane/templates/in-progress-jobs.html
@@ -114,7 +114,7 @@
             <div class="text-sm text-gray-900">{{ job.queue_name }}</div>
           </td>
           <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
-            <div class="text-sm text-gray-900">{% if job.priority != 0 %}{{ job.priority }}{% else %}—{% endif %}</div>
+            <div class="text-sm {% if job.priority == 0 %}text-gray-400{% else %}text-gray-900{% endif %}">{{ job.priority }}</div>
           </td>
           <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm text-gray-900">{{ job.worker_info }}</div>

--- a/src/control_plane/templates/in-progress-jobs.html
+++ b/src/control_plane/templates/in-progress-jobs.html
@@ -57,6 +57,10 @@
         <div class="text-xs text-gray-500">id {{ job.job_id }} · {{ job.queue_name }}</div>
       </div>
       <dl class="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
+        {% if job.priority != 0 %}
+        <dt class="text-gray-500">Priority</dt>
+        <dd class="text-gray-900">{{ job.priority }}</dd>
+        {% endif %}
         <dt class="text-gray-500">Started</dt>
         <dd class="text-gray-900"><span data-controller="localtime" data-localtime-datetime-value="{{ job.started_at }}">{{ job.started_at }}</span></dd>
         <dt class="text-gray-500">Worker</dt>
@@ -83,6 +87,9 @@
           Queue
         </th>
         <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          Priority
+        </th>
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Worker
         </th>
         <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
@@ -107,6 +114,9 @@
             <div class="text-sm text-gray-900">{{ job.queue_name }}</div>
           </td>
           <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
+            <div class="text-sm text-gray-900">{% if job.priority != 0 %}{{ job.priority }}{% else %}—{% endif %}</div>
+          </td>
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm text-gray-900">{{ job.worker_info }}</div>
           </td>
           <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
@@ -118,7 +128,7 @@
         {% endfor %}
       {% else %}
         <tr>
-          <td colspan="5" class="px-3 py-3 sm:px-6 sm:py-4 text-center text-sm text-gray-500">
+          <td colspan="6" class="px-3 py-3 sm:px-6 sm:py-4 text-center text-sm text-gray-500">
             No in-progress jobs found
           </td>
         </tr>

--- a/src/control_plane/templates/queue-details.html
+++ b/src/control_plane/templates/queue-details.html
@@ -91,7 +91,7 @@
                 <div class="text-sm text-gray-500">{{ job.id }}</div>
               </td>
               <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
-                <div class="text-sm text-gray-900">{% if job.priority != 0 %}{{ job.priority }}{% else %}—{% endif %}</div>
+                <div class="text-sm {% if job.priority == 0 %}text-gray-400{% else %}text-gray-900{% endif %}">{{ job.priority }}</div>
               </td>
               <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap text-sm text-gray-500">
                 <span data-controller="localtime" data-localtime-datetime-value="{{ job.created_at }}">{{ job.created_at }}</span>

--- a/src/control_plane/templates/queue-details.html
+++ b/src/control_plane/templates/queue-details.html
@@ -46,6 +46,9 @@
             </div>
             <div class="text-xs text-gray-500">ID {{ job.id }}</div>
           </div>
+          {% if job.priority != 0 %}
+          <div class="text-xs text-gray-500">Priority {{ job.priority }}</div>
+          {% endif %}
           <div class="text-xs text-gray-500">
             Created <span data-controller="localtime" data-localtime-datetime-value="{{ job.created_at }}">{{ job.created_at }}</span>
           </div>
@@ -68,6 +71,9 @@
               Job ID
             </th>
             <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Priority
+            </th>
+            <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
               Created At
             </th>
           </tr>
@@ -84,6 +90,9 @@
               <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
                 <div class="text-sm text-gray-500">{{ job.id }}</div>
               </td>
+              <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
+                <div class="text-sm text-gray-900">{% if job.priority != 0 %}{{ job.priority }}{% else %}—{% endif %}</div>
+              </td>
               <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap text-sm text-gray-500">
                 <span data-controller="localtime" data-localtime-datetime-value="{{ job.created_at }}">{{ job.created_at }}</span>
               </td>
@@ -91,7 +100,7 @@
             {% endfor %}
           {% else %}
             <tr>
-              <td colspan="3" class="px-3 py-3 sm:px-6 sm:py-4 text-center text-sm text-gray-500">
+              <td colspan="4" class="px-3 py-3 sm:px-6 sm:py-4 text-center text-sm text-gray-500">
                 No ready jobs in this queue
               </td>
             </tr>

--- a/src/control_plane/templates/scheduled-jobs.html
+++ b/src/control_plane/templates/scheduled-jobs.html
@@ -84,7 +84,7 @@
             <div class="text-sm text-gray-900">{{ job.queue_name }}</div>
           </td>
           <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
-            <div class="text-sm text-gray-900">{% if job.priority != 0 %}{{ job.priority }}{% else %}—{% endif %}</div>
+            <div class="text-sm {% if job.priority == 0 %}text-gray-400{% else %}text-gray-900{% endif %}">{{ job.priority }}</div>
           </td>
           <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm text-gray-900"><span data-controller="localtime" data-localtime-datetime-value="{{ job.scheduled_at }}">{{ job.scheduled_at }}</span></div>

--- a/src/control_plane/templates/scheduled-jobs.html
+++ b/src/control_plane/templates/scheduled-jobs.html
@@ -57,6 +57,9 @@
           Queue
         </th>
         <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          Priority
+        </th>
+        <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Scheduled At
         </th>
         <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
@@ -81,6 +84,9 @@
             <div class="text-sm text-gray-900">{{ job.queue_name }}</div>
           </td>
           <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
+            <div class="text-sm text-gray-900">{% if job.priority != 0 %}{{ job.priority }}{% else %}—{% endif %}</div>
+          </td>
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             <div class="text-sm text-gray-900"><span data-controller="localtime" data-localtime-datetime-value="{{ job.scheduled_at }}">{{ job.scheduled_at }}</span></div>
             <div class="text-xs text-gray-400">{{ job.scheduled_in }}</div>
           </td>
@@ -102,7 +108,7 @@
         {% endfor %}
       {% else %}
         <tr>
-          <td colspan="5" class="px-3 py-3 sm:px-6 sm:py-4 text-center text-sm text-gray-500">
+          <td colspan="6" class="px-3 py-3 sm:px-6 sm:py-4 text-center text-sm text-gray-500">
             No scheduled jobs found
           </td>
         </tr>

--- a/src/control_plane/templates/workers.html
+++ b/src/control_plane/templates/workers.html
@@ -46,6 +46,10 @@
         <dd class="text-gray-900"><span data-controller="timeago" data-timeago-datetime-value="{{ worker.last_heartbeat_at }}"></span></dd>
         <dt class="text-gray-500">Uptime</dt>
         <dd class="text-gray-900"><span data-controller="timeago" data-timeago-datetime-value="{{ worker.created_at }}" title="Process started"></span></dd>
+        {% if worker.memory %}
+        <dt class="text-gray-500">Memory</dt>
+        <dd class="text-gray-900">{{ worker.memory }}</dd>
+        {% endif %}
       </dl>
     </div>
     {% endfor %}
@@ -65,6 +69,7 @@
           <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">PID</th>
           <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Last Heartbeat</th>
           <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+          <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Memory</th>
         </tr>
       </thead>
       <tbody class="bg-white divide-y divide-gray-200">
@@ -117,12 +122,15 @@
               <span data-controller="timeago" data-timeago-datetime-value="{{ worker.created_at }}" title="Process started"></span>
             </div>
           </td>
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
+            <div class="text-sm text-gray-900">{{ worker.memory | default(value="—") }}</div>
+          </td>
         </tr>
         {% endfor %}
 
         {% if workers | length == 0 %}
         <tr>
-          <td colspan="7" class="px-4 py-3 text-sm text-center text-gray-500">No workers found</td>
+          <td colspan="8" class="px-4 py-3 text-sm text-center text-gray-500">No workers found</td>
         </tr>
         {% endif %}
       </tbody>

--- a/src/control_plane/templates/workers.html
+++ b/src/control_plane/templates/workers.html
@@ -46,10 +46,8 @@
         <dd class="text-gray-900"><span data-controller="timeago" data-timeago-datetime-value="{{ worker.last_heartbeat_at }}"></span></dd>
         <dt class="text-gray-500">Uptime</dt>
         <dd class="text-gray-900"><span data-controller="timeago" data-timeago-datetime-value="{{ worker.created_at }}" title="Process started"></span></dd>
-        {% if worker.memory %}
         <dt class="text-gray-500">Memory</dt>
-        <dd class="text-gray-900">{{ worker.memory }}</dd>
-        {% endif %}
+        <dd class="{% if worker.memory %}text-gray-900{% else %}text-gray-400{% endif %}">{% if worker.memory %}{{ worker.memory }}{% else %}N/A{% endif %}</dd>
       </dl>
     </div>
     {% endfor %}
@@ -68,8 +66,8 @@
           <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Hostname</th>
           <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">PID</th>
           <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Last Heartbeat</th>
-          <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
           <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Memory</th>
+          <th scope="col" class="px-3 py-2 sm:px-6 sm:py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
         </tr>
       </thead>
       <tbody class="bg-white divide-y divide-gray-200">
@@ -104,6 +102,13 @@
             <div class="text-sm text-gray-900"><span data-controller="timeago" data-timeago-datetime-value="{{ worker.last_heartbeat_at }}"></span></div>
           </td>
           <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
+            {% if worker.memory %}
+            <div class="text-sm text-gray-900">{{ worker.memory }}</div>
+            {% else %}
+            <div class="text-sm text-gray-400">N/A</div>
+            {% endif %}
+          </td>
+          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
             {% if worker.status == "alive" %}
               <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
                 Active
@@ -121,9 +126,6 @@
             <div class="mt-1 text-xs text-gray-500">
               <span data-controller="timeago" data-timeago-datetime-value="{{ worker.created_at }}" title="Process started"></span>
             </div>
-          </td>
-          <td class="px-3 py-3 sm:px-6 sm:py-4 whitespace-nowrap">
-            <div class="text-sm text-gray-900">{{ worker.memory | default(value="—") }}</div>
           </td>
         </tr>
         {% endfor %}

--- a/src/control_plane/templates/workers.html
+++ b/src/control_plane/templates/workers.html
@@ -44,6 +44,8 @@
         </dd>
         <dt class="text-gray-500">Heartbeat</dt>
         <dd class="text-gray-900"><span data-controller="timeago" data-timeago-datetime-value="{{ worker.last_heartbeat_at }}"></span></dd>
+        <dt class="text-gray-500">Uptime</dt>
+        <dd class="text-gray-900"><span data-controller="timeago" data-timeago-datetime-value="{{ worker.created_at }}" title="Process started"></span></dd>
       </dl>
     </div>
     {% endfor %}
@@ -111,6 +113,9 @@
                 Quiet
               </span>
             {% endif %}
+            <div class="mt-1 text-xs text-gray-500">
+              <span data-controller="timeago" data-timeago-datetime-value="{{ worker.created_at }}" title="Process started"></span>
+            </div>
           </td>
         </tr>
         {% endfor %}

--- a/src/control_plane/utils.rs
+++ b/src/control_plane/utils.rs
@@ -43,6 +43,18 @@ impl ControlPlane {
         datetime.format("%Y-%m-%d %H:%M:%S").to_string()
     }
 
+    /// Format an RSS byte count as a human-readable binary size, e.g. "3.1 GiB" / "298 MiB".
+    /// Picks the unit by magnitude via log-1024 (the classic StackOverflow approach).
+    pub fn format_rss_bytes(bytes: u64) -> String {
+        if bytes == 0 {
+            return "0 B".to_string();
+        }
+        const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
+        let exp = ((bytes as f64).log(1024.0).floor() as usize).min(UNITS.len() - 1);
+        let value = bytes as f64 / 1024_f64.powi(exp as i32);
+        format!("{:.1} {}", value, UNITS[exp])
+    }
+
     /// Calculate runtime from start time to now
     #[allow(dead_code)]
     pub fn calculate_runtime(started_at: NaiveDateTime) -> String {


### PR DESCRIPTION
Adds operational columns to the control plane and aligns scheduled ordering with claim order.

## Workers page
- **Uptime** — render each process's `created_at` via the existing timeago controller (Status cell on desktop, detail list on mobile). Dead workers are pruned within minutes, so no separate stop-time handling.
- **Memory (RSS)** — read `rss_bytes` from heartbeat metadata (already reported when `worker_max_rss_mb` is set) and render human-readable via a log-1024 formatter (e.g. `3.1 GiB`). Processes that don't report RSS (dispatchers, schedulers, workers without an RSS limit) show a muted `N/A`.
- Columns reordered to `Last Heartbeat | Memory | Status` so the status badge sits at the row end.

## Job lists
- **Priority** column on scheduled / in-progress / failed / finished / blocked / queue-details (desktop tables + the mobile cards that have them). The default `0` renders muted gray (it's a valid value, not missing data); non-zero — including negatives, which are higher priority — renders dark.
- **scheduled-jobs ordering** now matches the dispatcher's claim order (`scheduled_at, priority, job_id`), so jobs due at the same instant display in execution order.

## Notes
- `format_rss_bytes` is a new helper in `control_plane/utils.rs`.
- Fixed Tera autoescape turning the `/` in the `N/A` placeholder into `&#x2F;` by emitting it as literal template text.
- `cargo fmt --check` + `cargo clippy --all-targets --all-features` clean. Control plane has no automated test harness; verified by running the control plane locally and inspecting rendered output (priority muted-0/dark-non-zero, memory GiB/N-A, ordering, column layout).