### PR TITLE
fix(worker): sample live RSS for runtime metadata instead of stale cache

### DIFF
--- a/src/worker.rs
+++ b/src/worker.rs
@@ -15,7 +15,7 @@ use pyo3::prelude::*;
 
 use sea_orm::TransactionTrait;
 use sea_orm::*;
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::Instant;
 use tokio::sync::mpsc::Sender;
@@ -28,6 +28,19 @@ use pyo3::exceptions::PyTypeError;
 use pyo3::types::{PyBool, PyDict, PyList, PyTuple, PyType};
 
 use crate::notify::NotifyManager;
+
+fn reported_worker_rss_bytes(
+    last_rss_bytes: &AtomicU64,
+    current_rss_bytes: Option<u64>,
+) -> Option<u64> {
+    if let Some(rss_bytes) = current_rss_bytes {
+        last_rss_bytes.store(rss_bytes, Ordering::Relaxed);
+        Some(rss_bytes)
+    } else {
+        let rss_bytes = last_rss_bytes.load(Ordering::Relaxed);
+        (rss_bytes > 0).then_some(rss_bytes)
+    }
+}
 
 fn json_to_py(py: Python<'_>, value: &serde_json::Value) -> PyResult<Py<PyAny>> {
     match value {
@@ -4948,14 +4961,45 @@ impl ProcessTrait for Worker {
     }
 
     fn runtime_metadata(&self) -> Option<String> {
-        let rss_bytes = self.ctx.worker_last_rss_bytes.load(Ordering::Relaxed);
+        let rss_bytes = reported_worker_rss_bytes(
+            &self.ctx.worker_last_rss_bytes,
+            crate::memory::current_rss_bytes(),
+        );
         crate::process::build_runtime_metadata_with_memory(
             self.ctx.quiet.is_cancelled(),
             self.ctx
                 .worker_memory_recycle_requested
                 .load(Ordering::Relaxed)
                 .then_some("rss_limit"),
-            (rss_bytes > 0).then_some(rss_bytes),
+            rss_bytes,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::reported_worker_rss_bytes;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    #[test]
+    fn reported_worker_rss_updates_cache_from_current_sample() {
+        let last = AtomicU64::new(0);
+
+        assert_eq!(reported_worker_rss_bytes(&last, Some(123)), Some(123));
+        assert_eq!(last.load(Ordering::Relaxed), 123);
+    }
+
+    #[test]
+    fn reported_worker_rss_falls_back_to_cached_sample() {
+        let last = AtomicU64::new(456);
+
+        assert_eq!(reported_worker_rss_bytes(&last, None), Some(456));
+    }
+
+    #[test]
+    fn reported_worker_rss_is_absent_without_current_or_cached_sample() {
+        let last = AtomicU64::new(0);
+
+        assert_eq!(reported_worker_rss_bytes(&last, None), None);
     }
 }


### PR DESCRIPTION
## Problem
Worker runtime metadata (reported to the control plane on each heartbeat) read `worker_last_rss_bytes`, a cache that is only written by the memory-check loop. Once a worker exceeds `worker_max_rss_mb` and a memory recycle is requested, that loop stops calling `update_worker_rss` and only polls for exit — so the cached RSS freezes at the value observed when recycle was triggered. The heartbeat then keeps reporting that frozen value, which shows up as memory that "saved once and never updates again".

## Fix
`runtime_metadata` now samples the current RSS itself on each call via `crate::memory::current_rss_bytes()`, updating the cache when a sample is available and falling back to the cached value otherwise. Reported memory keeps refreshing through the quiet/recycle phase, and it also works when no `worker_max_rss_mb` is configured (the memory-check loop never runs in that case).

The sampling logic is extracted into `reported_worker_rss_bytes` with unit tests covering the live-sample, fallback, and absent cases.

## Test plan
- `cargo check` / `cargo clippy` pass.
- `cargo test --lib reported_worker_rss` (3 tests) pass. Note: this needs `libpython` on the dyld path because the crate links the extension module — e.g. `DYLD_FALLBACK_LIBRARY_PATH=$(python3 -c 'import sysconfig;print(sysconfig.get_config_var("LIBDIR"))') cargo test --lib reported_worker_rss`.