### PR TITLE
ci: publish to PyPI via trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/quebec/
     if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
     needs: [linux, musllinux, windows, macos, sdist]
     permissions:
@@ -207,6 +210,4 @@ jobs:
         uses: astral-sh/setup-uv@v7
       - name: Publish to PyPI
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
-        run: uv publish 'wheels-*/*'
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: uv publish --trusted-publishing always 'wheels-*/*'


### PR DESCRIPTION
Switch the release job from token-based publishing to PyPI trusted publishing (OIDC).

- Drop `UV_PUBLISH_TOKEN` / `secrets.PYPI_API_TOKEN`; `uv publish --trusted-publishing always` uses the existing `id-token: write` permission.
- Add a `pypi` deployment environment so the release shows up under the repo's Deployments and can carry environment protection rules.

Requires a trusted publisher to be configured on PyPI (owner `ratazzi`, repo `quebec`, workflow `ci.yml`) before the next tagged release.