### PR TITLE
perf(control-plane): cheaper distinct lookups for filter dropdowns

### DIFF
--- a/src/control_plane/mod.rs
+++ b/src/control_plane/mod.rs
@@ -36,10 +36,11 @@ pub struct ControlPlane {
     pub(crate) page_size: u64,
     pub(crate) base_path: String,
     pub(crate) sse_interval: Duration,
-    /// Cache for the queue-name / class-name DISTINCT lookups behind the filter
+    /// Cache for the queue-name / class-name distinct lookups behind the filter
     /// dropdowns and the /stats queue list. These sets change only when a new
-    /// queue or job class first appears, so a short TTL avoids repeated
-    /// full-table DISTINCT scans on solid_queue_jobs.
+    /// queue or job class first appears, so a 10-minute TTL keeps the distinct
+    /// scan on solid_queue_jobs rare. The scan itself is a loose index scan on
+    /// Postgres (see query_builder::jobs::distinct_column_sql).
     pub(crate) filter_options_cache: moka::future::Cache<FilterKind, Arc<Vec<String>>>,
     /// Cache for the finished-job COUNT behind the nav "Finished jobs" badge.
     /// The count only grows and is a coarse overview number, so a short TTL
@@ -79,7 +80,7 @@ impl ControlPlane {
             base_path: String::new(),
             sse_interval,
             filter_options_cache: moka::future::Cache::builder()
-                .time_to_live(Duration::from_secs(60))
+                .time_to_live(Duration::from_secs(600))
                 .build(),
             finished_count_cache: moka::future::Cache::builder()
                 .time_to_live(Duration::from_secs(60))

--- a/src/query_builder.rs
+++ b/src/query_builder.rs
@@ -656,6 +656,61 @@ pub mod jobs {
         execute_select(db, query).await
     }
 
+    /// Build the SQL returning the sorted distinct values of an indexed,
+    /// NOT NULL column.
+    ///
+    /// Postgres has no automatic skip scan, so a plain `SELECT DISTINCT col`
+    /// scans every row even with an index on `col`. Emulate a loose index
+    /// scan with a recursive CTE: each step does a single index seek for the
+    /// next larger value, making the query cost O(distinct values) instead of
+    /// O(rows). MySQL 8.0+ already performs a loose index scan for this, and
+    /// SQLite is only used for small test databases, so both keep the plain
+    /// DISTINCT. The terminating NULL row (produced when no larger value
+    /// remains) is filtered out at the end.
+    fn distinct_column_sql(backend: DbBackend, table_name: &str, column: &str) -> String {
+        let q = match backend {
+            DbBackend::MySql => '`',
+            _ => '"',
+        };
+
+        match backend {
+            DbBackend::Postgres => format!(
+                "WITH RECURSIVE t AS (\n    \
+                 (SELECT {q}{column}{q} FROM {q}{table_name}{q} ORDER BY {q}{column}{q} ASC LIMIT 1)\n    \
+                 UNION ALL\n    \
+                 SELECT (SELECT {q}{column}{q} FROM {q}{table_name}{q} \
+                 WHERE {q}{column}{q} > t.{q}{column}{q} ORDER BY {q}{column}{q} ASC LIMIT 1)\n    \
+                 FROM t WHERE t.{q}{column}{q} IS NOT NULL\n\
+                 )\n\
+                 SELECT {q}{column}{q} FROM t WHERE {q}{column}{q} IS NOT NULL \
+                 ORDER BY {q}{column}{q} ASC"
+            ),
+            _ => format!(
+                r#"SELECT DISTINCT {q}{column}{q} FROM {q}{table_name}{q} ORDER BY {q}{column}{q} ASC"#
+            ),
+        }
+    }
+
+    /// Fetch the sorted distinct values of an indexed column via a backend
+    /// query plan that avoids a full-table scan on Postgres.
+    async fn distinct_indexed_column<C>(
+        db: &C,
+        table_name: &str,
+        column: &'static str,
+    ) -> Result<Vec<String>, DbErr>
+    where
+        C: ConnectionTrait,
+    {
+        let backend = db.get_database_backend();
+        let sql = distinct_column_sql(backend, table_name, column);
+        let stmt = Statement::from_string(backend, sql);
+        let rows = db.query_all(stmt).await?;
+
+        rows.into_iter()
+            .map(|row| row.try_get("", column))
+            .collect()
+    }
+
     /// Get distinct queue names
     pub async fn get_queue_names<C>(
         db: &C,
@@ -664,24 +719,7 @@ pub mod jobs {
     where
         C: ConnectionTrait,
     {
-        let table_name = &table_config.jobs;
-        let backend = db.get_database_backend();
-
-        let (q, _) = match backend {
-            DbBackend::Postgres | DbBackend::Sqlite => ('"', '"'),
-            DbBackend::MySql => ('`', '`'),
-        };
-
-        let sql = format!(
-            r#"SELECT DISTINCT {q}queue_name{q} FROM {q}{table_name}{q} ORDER BY {q}queue_name{q} ASC"#
-        );
-
-        let stmt = Statement::from_string(backend, sql);
-        let rows = db.query_all(stmt).await?;
-
-        rows.into_iter()
-            .map(|row| row.try_get("", "queue_name"))
-            .collect()
+        distinct_indexed_column(db, &table_config.jobs, "queue_name").await
     }
 
     /// Get distinct class names
@@ -692,24 +730,7 @@ pub mod jobs {
     where
         C: ConnectionTrait,
     {
-        let table_name = &table_config.jobs;
-        let backend = db.get_database_backend();
-
-        let (q, _) = match backend {
-            DbBackend::Postgres | DbBackend::Sqlite => ('"', '"'),
-            DbBackend::MySql => ('`', '`'),
-        };
-
-        let sql = format!(
-            r#"SELECT DISTINCT {q}class_name{q} FROM {q}{table_name}{q} ORDER BY {q}class_name{q} ASC"#
-        );
-
-        let stmt = Statement::from_string(backend, sql);
-        let rows = db.query_all(stmt).await?;
-
-        rows.into_iter()
-            .map(|row| row.try_get("", "class_name"))
-            .collect()
+        distinct_indexed_column(db, &table_config.jobs, "class_name").await
     }
 
     /// Data needed to bulk-insert a single job row.
@@ -876,6 +897,39 @@ pub mod jobs {
             .to_owned();
 
         execute_count(db, query).await
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn sqlite_uses_plain_distinct() {
+            let sql = distinct_column_sql(DbBackend::Sqlite, "solid_queue_jobs", "class_name");
+            assert_eq!(
+                sql,
+                r#"SELECT DISTINCT "class_name" FROM "solid_queue_jobs" ORDER BY "class_name" ASC"#
+            );
+        }
+
+        #[test]
+        fn mysql_uses_backtick_quoting() {
+            let sql = distinct_column_sql(DbBackend::MySql, "solid_queue_jobs", "queue_name");
+            assert_eq!(
+                sql,
+                "SELECT DISTINCT `queue_name` FROM `solid_queue_jobs` ORDER BY `queue_name` ASC"
+            );
+        }
+
+        #[test]
+        fn postgres_emulates_loose_index_scan() {
+            let sql = distinct_column_sql(DbBackend::Postgres, "solid_queue_jobs", "class_name");
+            assert!(sql.starts_with("WITH RECURSIVE t AS ("));
+            assert!(sql.contains(r#"WHERE "class_name" > t."class_name""#));
+            assert!(sql.trim_end().ends_with(
+                r#"SELECT "class_name" FROM t WHERE "class_name" IS NOT NULL ORDER BY "class_name" ASC"#
+            ));
+        }
     }
 }
 


### PR DESCRIPTION
## Problem
The job-class / queue-name filter dropdowns issue `SELECT DISTINCT col` over the unbounded `solid_queue_jobs` table. On Postgres there is no automatic skip scan, so even with the existing single-column index the query scans every row; the cost grows with the table.

## Fix
- **Loose index scan (Postgres)**: `distinct_column_sql` builds a recursive CTE that seeks the next larger value one index entry at a time — O(distinct values) instead of O(rows) — with an explicit final `ORDER BY` to keep results sorted. MySQL 8.0+ already does a loose index scan for `DISTINCT` and SQLite is test-only, so both keep the plain `SELECT DISTINCT`. `get_queue_names` / `get_class_names` now share a `distinct_indexed_column` helper.
- **Cache TTL**: the filter-option `moka` cache TTL goes 60s → 10min. The distinct sets only change when a new queue/class first appears, so a longer TTL keeps the scan rare; new values still surface within 10 minutes.

## Verification
- `cargo clippy` clean.
- Unit tests assert the generated SQL per backend (`query_builder::jobs::tests`).
- Manually verified on a local Postgres that the recursive CTE returns the same sorted set as plain `DISTINCT` (multi-value / single-value / empty table) and that `EXPLAIN` shows an `Index Only Scan`, not a `Seq Scan`.

## Review notes
Reviewed with Codex. Fixed its one actionable finding (missing final `ORDER BY` — results relied on the CTE's implicit order). Two findings intentionally not addressed: the NOT-NULL-column assumption is documented and enforced by the two callers; identifier quoting that doesn't escape embedded quote chars is a pre-existing pattern (table prefix is trusted deploy-time config, column is a compile-time literal) and out of scope for this change.