### PR TITLE
style(control-plane): shadcn-style pagination via shared macro

### DIFF
--- a/src/control_plane/templates/_pagination.html
+++ b/src/control_plane/templates/_pagination.html
@@ -1,0 +1,78 @@
+{# Shared shadcn-style pagination bar.
+
+   Usage:
+     {% import "_pagination.html" as pagination %}
+     {{ pagination::bar(base_path=base_path, path="failed-jobs", page=current_page_num, total_pages=total_pages, filter_args=filter_args) }}
+
+   `total_pages=0` (the default) means the total is unknown (unbounded set):
+   pass `has_next` from a peek-one-extra-row query instead, and a trailing
+   ellipsis stands in for the unknown tail. #}
+
+{% macro num(base_path, path, p, page, filter_args="") %}
+  {%- if p == page -%}
+  <span class="inline-flex h-8 min-w-8 items-center justify-center rounded-lg border border-gray-200 px-2 text-sm font-medium text-gray-900">{{ p }}</span>
+  {%- else -%}
+  <a href="{{ base_path }}/{{ path }}?page={{ p }}{% if filter_args %}&{{ filter_args }}{% endif %}" data-turbo-action="advance" class="inline-flex h-8 min-w-8 items-center justify-center rounded-lg px-2 text-sm text-gray-700 hover:bg-gray-100">{{ p }}</a>
+  {%- endif -%}
+{% endmacro num %}
+
+{% macro gap() %}
+  <span class="inline-flex h-8 w-8 items-center justify-center text-sm text-gray-500">…</span>
+{% endmacro gap %}
+
+{% macro bar(base_path, path, page, total_pages=0, has_next=false, filter_args="") %}
+  {% set win_lo = page - 1 %}
+  {% if win_lo < 2 %}{% set win_lo = 2 %}{% endif %}
+  {% set win_hi = page %}
+  {% set tail_gap = false %}
+  {% set next_ok = false %}
+  {% if total_pages > 0 %}
+    {% set win_hi = page + 1 %}
+    {% if win_hi > total_pages - 1 %}{% set win_hi = total_pages - 1 %}{% endif %}
+    {% if win_hi < total_pages - 1 %}{% set tail_gap = true %}{% endif %}
+    {% if page < total_pages %}{% set next_ok = true %}{% endif %}
+  {% elif has_next %}
+    {% set win_hi = page + 1 %}
+    {% set tail_gap = true %}
+    {% set next_ok = true %}
+  {% endif %}
+  <div class="flex items-center justify-end mt-4">
+    <div class="flex items-center gap-1">
+      {% if page > 1 %}
+      <a href="{{ base_path }}/{{ path }}?page={{ page - 1 }}{% if filter_args %}&{{ filter_args }}{% endif %}" data-turbo-action="advance" class="inline-flex items-center gap-1 h-8 rounded-lg pl-2 pr-3 text-sm font-medium text-gray-700 hover:bg-gray-100 hover:text-gray-900">
+        <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7"/></svg>
+        Previous
+      </a>
+      {% else %}
+      <span class="inline-flex items-center gap-1 h-8 rounded-lg pl-2 pr-3 text-sm font-medium text-gray-400">
+        <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7"/></svg>
+        Previous
+      </span>
+      {% endif %}
+
+      <nav class="flex items-center gap-1 px-1 tabular-nums">
+        {{ self::num(base_path=base_path, path=path, p=1, page=page, filter_args=filter_args) }}
+        {% if win_lo > 2 %}{{ self::gap() }}{% endif %}
+        {% if win_hi >= win_lo %}
+          {% for p in range(start=win_lo, end=win_hi + 1) %}
+            {{ self::num(base_path=base_path, path=path, p=p, page=page, filter_args=filter_args) }}
+          {% endfor %}
+        {% endif %}
+        {% if tail_gap %}{{ self::gap() }}{% endif %}
+        {% if total_pages > 1 %}{{ self::num(base_path=base_path, path=path, p=total_pages, page=page, filter_args=filter_args) }}{% endif %}
+      </nav>
+
+      {% if next_ok %}
+      <a href="{{ base_path }}/{{ path }}?page={{ page + 1 }}{% if filter_args %}&{{ filter_args }}{% endif %}" data-turbo-action="advance" class="inline-flex items-center gap-1 h-8 rounded-lg pl-3 pr-2 text-sm font-medium text-gray-700 hover:bg-gray-100 hover:text-gray-900">
+        Next
+        <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
+      </a>
+      {% else %}
+      <span class="inline-flex items-center gap-1 h-8 rounded-lg pl-3 pr-2 text-sm font-medium text-gray-400">
+        Next
+        <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/></svg>
+      </span>
+      {% endif %}
+    </div>
+  </div>
+{% endmacro bar %}

--- a/src/control_plane/templates/base.html
+++ b/src/control_plane/templates/base.html
@@ -736,7 +736,7 @@
             <option id="nav-option-blocked-jobs" value="{{ base_path }}/blocked-jobs">Blocked jobs · {{ nav_blocked_jobs | default(value=0) }}</option>
             <option id="nav-option-scheduled-jobs" value="{{ base_path }}/scheduled-jobs">Scheduled jobs · {{ nav_scheduled_jobs | default(value=0) }}</option>
             <option value="{{ base_path }}/recurring-jobs">Recurring jobs</option>
-            <option id="nav-option-finished-jobs" value="{{ base_path }}/finished-jobs">Finished jobs · …</option>
+            <option id="nav-option-finished-jobs" value="{{ base_path }}/finished-jobs">Finished jobs</option>
             <option value="{{ base_path }}/workers">Workers</option>
           </select>
           <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-700">
@@ -769,7 +769,7 @@
             Recurring jobs
           </a>
           <a href="{{ base_path }}/finished-jobs" data-nav-target="navItem" data-action="click->nav#navigate" class="shrink-0 whitespace-nowrap px-4 h-8 font-medium text-gray-600 hover:text-black border-b-2 border-transparent hover:border-black">
-            Finished jobs <span id="finished-jobs-count" class="px-1 py-0.5 text-xs rounded-full bg-gray-200 text-gray-800">…</span>
+            Finished jobs
           </a>
 
           <a href="{{ base_path }}/workers" data-nav-target="navItem" data-action="click->nav#navigate" class="shrink-0 whitespace-nowrap px-4 h-8 font-medium text-gray-600 hover:text-black border-b-2 border-transparent hover:border-black">

--- a/src/control_plane/templates/blocked-jobs.html
+++ b/src/control_plane/templates/blocked-jobs.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import "_pagination.html" as pagination %}
 
 {% block title %}Blocked Jobs - Control Plane{% endblock %}
 
@@ -139,31 +140,7 @@
 </div>
 
 <!-- Pagination -->
-<div class="flex items-center justify-between mt-4">
-  <div class="text-sm text-gray-700">
-    {{ current_page_num }} / {{ total_pages }}
-  </div>
-  <div class="flex space-x-2">
-    {% if current_page_num > 1 %}
-      <a href="{{ base_path }}/blocked-jobs?page={{ current_page_num - 1 }}{% if filter_args %}&{{ filter_args }}{% endif %}" data-turbo-action="advance" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 h-8 px-3 py-1">
-        Previous page
-      </a>
-    {% else %}
-      <button disabled class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-gray-100 text-gray-400 h-8 px-3 py-1 cursor-not-allowed">
-        Previous page
-      </button>
-    {% endif %}
+{{ pagination::bar(base_path=base_path, path="blocked-jobs", page=current_page_num, total_pages=total_pages, filter_args=filter_args) }}
 
-    {% if current_page_num < total_pages %}
-      <a href="{{ base_path }}/blocked-jobs?page={{ current_page_num + 1 }}{% if filter_args %}&{{ filter_args }}{% endif %}" data-turbo-action="advance" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 h-8 px-3 py-1">
-        Next page
-      </a>
-    {% else %}
-      <button disabled class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-gray-100 text-gray-400 h-8 px-3 py-1 cursor-not-allowed">
-        Next page
-      </button>
-    {% endif %}
-  </div>
-</div>
 </turbo-frame>
 {% endblock %}

--- a/src/control_plane/templates/failed-jobs.html
+++ b/src/control_plane/templates/failed-jobs.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import "_pagination.html" as pagination %}
 
 {% block title %}Failed Jobs - Control Plane{% endblock %}
 
@@ -149,31 +150,6 @@
   </div>
 
   <!-- Pagination -->
-  <div class="flex items-center justify-between mt-4">
-    <div class="text-sm text-gray-700">
-      {{ current_page_num }} / {{ total_pages }}
-    </div>
-    <div class="flex space-x-2">
-      {% if current_page_num > 1 %}
-      <a href="{{ base_path }}/failed-jobs?page={{ current_page_num - 1 }}{% if filter_args %}&{{ filter_args }}{% endif %}" data-turbo-action="advance" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-3 py-1">
-        Previous page
-      </a>
-      {% else %}
-      <button disabled class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-gray-100 text-gray-400 h-8 px-3 py-1 cursor-not-allowed">
-        Previous page
-      </button>
-      {% endif %}
-
-      {% if current_page_num < total_pages %}
-      <a href="{{ base_path }}/failed-jobs?page={{ current_page_num + 1 }}{% if filter_args %}&{{ filter_args }}{% endif %}" data-turbo-action="advance" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-3 py-1">
-        Next page
-      </a>
-      {% else %}
-      <button disabled class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-gray-100 text-gray-400 h-8 px-3 py-1 cursor-not-allowed">
-        Next page
-      </button>
-      {% endif %}
-    </div>
-  </div>
+  {{ pagination::bar(base_path=base_path, path="failed-jobs", page=current_page_num, total_pages=total_pages, filter_args=filter_args) }}
   </turbo-frame>
 {% endblock %}

--- a/src/control_plane/templates/finished-jobs.html
+++ b/src/control_plane/templates/finished-jobs.html
@@ -141,7 +141,7 @@
 <!-- Pagination -->
 <div class="flex items-center justify-between mt-4">
   <div class="text-sm text-gray-700">
-    {{ current_page_num }} / …
+    {{ current_page_num }}
   </div>
   <div class="flex space-x-2">
     {% if current_page_num > 1 %}

--- a/src/control_plane/templates/finished-jobs.html
+++ b/src/control_plane/templates/finished-jobs.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import "_pagination.html" as pagination %}
 
 {% block title %}Finished Jobs - Control Plane{% endblock %}
 
@@ -139,32 +140,7 @@
 </div>
 
 <!-- Pagination -->
-<div class="flex items-center justify-between mt-4">
-  <div class="text-sm text-gray-700">
-    {{ current_page_num }}
-  </div>
-  <div class="flex space-x-2">
-    {% if current_page_num > 1 %}
-      <a href="{{ base_path }}/finished-jobs?page={{ current_page_num - 1 }}{% if filter_args %}&{{ filter_args }}{% endif %}" data-turbo-action="advance" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 h-8 px-3 py-1">
-        Previous page
-      </a>
-    {% else %}
-      <button disabled class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-gray-100 text-gray-400 h-8 px-3 py-1 cursor-not-allowed">
-        Previous page
-      </button>
-    {% endif %}
-
-    {% if has_next %}
-      <a href="{{ base_path }}/finished-jobs?page={{ current_page_num + 1 }}{% if filter_args %}&{{ filter_args }}{% endif %}" data-turbo-action="advance" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 h-8 px-3 py-1">
-        Next page
-      </a>
-    {% else %}
-      <button disabled class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-gray-100 text-gray-400 h-8 px-3 py-1 cursor-not-allowed">
-        Next page
-      </button>
-    {% endif %}
-  </div>
-</div>
+{{ pagination::bar(base_path=base_path, path="finished-jobs", page=current_page_num, has_next=has_next, filter_args=filter_args) }}
 
 </turbo-frame>
 {% endblock %}

--- a/src/control_plane/templates/in-progress-jobs.html
+++ b/src/control_plane/templates/in-progress-jobs.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import "_pagination.html" as pagination %}
 
 {% block title %}In Progress Jobs - Control Plane{% endblock %}
 
@@ -138,32 +139,7 @@
 </div>
 
 <!-- Pagination -->
-<div class="flex items-center justify-between mt-4">
-  <div class="text-sm text-gray-700">
-    {{ current_page_num }} / {{ total_pages }}
-  </div>
-  <div class="flex space-x-2">
-    {% if current_page_num > 1 %}
-      <a href="{{ base_path }}/in-progress-jobs?page={{ current_page_num - 1 }}{% if filter_args %}&{{ filter_args }}{% endif %}" data-turbo-action="advance" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 h-8 px-3 py-1">
-        Previous page
-      </a>
-    {% else %}
-      <button disabled class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-gray-100 text-gray-400 h-8 px-3 py-1 cursor-not-allowed">
-        Previous page
-      </button>
-    {% endif %}
-
-    {% if current_page_num < total_pages %}
-      <a href="{{ base_path }}/in-progress-jobs?page={{ current_page_num + 1 }}{% if filter_args %}&{{ filter_args }}{% endif %}" data-turbo-action="advance" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 h-8 px-3 py-1">
-        Next page
-      </a>
-    {% else %}
-      <button disabled class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-gray-100 text-gray-400 h-8 px-3 py-1 cursor-not-allowed">
-        Next page
-      </button>
-    {% endif %}
-  </div>
-</div>
+{{ pagination::bar(base_path=base_path, path="in-progress-jobs", page=current_page_num, total_pages=total_pages, filter_args=filter_args) }}
 
 </turbo-frame>
 {% endblock %}

--- a/src/control_plane/templates/queue-details.html
+++ b/src/control_plane/templates/queue-details.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import "_pagination.html" as pagination %}
 
 {% block title %}Queue Details: {{ queue_name }} - Control Plane{% endblock %}
 
@@ -111,32 +112,7 @@
   </div>
 
   <!-- Pagination -->
-  <div class="flex items-center justify-between mt-4">
-    <div class="text-sm text-gray-700">
-      Page {{ current_page }} of {{ total_pages }}
-    </div>
-    <div class="flex space-x-2">
-      {% if current_page > 1 %}
-        <a href="{{ base_path }}/queues/{{ queue_name }}?page={{ current_page - 1 }}" data-turbo-action="advance" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 h-8 px-3 py-1">
-          Previous page
-        </a>
-      {% else %}
-        <button disabled class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-gray-100 text-gray-400 h-8 px-3 py-1 cursor-not-allowed">
-          Previous page
-        </button>
-      {% endif %}
-
-      {% if current_page < total_pages %}
-        <a href="{{ base_path }}/queues/{{ queue_name }}?page={{ current_page + 1 }}" data-turbo-action="advance" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 h-8 px-3 py-1">
-          Next page
-        </a>
-      {% else %}
-        <button disabled class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-gray-100 text-gray-400 h-8 px-3 py-1 cursor-not-allowed">
-          Next page
-        </button>
-      {% endif %}
-    </div>
-  </div>
+  {{ pagination::bar(base_path=base_path, path="queues/" ~ queue_name, page=current_page, total_pages=total_pages) }}
 </div>
 </turbo-frame>
 {% endblock %}

--- a/src/control_plane/templates/queues.html
+++ b/src/control_plane/templates/queues.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import "_pagination.html" as pagination %}
 
 {% block title %}Queues - Control Plane{% endblock %}
 
@@ -124,32 +125,7 @@
 </div>
 
 <!-- Pagination -->
-<div class="flex items-center justify-between mt-4">
-  <div class="text-sm text-gray-700">
-    {{ current_page_num }} / {{ total_pages }}
-  </div>
-  <div class="flex space-x-2">
-    {% if current_page_num == 1 %}
-    <button disabled class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-gray-100 text-gray-400 cursor-not-allowed h-8 px-3 py-1">
-      Previous page
-    </button>
-    {% else %}
-    <a href="{{ base_path }}/queues?page={{ current_page_num - 1 }}" data-turbo-action="advance" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-3 py-1">
-      Previous page
-    </a>
-    {% endif %}
-
-    {% if current_page_num == total_pages %}
-    <button disabled class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-gray-100 text-gray-400 cursor-not-allowed h-8 px-3 py-1">
-      Next page
-    </button>
-    {% else %}
-    <a href="{{ base_path }}/queues?page={{ current_page_num + 1 }}" data-turbo-action="advance" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 hover:text-gray-900 h-8 px-3 py-1">
-      Next page
-    </a>
-    {% endif %}
-  </div>
-</div>
+{{ pagination::bar(base_path=base_path, path="queues", page=current_page_num, total_pages=total_pages) }}
 
 <script>
 async function toggleQueueStatus(button) {

--- a/src/control_plane/templates/scheduled-jobs.html
+++ b/src/control_plane/templates/scheduled-jobs.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import "_pagination.html" as pagination %}
 
 {% block title %}Scheduled Jobs - Control Plane{% endblock %}
 
@@ -118,32 +119,7 @@
 </div>
 
 <!-- Pagination -->
-<div class="flex items-center justify-between mt-4">
-  <div class="text-sm text-gray-700">
-    {{ current_page_num }} / {{ total_pages }}
-  </div>
-  <div class="flex space-x-2">
-    {% if current_page_num > 1 %}
-      <a href="{{ base_path }}/scheduled-jobs?page={{ current_page_num - 1 }}{% if filter_args %}&{{ filter_args }}{% endif %}" data-turbo-action="advance" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 h-8 px-3 py-1">
-        Previous page
-      </a>
-    {% else %}
-      <button disabled class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-gray-100 text-gray-400 h-8 px-3 py-1 cursor-not-allowed">
-        Previous page
-      </button>
-    {% endif %}
-
-    {% if current_page_num < total_pages %}
-      <a href="{{ base_path }}/scheduled-jobs?page={{ current_page_num + 1 }}{% if filter_args %}&{{ filter_args }}{% endif %}" data-turbo-action="advance" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-white hover:bg-gray-100 h-8 px-3 py-1">
-        Next page
-      </a>
-    {% else %}
-      <button disabled class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-gray-200 bg-gray-100 text-gray-400 h-8 px-3 py-1 cursor-not-allowed">
-        Next page
-      </button>
-    {% endif %}
-  </div>
-</div>
+{{ pagination::bar(base_path=base_path, path="scheduled-jobs", page=current_page_num, total_pages=total_pages, filter_args=filter_args) }}
 
 </turbo-frame>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Replace the per-page pagination markup with a shared Tera macro (`_pagination.html`) rendering shadcn-style pagination: ghost Previous/Next with chevrons, numbered pages with the current page outlined, and ellipses for collapsed ranges.
- Counted pages (failed/blocked/scheduled/in-progress/queues/queue-details) keep showing the total: `1 … 4 [5] 6 … 20`. Finished jobs has no COUNT, so it ends with a trailing ellipsis while a next page exists: `1 2 [3] 4 …`.
- Drop the static `…` badge next to "Finished jobs" in the nav (the finished set is unbounded; the badge carried no information).

## Validation
- All 15 templates parse under Tera 1.20.1; the macro was rendered against 10 boundary cases (first/middle/last page, single page, empty set, unknown-total with/without next, dynamic queue-details path) with correct output.
- Codex review: no blocking findings.