### PR TITLE
perf(control-plane): batch-fetch jobs in blocked/failed list handlers

### DIFF
--- a/src/control_plane/handlers/blocked_jobs.rs
+++ b/src/control_plane/handlers/blocked_jobs.rs
@@ -53,11 +53,19 @@ impl ControlPlane {
         // Get current time, for calculating waiting time
         let now = chrono::Utc::now().naive_utc();
 
+        // Batch-fetch the jobs for this page instead of one query per row.
+        let job_ids: Vec<i64> = blocked_executions.iter().map(|e| e.job_id).collect();
+        let job_map: std::collections::HashMap<i64, _> =
+            query_builder::jobs::find_by_ids(db, table_config, job_ids)
+                .await
+                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+                .into_iter()
+                .map(|job| (job.id, job))
+                .collect();
+
         // Get job information for each blocked execution
         for execution in blocked_executions {
-            if let Ok(Some(job)) =
-                query_builder::jobs::find_by_id(db, table_config, execution.job_id).await
-            {
+            if let Some(job) = job_map.get(&execution.job_id) {
                 // Calculate waiting time
                 let waiting_time = match now.signed_duration_since(execution.created_at) {
                     duration if duration.num_hours() >= 1 => {

--- a/src/control_plane/handlers/failed_jobs.rs
+++ b/src/control_plane/handlers/failed_jobs.rs
@@ -53,11 +53,19 @@ impl ControlPlane {
         // Create a vector to store failed job information
         let mut failed_jobs: Vec<FailedJobInfo> = Vec::with_capacity(failed_executions.len());
 
+        // Batch-fetch the jobs for this page instead of one query per row.
+        let job_ids: Vec<i64> = failed_executions.iter().map(|e| e.job_id).collect();
+        let job_map: std::collections::HashMap<i64, _> =
+            query_builder::jobs::find_by_ids(db, table_config, job_ids)
+                .await
+                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+                .into_iter()
+                .map(|job| (job.id, job))
+                .collect();
+
         // Get job information for each failed execution
         for execution in failed_executions {
-            if let Ok(Some(job)) =
-                query_builder::jobs::find_by_id(db, table_config, execution.job_id).await
-            {
+            if let Some(job) = job_map.get(&execution.job_id) {
                 failed_jobs.push(FailedJobInfo {
                     id: job.id,
                     queue_name: job.queue_name.clone(),


### PR DESCRIPTION
## Problem

The blocked-jobs and failed-jobs list handlers fetched job rows one at a time inside the per-row loop:

```rust
for execution in executions {
    if let Ok(Some(job)) = query_builder::jobs::find_by_id(db, table_config, execution.job_id).await {
        ...
    }
}
```

For a page of N rows this issues N separate `find_by_id` queries on top of the initial paginated query (the classic N+1). With the default page size that is ~50 extra round trips per dashboard render.

## Fix

Collect the page's `job_id`s and resolve them in a single `find_by_ids` query, then look each row up in a `HashMap`:

```rust
let job_ids: Vec<i64> = executions.iter().map(|e| e.job_id).collect();
let job_map: HashMap<i64, _> = query_builder::jobs::find_by_ids(db, table_config, job_ids)
    .await?
    .into_iter()
    .map(|job| (job.id, job))
    .collect();
```

Row order and the "skip rows whose job is missing" behavior are preserved. This is the same eager-loading idea Rails uses with `includes`/`preload` to avoid N+1 on list views.

## Scope

- `src/control_plane/handlers/blocked_jobs.rs`
- `src/control_plane/handlers/failed_jobs.rs`

No schema changes. `find_by_ids` already exists and is used elsewhere; it chunks ids to stay within SQLite's parameter limit.

## Testing

`cargo check` + `cargo clippy` clean. `pytest tests/test_failed_jobs.py tests/test_failed_ops.py` pass (23). Full suite unchanged vs master (the one pre-existing `test_recurring` flake reproduces on master too).