### PR TITLE
feat(worker): align retry_on/discard_on/rescue_from handlers with ActiveJob

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,22 @@ QUEBEC_FORCE_OVERRIDE_QUEUE=branch_x python -m quebec your.jobs
 
 Every enqueue path rewrites `queue_name` to this value (ignoring whatever the class, call site, or scheduler specified), and the worker only consumes that queue — so jobs enqueued by one branch are never picked up by another. URL-hostile characters in the name are sanitized to `-`.
 
+### Transactional Enqueue
+
+> [!IMPORTANT]
+> **Enqueuing is _not_ part of your database transaction — even on the same database.** Quebec's enqueue runs through the Rust engine on its own connection pool, completely separate from your Python connection (SQLAlchemy / Django / psycopg). There is no way to atomically commit a business write and a job enqueue together.
+
+This is the deliberate cost of keeping the engine fully decoupled from your ORM and connection — the upside is that Quebec drags no Python database dependencies into your app, but it means the enqueue cannot join your transaction. Two failure windows follow:
+
+- The business transaction commits but the enqueue fails → **the job is lost**.
+- The enqueue commits but the business transaction rolls back → **the job runs against missing or stale data**.
+
+Recommendations:
+
+- **Enqueue after your business transaction commits.** This removes the worse direction — a job running for a write that was rolled back.
+- **Make jobs idempotent** and tolerant of data that may not be visible yet; lean on retries.
+- If you genuinely need atomicity, use a **transactional outbox**: write an outbox row inside your own transaction (business + outbox commit atomically), then relay it into a real job (at-least-once delivery).
+
 ### Delayed Jobs
 
 ```python
@@ -234,7 +250,8 @@ class PaymentJob(quebec.BaseClass):
             (ValueError,),
             wait=timedelta(seconds=5),
             attempts=1,
-            handler=lambda exc: True,  # optional callback
+            # Called once retries are exhausted; receives (job, error).
+            handler=lambda job, error: notify_admin(error),
         ),
     ]
 
@@ -242,7 +259,7 @@ class PaymentJob(quebec.BaseClass):
         process_payment(order_id)
 ```
 
-Multiple `RetryStrategy` entries can target different exception types with independent wait/attempts.
+Multiple `RetryStrategy` entries can target different exception types with independent wait/attempts. The optional `handler` fires only when a strategy's attempts are exhausted (mirroring ActiveJob's `retry_on ... do |job, error|` block) and is called with `(job, error)`. `discard_on` and `rescue_from` handlers use the same `(job, error)` signature.
 
 ### Concurrency Control
 
@@ -332,7 +349,7 @@ Restart=on-failure
 WantedBy=multi-user.target
 ```
 
-Exit code 75 is non-zero, so `Restart=on-failure` treats the planned recycle as a failure and relaunches the worker.
+Exit code 75 is non-zero, so `Restart=on-failure` treats the planned recycle as a failure and relaunches the worker. If you'd rather not have planned recycles show up as failures (in `systemctl status` or the start-limit counter), add `SuccessExitStatus=75` together with `RestartForceExitStatus=75` — the former keeps 75 out of the failure tally, the latter still forces the restart.
 
 ### Per-Queue Concurrency (experimental)
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -126,6 +126,19 @@ pub(crate) struct RetryInfo {
     pub(crate) arguments: String,
 }
 
+/// Outcome of matching a job error against its `retry_on` declarations.
+enum RetryDecision {
+    /// Attempts remain — re-enqueue with the strategy's wait.
+    Retry {
+        strategy: RetryStrategy,
+        exception_key: String,
+    },
+    /// The matching declaration is out of attempts. Carries the strategy so the
+    /// caller can run its handler (mirrors ActiveJob's `retry_on ... do` block,
+    /// which fires once attempts are exhausted).
+    Exhausted { strategy: RetryStrategy },
+}
+
 impl Runnable {
     pub fn new(class_name: String, handler: Py<PyAny>, queue_as: String, priority: i64) -> Self {
         Self {
@@ -388,7 +401,7 @@ impl Runnable {
         bound: &Bound<PyAny>,
         error: &PyErr,
         job_arguments: Option<&str>,
-    ) -> PyResult<Option<(RetryStrategy, String)>> {
+    ) -> PyResult<Option<RetryDecision>> {
         if !bound.hasattr("retry_on")? {
             return Ok(None);
         }
@@ -406,10 +419,13 @@ impl Runnable {
             if i64::from(count) + 1 >= strategy.attempts {
                 // Exhausted for this declaration — don't try other strategies
                 // (matches ActiveJob's rescue_from: first match wins)
-                return Ok(None);
+                return Ok(Some(RetryDecision::Exhausted { strategy }));
             }
 
-            return Ok(Some((strategy, key)));
+            return Ok(Some(RetryDecision::Retry {
+                strategy,
+                exception_key: key,
+            }));
         }
 
         Ok(None)
@@ -518,9 +534,7 @@ impl Runnable {
     ) -> Result<quebec_jobs::Model> {
         // Call discard handler (if any)
         if let Some(handler) = &strategy.handler {
-            if let Err(handler_error) = handler.call1(py, (error.value(py),)) {
-                warn!("Error in discard handler: {}", handler_error);
-            }
+            self.call_strategy_handler(py, handler, &job, error, "discard");
         }
 
         let error_name = error
@@ -542,6 +556,29 @@ impl Runnable {
         }
 
         // Return success directly, indicating task was discarded and marked as completed
+        Ok(job)
+    }
+
+    /// Handle retry exhaustion — run the strategy's handler and mark the job
+    /// completed without recording a failure. Mirrors ActiveJob's
+    /// `retry_on ... do |job, error|` block, which fires once attempts are used up.
+    fn handle_retry_exhausted(
+        &self,
+        py: Python,
+        strategy: &RetryStrategy,
+        error: &PyErr,
+        job: quebec_jobs::Model,
+    ) -> Result<quebec_jobs::Model> {
+        if let Some(handler) = &strategy.handler {
+            self.call_strategy_handler(py, handler, &job, error, "retry");
+        }
+
+        let error_name = error
+            .get_type(py)
+            .name()
+            .map_or_else(|_| "unknown error".to_string(), |s| s.to_string());
+        info!("Job retries exhausted for {error_name}, handled by retry handler");
+
         Ok(job)
     }
 
@@ -871,10 +908,21 @@ impl Runnable {
         // Check error handling strategies by priority
 
         // 1. Check if should retry
-        if let Some((retry_strategy, exception_key)) =
-            self.should_retry(py, &bound, error, job.arguments.as_deref())?
-        {
-            return self.apply_retry_strategy(job, retry_strategy, &exception_key);
+        match self.should_retry(py, &bound, error, job.arguments.as_deref())? {
+            Some(RetryDecision::Retry {
+                strategy,
+                exception_key,
+            }) => {
+                return self.apply_retry_strategy(job, strategy, &exception_key);
+            }
+            // Attempts exhausted with a handler — run it and complete the job,
+            // matching ActiveJob's `retry_on ... do |job, error|` block.
+            Some(RetryDecision::Exhausted { strategy }) if strategy.handler.is_some() => {
+                return self.handle_retry_exhausted(py, &strategy, error, job.clone());
+            }
+            // Exhausted without a handler (or no match) — fall through to
+            // discard / rescue / default failure handling.
+            _ => {}
         }
 
         // 2. Check if should discard
@@ -975,7 +1023,10 @@ impl Runnable {
         strategy: &RescueStrategy,
         error: &PyErr,
     ) -> Result<quebec_jobs::Model> {
-        match strategy.handler.call1(py, (error.value(py),)) {
+        let job_arg = self
+            .build_job_instance(py, job)
+            .unwrap_or_else(|| py.None().into_bound(py));
+        match strategy.handler.call1(py, (job_arg, error.value(py))) {
             Ok(_) => {
                 info!("Job rescued from error");
                 Ok(job.clone())

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -9,6 +9,7 @@ use tokio_util::sync::CancellationToken;
 
 use tracing::{debug, error, info, trace, warn};
 
+use pyo3::exceptions::PyBaseException;
 use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
 
@@ -498,30 +499,82 @@ impl Runnable {
         Ok(None)
     }
 
-    /// Check if exception matches
+    /// Check whether `error` matches the strategy's declared exception spec.
+    ///
+    /// The spec must be an exception class or a tuple of them. Every entry is
+    /// validated up front: anything that is not a `BaseException` subclass
+    /// (e.g. a lambda or a non-exception type) can never match and is almost
+    /// certainly a misconfiguration, so it is warned about regardless of
+    /// whether another entry in the tuple matched.
     fn is_exception_match(
         &self,
         py: Python,
         exceptions: &Py<PyAny>,
         error: &PyErr,
     ) -> PyResult<bool> {
-        let exceptions_bound = exceptions.bind(py);
+        let bound = exceptions.bind(py);
 
-        if let Ok(exception_type) = exceptions_bound.cast::<PyType>() {
-            return Ok(error.is_instance(py, exception_type));
-        }
+        // Normalize a single class or a tuple of classes into a flat item list.
+        let items: Vec<Bound<PyAny>> = match bound.cast::<PyTuple>() {
+            Ok(tuple) => tuple.iter().collect(),
+            Err(_) => vec![bound.clone()],
+        };
 
-        if let Ok(exception_tuple) = exceptions_bound.cast::<PyTuple>() {
-            let matched = exception_tuple.iter().any(|item| {
-                item.cast::<PyType>()
-                    .is_ok_and(|exception_type| error.is_instance(py, exception_type))
-            });
-            if matched {
-                return Ok(true);
+        let mut matched = false;
+        for item in &items {
+            let valid_class = item
+                .cast::<PyType>()
+                .ok()
+                .filter(|ty| ty.is_subclass_of::<PyBaseException>().unwrap_or(false));
+
+            match valid_class {
+                Some(ty) => {
+                    if error.is_instance(py, ty) {
+                        matched = true;
+                    }
+                }
+                None => warn!(
+                    "retry_on/discard_on/rescue_from exception spec must be exception \
+                     classes; got an unsupported entry (e.g. a lambda or non-exception \
+                     type), which can never match and was ignored"
+                ),
             }
         }
 
-        Ok(false)
+        Ok(matched)
+    }
+
+    /// Build the job instance handed to error-strategy handlers as the first
+    /// argument, mirroring ActiveJob's `yield self, error` (the block's first
+    /// parameter is the job instance). Constructed the same way as the
+    /// `after_discard` hook: instantiate the job class and stamp its id.
+    /// Falls back to `None` so the handler still receives `error`.
+    fn build_job_instance<'py>(
+        &self,
+        py: Python<'py>,
+        job: &quebec_jobs::Model,
+    ) -> Option<Bound<'py, PyAny>> {
+        let instance = self.handler.bind(py).call0().ok()?;
+        instance.setattr("id", job.id).ok();
+        Some(instance)
+    }
+
+    /// Invoke an error-strategy handler with `(job, error)`. Logs and swallows
+    /// any error raised inside the handler.
+    fn call_strategy_handler(
+        &self,
+        py: Python,
+        handler: &Py<PyAny>,
+        job: &quebec_jobs::Model,
+        error: &PyErr,
+        label: &str,
+    ) {
+        let job_arg = self
+            .build_job_instance(py, job)
+            .unwrap_or_else(|| py.None().into_bound(py));
+        if let Err(handler_error) = handler.call1(py, (job_arg, error.value(py))) {
+            warn!("Error in {label} handler: {handler_error}");
+        }
     }
 
     /// Handle discard - directly mark task as completed without recording failure information

--- a/tests/test_error_strategies.py
+++ b/tests/test_error_strategies.py
@@ -1,11 +1,45 @@
 from __future__ import annotations
 
+from datetime import timedelta
+
 import quebec
 
 
+class RetryExhaustingJob(quebec.BaseClass):
+    # Handlers receive (job, error), matching ActiveJob's `yield self, error`.
+    handled: list[tuple[str, str]] = []
+    retry_on = [
+        quebec.RetryStrategy(
+            (ValueError,),
+            wait=timedelta(seconds=1),
+            attempts=1,
+            handler=lambda job, exc: RetryExhaustingJob.handled.append(
+                (type(job).__name__, str(exc))
+            ),
+        )
+    ]
+
+    def perform(self, value: int) -> None:
+        raise ValueError(f"boom {value}")
+
+
+class RetryWithAttemptsJob(quebec.BaseClass):
+    handled: list[str] = []
+    retry_on = [
+        quebec.RetryStrategy(
+            (ValueError,),
+            wait=timedelta(seconds=1),
+            attempts=3,
+            handler=lambda job, exc: RetryWithAttemptsJob.handled.append(str(exc)),
+        )
+    ]
+
+    def perform(self, value: int) -> None:
+        raise ValueError(f"boom {value}")
+
 class DiscardingJob(quebec.BaseClass):
     discard_events: list[str] = []
-    discard_on = [quebec.DiscardStrategy((ValueError,), lambda exc: None)]
+    discard_on = [quebec.DiscardStrategy((ValueError,), lambda job, exc: None)]
 
     def perform(self, value: int) -> None:
         raise ValueError(f"discard {value}")
@@ -19,13 +53,55 @@ class RescuingJob(quebec.BaseClass):
     rescue_from = [
         quebec.RescueStrategy(
             (ValueError,),
-            lambda exc: RescuingJob.rescued.append(str(exc)),
+            lambda job, exc: RescuingJob.rescued.append(str(exc)),
         )
     ]
 
     def perform(self, value: int) -> None:
         raise ValueError(f"rescued {value}")
 
+
+def test_retry_handler_runs_on_exhaustion_without_failed_execution(
+    qc_with_sqlalchemy, db_assert
+) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+
+    RetryExhaustingJob.handled = []
+    qc.register_job(RetryExhaustingJob)
+
+    RetryExhaustingJob.perform_later(qc, 7)
+    execution = qc.drain_one()
+    execution.perform()
+
+    # attempts=1 means the first failure is already exhausted: the handler
+    # fires once with (job, error) and the job completes without a retry or a
+    # failed execution.
+    assert RetryExhaustingJob.handled == [("RetryExhaustingJob", "boom 7")]
+    assert db_assert.count_jobs() == 1
+    assert db_assert.count_ready_executions() == 0
+    assert db_assert.count_claimed_executions() == 0
+    assert db_assert.count_scheduled_executions() == 0
+    assert db_assert.count_failed_executions() == 0
+
+
+def test_retry_handler_does_not_fire_on_intermediate_attempt(
+    qc_with_sqlalchemy, db_assert
+) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+
+    RetryWithAttemptsJob.handled = []
+    qc.register_job(RetryWithAttemptsJob)
+
+    RetryWithAttemptsJob.perform_later(qc, 9)
+    execution = qc.drain_one()
+    execution.perform()
+
+    # attempts=3: the first failure still has attempts left, so it takes the
+    # Retry path — the handler must NOT fire, a retry is scheduled, and no
+    # failed execution is recorded.
+    assert RetryWithAttemptsJob.handled == []
+    assert db_assert.count_scheduled_executions() == 1
+    assert db_assert.count_failed_executions() == 0
 
 def test_discard_strategy_marks_job_finished_without_failed_execution(
     qc_with_sqlalchemy, db_assert

--- a/tests/test_error_strategies.py
+++ b/tests/test_error_strategies.py
@@ -37,6 +37,24 @@ class RetryWithAttemptsJob(quebec.BaseClass):
     def perform(self, value: int) -> None:
         raise ValueError(f"boom {value}")
 
+
+class MixedSpecJob(quebec.BaseClass):
+    # A tuple mixing a real exception class with a non-class entry: the valid
+    # class must still match (the bogus entry is ignored, with a warning).
+    handled: list[str] = []
+    retry_on = [
+        quebec.RetryStrategy(
+            (ValueError, lambda exc: exc),
+            wait=timedelta(seconds=1),
+            attempts=1,
+            handler=lambda job, exc: MixedSpecJob.handled.append(str(exc)),
+        )
+    ]
+
+    def perform(self, value: int) -> None:
+        raise ValueError(f"mixed {value}")
+
+
 class DiscardingJob(quebec.BaseClass):
     discard_events: list[str] = []
     discard_on = [quebec.DiscardStrategy((ValueError,), lambda job, exc: None)]
@@ -102,6 +120,26 @@ def test_retry_handler_does_not_fire_on_intermediate_attempt(
     assert RetryWithAttemptsJob.handled == []
     assert db_assert.count_scheduled_executions() == 1
     assert db_assert.count_failed_executions() == 0
+
+
+def test_mixed_exception_tuple_still_matches_valid_class(
+    qc_with_sqlalchemy, db_assert
+) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+
+    MixedSpecJob.handled = []
+    qc.register_job(MixedSpecJob)
+
+    MixedSpecJob.perform_later(qc, 3)
+    execution = qc.drain_one()
+    execution.perform()
+
+    # The ValueError entry matches even though the tuple also contains a bogus
+    # non-class entry; the handler fires on exhaustion (attempts=1).
+    assert MixedSpecJob.handled == ["mixed 3"]
+    assert db_assert.count_failed_executions() == 0
+    assert db_assert.count_scheduled_executions() == 0
+
 
 def test_discard_strategy_marks_job_finished_without_failed_execution(
     qc_with_sqlalchemy, db_assert


### PR DESCRIPTION
## Summary

Brings Quebec's error-strategy handlers in line with ActiveJob (`ActiveJob::Exceptions`) semantics, verified against the activejob 8.0.2 source.

- **`retry_on` handler now fires on retry exhaustion.** Previously the `handler` field was parsed but never invoked on the retry path (only `discard_on` called its handler). It now runs once a strategy's `attempts` are exhausted — mirroring ActiveJob's `retry_on ... do |job, error|` block, which yields only after the final failed attempt. The job is then completed without recording a failed execution. Gate condition `count + 1 >= attempts` is mathematically identical to ActiveJob's `executions >= attempts`.
- **All three handlers (`retry_on` / `discard_on` / `rescue_from`) now receive `(job, error)`.** Matches ActiveJob's `yield self, error`. The `job` argument is a freshly constructed job instance with its `id` stamped, the same way the `after_discard` hook builds one.
- **Invalid exception specs now warn instead of failing silently.** `is_exception_match` validates every entry as a `BaseException` subclass. A spec that is a lambda or a non-exception type (or a tuple entry that is) can never match and previously fell through silently; it now emits a `warn!`, regardless of whether another tuple entry matched.

## Breaking change

`discard_on` / `rescue_from` handlers previously took a single `(error)` argument. They now take `(job, error)`. Existing single-arg `lambda exc: ...` handlers will raise `TypeError`. README and API docs updated accordingly.

## Tests

Added to `tests/test_error_strategies.py`:
- handler fires on exhaustion with `(job, error)`, no failed execution
- handler does NOT fire on intermediate (non-exhausted) attempts
- a mixed tuple `(ValueError, <non-class>)` still matches the valid class

Full suite: 244 passed. `cargo clippy --all-targets --all-features` clean.