### PR TITLE
perf(control-plane): stop COUNT-ing the unbounded finished jobs table

### DIFF
--- a/src/control_plane/handlers/finished_jobs.rs
+++ b/src/control_plane/handlers/finished_jobs.rs
@@ -34,17 +34,22 @@ impl ControlPlane {
         let page_size = state.page_size;
         let offset = (pagination.page - 1) * page_size;
 
-        // Get completed jobs using query_builder (filters applied at SQL level)
-        let finished_jobs_models = query_builder::jobs::find_finished_paginated(
+        // Fetch one extra row to detect whether a next page exists, avoiding a
+        // full-table COUNT on the (unbounded) finished jobs. Mirrors Mission
+        // Control's keyset-style "N / ..." pagination.
+        let mut finished_jobs_models = query_builder::jobs::find_finished_paginated(
             db,
             table_config,
             offset,
-            page_size,
+            page_size + 1,
             pagination.class_name.as_deref(),
             pagination.queue_name.as_deref(),
         )
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+        let has_next = finished_jobs_models.len() as u64 > page_size;
+        finished_jobs_models.truncate(page_size as usize);
 
         // Create a vector to store completed job information
         let mut finished_jobs: Vec<FinishedJobInfo> =
@@ -99,34 +104,12 @@ impl ControlPlane {
         debug!("Fetched finished jobs in {:?}", start.elapsed());
         info!("Found {} finished jobs", finished_jobs.len());
 
-        // Get total number of completed jobs for pagination using query_builder
-        let start = Instant::now();
-
-        let total_count: u64 = query_builder::jobs::count_finished(
-            db,
-            table_config,
-            pagination.class_name.as_deref(),
-            pagination.queue_name.as_deref(),
-        )
-        .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-
-        info!("Total finished jobs count: {}", total_count);
-
-        let total_pages = ((total_count as f64) / (page_size as f64)).ceil() as u64;
-        let total_pages = total_pages.max(1);
-
-        if total_pages > 0 && pagination.page > total_pages {
-            return Err((StatusCode::NOT_FOUND, "Page not found".to_string()));
-        }
-        debug!("Fetched count in {:?}", start.elapsed());
-
         let start = Instant::now();
         let mut context = tera::Context::new();
         context.insert("finished_jobs", &finished_jobs);
         context.insert("filter_options", &filter_options);
         context.insert("current_page_num", &pagination.page);
-        context.insert("total_pages", &total_pages);
+        context.insert("has_next", &has_next);
         context.insert("active_page", "finished-jobs");
         context.insert("filter_class_name", &pagination.class_name);
         context.insert("filter_queue_name", &pagination.queue_name);

--- a/src/control_plane/mod.rs
+++ b/src/control_plane/mod.rs
@@ -41,10 +41,6 @@ pub struct ControlPlane {
     /// queue or job class first appears, so a short TTL avoids repeated
     /// full-table DISTINCT scans on solid_queue_jobs.
     pub(crate) filter_options_cache: moka::future::Cache<FilterKind, Arc<Vec<String>>>,
-    /// Cache for the finished-job COUNT behind the nav "Finished jobs" badge.
-    /// The count only grows and is a coarse overview number, so a short TTL
-    /// avoids re-running the index-only scan on every render / SSE tick.
-    pub(crate) finished_count_cache: moka::future::Cache<(), i64>,
 }
 
 impl ControlPlane {
@@ -79,9 +75,6 @@ impl ControlPlane {
             base_path: String::new(),
             sse_interval,
             filter_options_cache: moka::future::Cache::builder()
-                .time_to_live(Duration::from_secs(60))
-                .build(),
-            finished_count_cache: moka::future::Cache::builder()
                 .time_to_live(Duration::from_secs(60))
                 .build(),
         }

--- a/src/control_plane/templates.rs
+++ b/src/control_plane/templates.rs
@@ -220,6 +220,19 @@ mod tests {
         assert!(!template.contains("total_pages"));
     }
 
+    #[test]
+    fn nav_finished_badge_shows_no_count() {
+        // The finished set is unbounded; its nav badge is a static "…" rather
+        // than a COUNT, so the templates must not reference finished_jobs_count.
+        for name in ["base.html", "stats.html"] {
+            let template = get_template_content(name).expect("template exists");
+            assert!(
+                !template.contains("finished_jobs_count"),
+                "{name} should not reference finished_jobs_count"
+            );
+        }
+    }
+
     #[cfg(debug_assertions)]
     #[test]
     fn manifest_template_path_points_to_control_plane_templates() {

--- a/src/control_plane/templates.rs
+++ b/src/control_plane/templates.rs
@@ -211,6 +211,15 @@ mod tests {
         assert_eq!(templates.first().map(String::as_str), Some("base.html"));
     }
 
+    #[test]
+    fn finished_jobs_template_paginates_without_total_count() {
+        let template =
+            get_template_content("finished-jobs.html").expect("finished jobs template exists");
+        // Next page is driven by a has_next probe, not a full COUNT-derived total.
+        assert!(template.contains("has_next"));
+        assert!(!template.contains("total_pages"));
+    }
+
     #[cfg(debug_assertions)]
     #[test]
     fn manifest_template_path_points_to_control_plane_templates() {

--- a/src/control_plane/templates/base.html
+++ b/src/control_plane/templates/base.html
@@ -736,7 +736,7 @@
             <option id="nav-option-blocked-jobs" value="{{ base_path }}/blocked-jobs">Blocked jobs · {{ nav_blocked_jobs | default(value=0) }}</option>
             <option id="nav-option-scheduled-jobs" value="{{ base_path }}/scheduled-jobs">Scheduled jobs · {{ nav_scheduled_jobs | default(value=0) }}</option>
             <option value="{{ base_path }}/recurring-jobs">Recurring jobs</option>
-            <option id="nav-option-finished-jobs" value="{{ base_path }}/finished-jobs">Finished jobs · {{ finished_jobs_count | default(value=0) }}</option>
+            <option id="nav-option-finished-jobs" value="{{ base_path }}/finished-jobs">Finished jobs · …</option>
             <option value="{{ base_path }}/workers">Workers</option>
           </select>
           <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-700">
@@ -769,7 +769,7 @@
             Recurring jobs
           </a>
           <a href="{{ base_path }}/finished-jobs" data-nav-target="navItem" data-action="click->nav#navigate" class="shrink-0 whitespace-nowrap px-4 h-8 font-medium text-gray-600 hover:text-black border-b-2 border-transparent hover:border-black">
-            Finished jobs <span id="finished-jobs-count" class="px-1 py-0.5 text-xs rounded-full bg-gray-200 text-gray-800">{{ finished_jobs_count | default(value=0) }}</span>
+            Finished jobs <span id="finished-jobs-count" class="px-1 py-0.5 text-xs rounded-full bg-gray-200 text-gray-800">…</span>
           </a>
 
           <a href="{{ base_path }}/workers" data-nav-target="navItem" data-action="click->nav#navigate" class="shrink-0 whitespace-nowrap px-4 h-8 font-medium text-gray-600 hover:text-black border-b-2 border-transparent hover:border-black">

--- a/src/control_plane/templates/finished-jobs.html
+++ b/src/control_plane/templates/finished-jobs.html
@@ -141,7 +141,7 @@
 <!-- Pagination -->
 <div class="flex items-center justify-between mt-4">
   <div class="text-sm text-gray-700">
-    {{ current_page_num }} / {{ total_pages }}
+    {{ current_page_num }} / …
   </div>
   <div class="flex space-x-2">
     {% if current_page_num > 1 %}
@@ -154,7 +154,7 @@
       </button>
     {% endif %}
 
-    {% if current_page_num < total_pages %}
+    {% if has_next %}
       <a href="{{ base_path }}/finished-jobs?page={{ current_page_num + 1 }}{% if filter_args %}&{{ filter_args }}{% endif %}" data-turbo-action="advance" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 h-8 px-3 py-1">
         Next page
       </a>

--- a/src/control_plane/templates/stats.html
+++ b/src/control_plane/templates/stats.html
@@ -35,15 +35,6 @@
   <template>Scheduled jobs · {{ scheduled_jobs_count }}</template>
 </turbo-stream>
 
-<turbo-stream action="update" target="finished-jobs-count">
-  <template>
-    <span class="px-1 py-0.5 text-xs rounded-full bg-gray-200 text-gray-800">{{ finished_jobs_count }}</span>
-  </template>
-</turbo-stream>
-<turbo-stream action="update" target="nav-option-finished-jobs">
-  <template>Finished jobs · {{ finished_jobs_count }}</template>
-</turbo-stream>
-
 {# Per-queue live counters. Anchored to id="queue-count-{slug}" and
    id="queue-status-{slug}" in queues.html. The queues page is the only one
    that renders these anchors; on other pages the targets simply don't exist

--- a/src/control_plane/utils.rs
+++ b/src/control_plane/utils.rs
@@ -115,22 +115,6 @@ impl ControlPlane {
         Ok((*names).clone())
     }
 
-    /// Get the finished-job count (cached). Backs the nav "Finished jobs" badge,
-    /// where an exact value is not important.
-    async fn cached_finished_count(&self) -> Result<i64, DbErr> {
-        self.finished_count_cache
-            .try_get_with((), async {
-                let db = self.ctx.get_db().await?;
-                let db = db.as_ref();
-                let table_config = &self.ctx.table_config;
-                let count =
-                    query_builder::jobs::count_finished(db, table_config, None, None).await? as i64;
-                Ok::<_, DbErr>(count)
-            })
-            .await
-            .map_err(|e: Arc<DbErr>| DbErr::Custom(format!("finished count query failed: {e}")))
-    }
-
     /// Populate navigation statistics for templates using query_builder
     pub async fn populate_nav_stats(&self, context: &mut Context) -> Result<(), DbErr> {
         let db = self.ctx.get_db().await?;
@@ -178,9 +162,8 @@ impl ControlPlane {
         context.insert("blocked_jobs_count", &blocked_count);
         context.insert("scheduled_jobs_count", &scheduled_count);
 
-        // Count finished jobs by finished_at to match the /finished-jobs page
-        let finished_count = self.cached_finished_count().await?;
-        context.insert("finished_jobs_count", &finished_count);
+        // The finished set is unbounded; the nav badge shows "…" instead of an
+        // exact count (Mission Control parity), so no COUNT is issued here.
 
         // Per-queue ready-execution counts + paused-state snapshot, so the
         // /stats turbo-stream can update each row of the queues table in sync

--- a/src/query_builder.rs
+++ b/src/query_builder.rs
@@ -509,7 +509,6 @@ pub mod jobs {
         execute_count(db, query).await
     }
 
-    /// Count finished jobs
     /// Find finished jobs with pagination
     pub async fn find_finished_paginated<C>(
         db: &C,

--- a/src/query_builder.rs
+++ b/src/query_builder.rs
@@ -510,32 +510,6 @@ pub mod jobs {
     }
 
     /// Count finished jobs
-    pub async fn count_finished<C>(
-        db: &C,
-        table_config: &TableConfig,
-        class_name: Option<&str>,
-        queue_name: Option<&str>,
-    ) -> Result<u64, DbErr>
-    where
-        C: ConnectionTrait,
-    {
-        let table = Alias::new(&table_config.jobs);
-        let mut query = Query::select()
-            .expr(Expr::col(Asterisk).count())
-            .from(table)
-            .and_where(Expr::col(col("finished_at")).is_not_null())
-            .to_owned();
-
-        if let Some(cn) = class_name {
-            query.and_where(Expr::col(col("class_name")).eq(cn));
-        }
-        if let Some(qn) = queue_name {
-            query.and_where(Expr::col(col("queue_name")).eq(qn));
-        }
-
-        execute_count(db, query).await
-    }
-
     /// Find finished jobs with pagination
     pub async fn find_finished_paginated<C>(
         db: &C,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -156,9 +156,10 @@ mod jobs {
         assert!(job.finished_at.is_some());
 
         assert_eq!(
-            query_builder::jobs::count_finished(&db, &tc, None, None)
+            query_builder::jobs::find_finished_paginated(&db, &tc, 0, 100, None, None)
                 .await
-                .unwrap(),
+                .unwrap()
+                .len(),
             1
         );
     }
@@ -182,9 +183,10 @@ mod jobs {
             .unwrap();
         assert_eq!(rows, 2);
         assert_eq!(
-            query_builder::jobs::count_finished(&db, &tc, None, None)
+            query_builder::jobs::find_finished_paginated(&db, &tc, 0, 100, None, None)
                 .await
-                .unwrap(),
+                .unwrap()
+                .len(),
             2
         );
     }


### PR DESCRIPTION
## Problem
The finished jobs set is the only unbounded table in the control plane, yet it was counted in two places:
1. **List page** — `COUNT(*)` (with the active filters) ran on every page load to compute total pages.
2. **Nav badge** — a cached `COUNT(*)` backed the "Finished jobs" badge and refreshed on every `/stats` SSE tick.

Both degrade as finished jobs accumulate.

## Fix (Mission Control parity)
- **List page**: fetch `page_size + 1` rows to detect a next page (`has_next`) instead of deriving page count from `COUNT(*)`; render the indicator as `N / …` and drive Next off `has_next`.
- **Nav badge**: show a static `…` instead of a count; drop the count query, its `moka` cache (`finished_count_cache`), the `/stats` turbo-stream updates for the finished badge, and the now-unused `query_builder::jobs::count_finished`.

Other tabs (failed / scheduled / blocked / in-progress) are bounded and keep their precise counts.

## Non-goals
- OFFSET cost for deep pagination is unchanged (same as Mission Control).

## Test plan
- `cargo clippy` clean (pre-existing `explicit_counter_loop` warning unrelated).
- Template tests `finished_jobs_template_paginates_without_total_count` and `nav_finished_badge_shows_no_count` assert the `has_next` pagination and the absence of any `finished_jobs_count` / `total_pages` references. Run via `DYLD_FALLBACK_LIBRARY_PATH=$(python3 -c 'import sysconfig;print(sysconfig.get_config_var("LIBDIR"))') cargo test --lib control_plane::templates`.