### PR TITLE
feat(worker): emit structured job lifecycle log fields

### DIFF
--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1187,7 +1187,7 @@ impl Execution {
         let now = chrono::Utc::now().naive_utc();
         self.started_at = Some(now);
         let target = self.job.scheduled_at.unwrap_or(self.job.created_at);
-        let delay_ms = (now - target).num_milliseconds().max(0);
+        let delay_ms = (now - target).to_std().unwrap_or_default().as_secs_f64() * 1000.0;
         let mut job = self.job.clone();
         let jid = job.active_job_id.clone().unwrap_or_default();
         let supervised = self
@@ -1212,10 +1212,18 @@ impl Execution {
         let result = async {
             let class_name = &self.runnable.class_name;
             if job.priority == 0 {
-                info!(id = job.id, delay_ms, "Job `{class_name}' started");
+                info!(
+                    event = "job.started",
+                    id = job.id,
+                    class_name = %class_name,
+                    delay_ms,
+                    "Job `{class_name}' started"
+                );
             } else {
                 info!(
+                    event = "job.started",
                     id = job.id,
+                    class_name = %class_name,
                     priority = job.priority,
                     delay_ms,
                     "Job `{class_name}' started"
@@ -1295,32 +1303,46 @@ impl Execution {
         let job_id = self.claimed.job_id;
         let job = self.job.clone();
 
-        let eplased = self.timer.elapsed();
+        let elapsed = self.timer.elapsed();
+        let duration_ms = elapsed.as_secs_f64() * 1000.0;
+        let delay = self
+            .started_at
+            .map(|started| {
+                let target = self.job.scheduled_at.unwrap_or(self.job.created_at);
+                (started - target).to_std().unwrap_or_default()
+            })
+            .unwrap_or_default();
+        let delay_ms = delay.as_secs_f64() * 1000.0;
         async {
             if result.is_ok() {
                 info!(
+                    event = "job.completed",
+                    status = "executed",
+                    id = job_id,
+                    class_name = %self.runnable.class_name,
+                    duration_ms,
+                    delay_ms,
                     "Job `{}' executed in: {}",
                     self.runnable.class_name,
-                    format!("{eplased:?}").bright_purple(),
+                    format!("{elapsed:?}").bright_purple(),
                 );
             } else {
                 error!(
+                    event = "job.completed",
+                    status = "failed",
+                    id = job_id,
+                    class_name = %self.runnable.class_name,
+                    duration_ms,
+                    delay_ms,
                     "Job `{}' failed in: {:?}",
-                    self.runnable.class_name, eplased
+                    self.runnable.class_name, elapsed
                 );
             }
 
-            let delay = self
-                .started_at
-                .map(|started| {
-                    let target = self.job.scheduled_at.unwrap_or(self.job.created_at);
-                    (started - target).to_std().unwrap_or_default()
-                })
-                .unwrap_or_default();
             let metric = Metric {
                 id: job_id,
                 success: result.is_ok(),
-                duration: eplased,
+                duration: elapsed,
                 delay,
             };
             self.metric = Some(metric);


### PR DESCRIPTION
## Summary

Adds structured logging fields to the worker's job lifecycle log lines so they can be queried/filtered by machines, not just parsed from message text.

- `job.started`: `event`, `id`, `class_name`, (`priority`,) `delay_ms`
- `job.completed`: `event`, `status` (`executed`/`failed`), `id`, `class_name`, `duration_ms`, `delay_ms`

A single `event` value (`job.started` / `job.completed`) lets a query pull all lifecycle events of one kind; `status` then splits success from failure. `jid` continues to be inherited from the `runner` span and remains the primary search key — `id` (numeric PK) is carried only on these lines for DB-row lookup.

Also:
- Fix the `eplased` → `elapsed` typo.
- Unify `delay_ms` / `duration_ms` to `f64` milliseconds across both events (the started line previously logged `delay_ms` as truncated `i64`). The new `(now - target).to_std().unwrap_or_default()` preserves the prior negative→0 clamping.

## Note

`delay_ms` changes from integer to fractional milliseconds on the `job.started` line — a minor log schema change for any downstream consumer parsing it as an integer.

## Test

`QUEBEC_SKIP_IMPORT_HOOK=1 uv run pytest --ignore=tests/step_defs` — 229 passed. `cargo clippy --lib` clean.