### PR TITLE
feat(control-plane): show job priority on job details page

### DIFF
--- a/src/control_plane/handlers/job_details.rs
+++ b/src/control_plane/handlers/job_details.rs
@@ -41,6 +41,7 @@ impl ControlPlane {
             j.id,
             j.queue_name,
             j.class_name,
+            j.priority,
             j.created_at,
             j.finished_at,
             j.arguments,
@@ -87,6 +88,7 @@ impl ControlPlane {
             let job_id: i64 = row.try_get("", "id").unwrap_or_default();
             let queue_name: String = row.try_get("", "queue_name").unwrap_or_default();
             let class_name: String = row.try_get("", "class_name").unwrap_or_default();
+            let priority: i32 = row.try_get("", "priority").unwrap_or(0);
             let status: String = row.try_get("", "status").unwrap_or_default();
             let arguments: Option<String> = row.try_get("", "arguments").ok();
             let error: Option<String> = row.try_get("", "error_message").ok();
@@ -124,6 +126,7 @@ impl ControlPlane {
                 id: job_id,
                 queue_name,
                 class_name,
+                priority,
                 status: status.clone(),
                 created_at,
                 failed_at: None,

--- a/src/control_plane/models.rs
+++ b/src/control_plane/models.rs
@@ -174,6 +174,7 @@ pub struct JobDetailsInfo {
     pub id: i64,
     pub queue_name: String,
     pub class_name: String,
+    pub priority: i32,
     pub status: String,
     pub created_at: String,
     pub failed_at: Option<String>,

--- a/src/control_plane/templates.rs
+++ b/src/control_plane/templates.rs
@@ -211,6 +211,13 @@ mod tests {
         assert_eq!(templates.first().map(String::as_str), Some("base.html"));
     }
 
+    #[test]
+    fn job_details_template_renders_job_priority() {
+        let template =
+            get_template_content("job-details.html").expect("job details template exists");
+        assert!(template.contains("{{ job.priority }}"));
+    }
+
     #[cfg(debug_assertions)]
     #[test]
     fn manifest_template_path_points_to_control_plane_templates() {

--- a/src/control_plane/templates/job-details.html
+++ b/src/control_plane/templates/job-details.html
@@ -87,7 +87,7 @@
           </div>
           <div class="grid grid-cols-3 gap-2">
             <div class="text-sm text-gray-500">Priority</div>
-            <div class="col-span-2 text-sm">0</div>
+            <div class="col-span-2 text-sm {% if job.priority == 0 %}text-gray-400{% else %}text-gray-900{% endif %}">{{ job.priority }}</div>
           </div>
           <div class="grid grid-cols-3 gap-2">
             <div class="text-sm text-gray-500">Created at</div>

--- a/src/control_plane/templates/job-details.html
+++ b/src/control_plane/templates/job-details.html
@@ -161,11 +161,7 @@
             <pre class="text-xs text-gray-800 whitespace-pre-wrap">{{ job.context }}</pre>
           </div>
           {% else %}
-          <div class="text-sm text-gray-500">{
-  "locale": "en",
-  "timezone": "Asia/Shanghai",
-  "request_id": "f7ceb5a1-8e7d-4f37-b7fd-42388127a67c"
-}</div>
+          <div class="text-sm text-gray-500">No context for this job.</div>
           {% endif %}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Surface the job `priority` value on the control plane job details page instead of the hardcoded `0`. Select `j.priority` in the query, carry it through `JobDetailsInfo`, and render it in the template — default priority (`0`) is dimmed, non-default values are emphasized.
- Fix the job context section: the empty-context branch accidentally rendered a hardcoded JSON blob; replace it with a proper placeholder message.

## Test plan
- `cargo check` / `cargo clippy` pass (pre-existing `explicit_counter_loop` warning is unrelated).
- Added `job_details_template_renders_job_priority` template test asserting `{{ job.priority }}` is present.