### PR TITLE
fix(dispatcher): use job concurrency_duration for semaphore TTL when unblocking

### DIFF
--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -396,30 +396,44 @@ impl Dispatcher {
                     return Ok(false);
                 };
 
-                // Resolve concurrency_limit from the registered runnable via the
-                // job's class_name (Solid Queue reads `job.concurrency_limit`).
-                let concurrency_limit = {
+                // Resolve concurrency_limit + duration from the registered runnable
+                // via the job's class_name. Solid Queue's `#release` calls
+                // `Semaphore.wait(job)`, which sets the semaphore TTL from
+                // `job.concurrency_duration`; pass it through so unblock matches
+                // both Solid Queue and the scheduled-dispatch path instead of
+                // falling back to `acquire_semaphore`'s default TTL.
+                let (concurrency_limit, concurrency_duration) = {
                     #[cfg(feature = "python")]
                     {
                         query_builder::jobs::find_by_id(txn, &ctx.table_config, execution.job_id)
                             .await?
                             .and_then(|job| {
                                 ctx.runnables.read().ok().and_then(|runnables| {
-                                    runnables
-                                        .get(&job.class_name)
-                                        .and_then(|r| r.concurrency_limit)
+                                    runnables.get(&job.class_name).map(|r| {
+                                        (
+                                            r.concurrency_limit.unwrap_or(1),
+                                            r.concurrency_duration
+                                                .map(|s| chrono::Duration::seconds(s as i64)),
+                                        )
+                                    })
                                 })
                             })
-                            .unwrap_or(1)
+                            .unwrap_or((1, None))
                     }
                     #[cfg(not(feature = "python"))]
                     {
-                        1
+                        (1, None)
                     }
                 };
 
-                if acquire_semaphore(txn, &ctx.table_config, key.clone(), concurrency_limit, None)
-                    .await?
+                if acquire_semaphore(
+                    txn,
+                    &ctx.table_config,
+                    key.clone(),
+                    concurrency_limit,
+                    concurrency_duration,
+                )
+                .await?
                 {
                     query_builder::ready_executions::insert(
                         txn,


### PR DESCRIPTION
## Problem

When unblocking an expired concurrency key, `release_one` acquired the semaphore with `duration = None`, so the semaphore's `expires_at` fell back to `acquire_semaphore`'s fixed 2-minute default instead of the job's declared `concurrency_duration`.

This diverges from:
- **Solid Queue**, whose `BlockedExecution#release` → `Semaphore.wait(job)` sets the TTL from `job.concurrency_duration.from_now`.
- **The scheduled-dispatch path** in this same dispatcher, which already passes the runnable's `concurrency_duration` through to `acquire_semaphore`.

The semaphore `expires_at` is a crash-safety TTL (cleared by `delete_expired` if a holder dies). Using a fixed 2 min rather than the job's configured duration could expire the slot while a long-running unblocked job is still holding it, letting another job acquire the same key and breach `concurrency_limit`.

## Fix

`release_one` now resolves `concurrency_duration` from the registered runnable (same as the dispatch path) and passes it to `acquire_semaphore`, so unblock matches both Solid Queue and the dispatch path. When a runnable has no `concurrency_duration`, behavior is unchanged (falls back to `acquire_semaphore`'s default), consistent with the dispatch path.

## Relation to prior concurrency work

This `None` is not a regression and not a recently-introduced bug — it has been there since the original `feat: concurrency control` (`d1b313a`) and had never been touched until now. It is also distinct from the prior concurrency/crash-safety hardening:

- `#79 claim-ledger-hardening` reworked the **worker-side claim lifecycle** (requeue of `claimed_executions` on crash/shutdown); it never touched `dispatcher.rs` or `semaphore.rs`. Different resource (claimed executions vs concurrency slot).
- `f376ee8` fixed the `limit==1` short-circuit *inside* `acquire_semaphore` (re-acquire mistaken for cooldown); it did not touch how unblock calls it.
- `02aaf23` ("enforce limit on all promotion paths") unified the **scheduled→ready** path to go through `acquire_semaphore` with `concurrency_duration` — but did not touch the **unblock** sibling path. This PR fills exactly that gap.

## Notes

Stacked on #99 (`release_one` is introduced there); base is `refactor/unblock-solid-queue-parity`. Merge after #99.

## Testing

`cargo check` + `cargo clippy` clean. All 32 concurrency tests pass.