### PR TITLE
fix(supervisor): prevent fork recursion from inherited QUEBEC_SUPERVISOR

### DIFF
--- a/python/quebec/supervisor.py
+++ b/python/quebec/supervisor.py
@@ -325,6 +325,12 @@ class Supervisor:
                 signal.signal(signal.SIGQUIT, signal.SIG_DFL)
                 os.close(self._wakeup_r)
                 os.close(self._wakeup_w)
+                # This child runs a single role, not another supervisor. Drop
+                # QUEBEC_SUPERVISOR so the `qc.run(spawn=[...])` below takes the
+                # single-process path instead of re-entering supervisor mode
+                # (which would recurse: supervisor_plan_from_config sees the
+                # same queue.yml, forks again, ad infinitum).
+                os.environ.pop("QUEBEC_SUPERVISOR", None)
 
                 self.qc.reset_after_fork()
                 # Record ppid so role loops self-terminate if supervisor dies.


### PR DESCRIPTION
## Problem

Under fork-based supervisor mode (`QUEBEC_SUPERVISOR=1`), a forked
worker/dispatcher child inherited `QUEBEC_SUPERVISOR=1`. When it called
`qc.run(spawn=[...])`, `_quebec_run` re-entered the supervisor branch, saw the
same `queue.yml`, and forked again — an infinite recursion. Combined with
forking a process that already has live tokio worker threads, this corrupted
the runtime state (`misaligned pointer dereference` in `parking_lot`) and
produced a crash-loop that pinned CPU at 100%.

The child's process title showing `supervisor#0/0` (instead of `worker#0/0`)
was the tell that it had re-entered `Supervisor.start()`.

## Fix

Drop `QUEBEC_SUPERVISOR` in the forked child (before `reset_after_fork`), so
`qc.run(spawn=[...])` takes the single-process path instead of re-entering
supervisor mode.

## Verification

- Real machine (Debian 13 + systemd 257): supervisor-mode panic count went
  from 38 to 0, Tasks stayed flat, crash-loop gone.
- `tests/test_supervisor.py` (23 tests) pass.

https://claude.ai/code/session_0128pUbdHbDqpsFLwxS5uhNv
