### PR TITLE
feat(systemd): sd_notify integration (READY/STATUS/WATCHDOG/STOPPING)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2065,6 +2065,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "rust-embed",
+ "sd-notify",
  "sea-orm",
  "serde",
  "serde_json",
@@ -2421,6 +2422,15 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sd-notify"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e4ef7359e694bfaf1dd27a30f9d760b54c00dfae9f19bd0c05a39bc9128fe76"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "sea-bae"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,12 @@ proctitle = "0.1.1"
 libc = "0.2"
 moka = { version = "0.12.15", features = ["future"] }
 
+# systemd sd_notify(3) integration. unix-only crate (UnixDatagram +
+# CLOCK_MONOTONIC), so gate it off Windows wheel builds; src/systemd.rs
+# provides a no-op stub on non-unix targets.
+[target.'cfg(unix)'.dependencies]
+sd-notify = "0.5.0"
+
 [lints.rust]
 dead_code = "warn"
 unused_variables = "warn"

--- a/python/quebec/__init__.py
+++ b/python/quebec/__init__.py
@@ -389,6 +389,29 @@ class ThreadedRunner:
 _quebec_state: dict = {}
 
 
+def _systemd_status_line(qc, components):
+    """Build the single-process systemd STATUS line from in-process state.
+
+    Worker thread/idle figures come from the configured thread count and the
+    worker-owned claim ledger (``qc.in_flight_count()`` = busy threads) —
+    process-local, never a DB query. Recomputed on each notify so idle tracks
+    current load. Puma-style: report total threads and how many are idle.
+    """
+    from .quebec import __version__
+
+    segs = []
+    if "worker" in components:
+        total = qc.worker_threads
+        idle = max(0, total - qc.in_flight_count())
+        segs.append(f"worker {total} threads, {idle} idle")
+    if "dispatcher" in components:
+        segs.append("dispatcher")
+    if "scheduler" in components:
+        segs.append("scheduler")
+    body = ", ".join(segs) if segs else "running"
+    return f"Quebec {__version__}: {body}; running"
+
+
 def _quebec_start(
     self,
     *,
@@ -458,32 +481,22 @@ def _quebec_start(
         t.start()
         worker_threads.append(t)
 
-    # systemd STATUS line from in-process info (spawned components + thread
-    # count), not a database query.
-    from .quebec import __version__
-
+    # Remember which components this process spawned; the systemd STATUS line
+    # is rebuilt from in-process state (worker busy/total) on each notify.
     components = spawn if spawn is not None else ["worker", "dispatcher", "scheduler"]
-    segs = []
-    if "worker" in components:
-        segs.append(f"worker {self.worker_threads} threads")
-    if "dispatcher" in components:
-        segs.append("dispatcher")
-    if "scheduler" in components:
-        segs.append("scheduler")
-    sd_status = f"Quebec {__version__}: {', '.join(segs) or 'running'}; running"
 
     # Store state by instance id
     _quebec_state[id(self)] = {
         "shutdown_event": shutdown_event,
         "job_queue": job_queue,
         "worker_threads": worker_threads,
-        "sd_status": sd_status,
+        "sd_components": components,
     }
 
     # Components started: tell systemd we're ready. No-op unless launched
     # under a Type=notify unit. In supervisor mode the forked child drops
     # NOTIFY_SOCKET before entering qc.run(), so children stay silent here.
-    self.systemd_ready(sd_status)
+    self.systemd_ready(_systemd_status_line(self, components))
 
     return self  # Enable chaining: qc.start().wait()
 
@@ -504,9 +517,10 @@ def _quebec_wait(self):
 
     try:
         while not state["shutdown_event"].is_set():
-            # Refresh status + pet the systemd watchdog (no-op without
-            # NOTIFY_SOCKET). Driven by this loop, so a hung loop stops petting.
-            self.systemd_notify(state["sd_status"])
+            # Refresh status (live worker busy/total) + pet the systemd watchdog
+            # (no-op without NOTIFY_SOCKET). Driven by this loop, so a hung loop
+            # stops petting.
+            self.systemd_notify(_systemd_status_line(self, state["sd_components"]))
             # Detect supervisor death in fork-based mode: if Rust flagged us
             # orphaned, unblock this wait loop so run() returns and the child
             # can exit. `is_orphaned()` stays False unless `watch_parent_pid`

--- a/python/quebec/__init__.py
+++ b/python/quebec/__init__.py
@@ -458,12 +458,32 @@ def _quebec_start(
         t.start()
         worker_threads.append(t)
 
+    # systemd STATUS line from in-process info (spawned components + thread
+    # count), not a database query.
+    from .quebec import __version__
+
+    components = spawn if spawn is not None else ["worker", "dispatcher", "scheduler"]
+    segs = []
+    if "worker" in components:
+        segs.append(f"worker {self.worker_threads} threads")
+    if "dispatcher" in components:
+        segs.append("dispatcher")
+    if "scheduler" in components:
+        segs.append("scheduler")
+    sd_status = f"Quebec {__version__}: {', '.join(segs) or 'running'}; running"
+
     # Store state by instance id
     _quebec_state[id(self)] = {
         "shutdown_event": shutdown_event,
         "job_queue": job_queue,
         "worker_threads": worker_threads,
+        "sd_status": sd_status,
     }
+
+    # Components started: tell systemd we're ready. No-op unless launched
+    # under a Type=notify unit. In supervisor mode the forked child drops
+    # NOTIFY_SOCKET before entering qc.run(), so children stay silent here.
+    self.systemd_ready(sd_status)
 
     return self  # Enable chaining: qc.start().wait()
 
@@ -484,6 +504,9 @@ def _quebec_wait(self):
 
     try:
         while not state["shutdown_event"].is_set():
+            # Refresh status + pet the systemd watchdog (no-op without
+            # NOTIFY_SOCKET). Driven by this loop, so a hung loop stops petting.
+            self.systemd_notify(state["sd_status"])
             # Detect supervisor death in fork-based mode: if Rust flagged us
             # orphaned, unblock this wait loop so run() returns and the child
             # can exit. `is_orphaned()` stays False unless `watch_parent_pid`
@@ -508,6 +531,7 @@ def _quebec_wait(self):
         logger.debug("KeyboardInterrupt, shutting down...")
         self.graceful_shutdown()
     finally:
+        self.systemd_stop()
         # Wait for worker threads to finish
         for t in state["worker_threads"]:
             t.join(timeout=5.0)

--- a/python/quebec/supervisor.py
+++ b/python/quebec/supervisor.py
@@ -176,9 +176,13 @@ class Supervisor:
 
             self._start_heartbeat()
             self._start_maintenance()
+            # Children forked and control plane up: tell systemd we're ready.
+            # No-op unless launched under a Type=notify unit.
+            self.qc.systemd_ready(self._status_text())
             self._supervise()
         finally:
             try:
+                self.qc.systemd_stop()
                 self._terminate_gracefully()
             finally:
                 self._heartbeat_stop.set()
@@ -325,6 +329,9 @@ class Supervisor:
                 signal.signal(signal.SIGQUIT, signal.SIG_DFL)
                 os.close(self._wakeup_r)
                 os.close(self._wakeup_w)
+                # Only the supervisor (main PID) talks to systemd; drop the
+                # socket so a child can never feed the watchdog or send status.
+                os.environ.pop("NOTIFY_SOCKET", None)
 
                 self.qc.reset_after_fork()
                 # Record ppid so role loops self-terminate if supervisor dies.
@@ -366,8 +373,33 @@ class Supervisor:
             logger.info("Forked %s[%d] as pid=%d", role, index, pid)
             self._children[pid] = _ChildInfo(role=role, index=index, pid=pid)
 
+    def _status_text(self) -> str:
+        """Build the systemd STATUS line from in-process state.
+
+        Uses the live child set (`self._children`) and the configured plan —
+        not a database query — so it reflects exactly the processes this
+        supervisor manages, never a global, cross-node view.
+        """
+        from .quebec import __version__
+
+        counts: Dict[str, int] = {}
+        for info in self._children.values():
+            counts[info.role] = counts.get(info.role, 0) + 1
+        segs = []
+        for role in (ROLE_WORKER, ROLE_DISPATCHER, ROLE_SCHEDULER):
+            expected = self.plan.get(role, 0)
+            if expected:
+                segs.append(f"{role}s {counts.get(role, 0)}/{expected}")
+        body = ", ".join(segs) if segs else "starting"
+        state = "stopping" if self._stopping else "running"
+        return f"Quebec {__version__}: supervisor; {body}; {state}"
+
     def _supervise(self) -> None:
         while not self._stopping:
+            # Refresh status + pet the systemd watchdog. Driving this from the
+            # supervise loop means a hung loop stops petting and lets systemd
+            # restart us. No-op unless launched under a Type=notify unit.
+            self.qc.systemd_notify(self._status_text())
             pid, status = self._reap_one(block=False)
             if pid == 0:
                 self._interruptible_sleep(1.0)

--- a/src/context.rs
+++ b/src/context.rs
@@ -688,6 +688,18 @@ impl AppContext {
             .any(|s| matches!(s, ClaimState::Dispatched | ClaimState::InFlight))
     }
 
+    /// Count active (Dispatched or InFlight) ledger entries — how many jobs this
+    /// worker is currently handling. CleanupPending entries are excluded (those
+    /// already executed). Feeds the single-process systemd STATUS busy/total line.
+    pub fn ledger_active_count(&self) -> usize {
+        self.claim_ledger
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .values()
+            .filter(|s| matches!(s, ClaimState::Dispatched | ClaimState::InFlight))
+            .count()
+    }
+
     /// Snapshot the claim ledger so callers can inspect states without holding
     /// the lock. Poison-recovering.
     pub fn ledger_snapshot(&self) -> std::collections::HashMap<i64, ClaimState> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ mod scheduler;
 pub mod schema_builder;
 pub mod semaphore;
 mod supervisor;
+mod systemd;
 #[cfg(feature = "python")]
 mod types;
 pub mod utils;

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -1,0 +1,51 @@
+//! systemd `sd_notify(3)` integration: READY / STATUS / WATCHDOG / STOPPING.
+//!
+//! Active only when launched under a `Type=notify` unit (i.e. `NOTIFY_SOCKET`
+//! is set); a complete no-op everywhere else, and on non-unix targets (the
+//! `sd-notify` crate is unix-only, so it is gated out of Windows wheels and
+//! replaced by the stubs at the bottom of this file).
+//!
+//! This module is pure protocol: callers pass a fully-formatted status line
+//! built from *in-process* state (the supervisor's live child set, or a single
+//! process's thread/component list) — never a database snapshot, which would
+//! reflect a global, cross-node view including not-yet-pruned rows.
+//!
+//! The watchdog is driven by the main loop, not a background timer: each
+//! `notify` from the loop also pets the watchdog, so a hung loop simply stops
+//! petting and systemd restarts the process. No liveness timestamp needed.
+
+#[cfg(unix)]
+mod imp {
+    use sd_notify::NotifyState;
+
+    /// Send `READY=1` plus the initial status line. No-op without NOTIFY_SOCKET.
+    pub fn ready(status: &str) {
+        let _ = sd_notify::notify(&[NotifyState::Ready, NotifyState::Status(status)]);
+    }
+
+    /// Refresh the status line and pet the watchdog. Called from the main loop,
+    /// so a hung loop stops petting and lets systemd restart the process.
+    /// `watchdog_enabled()` honours WATCHDOG_PID/USEC and is cheap (two env
+    /// reads), so we check it each call rather than caching process-globally.
+    pub fn notify(status: &str) {
+        if sd_notify::watchdog_enabled().is_some() {
+            let _ = sd_notify::notify(&[NotifyState::Status(status), NotifyState::Watchdog]);
+        } else {
+            let _ = sd_notify::notify(&[NotifyState::Status(status)]);
+        }
+    }
+
+    /// Notify systemd we are stopping (`STOPPING=1`).
+    pub fn stopping() {
+        let _ = sd_notify::notify(&[NotifyState::Stopping]);
+    }
+}
+
+#[cfg(not(unix))]
+mod imp {
+    pub fn ready(_status: &str) {}
+    pub fn notify(_status: &str) {}
+    pub fn stopping() {}
+}
+
+pub use imp::{notify, ready, stopping};

--- a/src/types.rs
+++ b/src/types.rs
@@ -2881,6 +2881,15 @@ impl PyQuebec {
         crate::systemd::stopping();
     }
 
+    /// Number of jobs this worker is currently handling (Dispatched + InFlight),
+    /// i.e. busy threads. Process-local (the worker-owned claim ledger), so it
+    /// is meaningful only in single-process mode — the supervisor's workers run
+    /// in separate processes and keep their own ledgers. Feeds the busy/total
+    /// figure in the single-process systemd STATUS line.
+    fn in_flight_count(&self) -> usize {
+        self.ctx.ledger_active_count()
+    }
+
     /// Clear finished jobs older than the configured threshold.
     /// Returns the total number of jobs deleted.
     ///

--- a/src/types.rs
+++ b/src/types.rs
@@ -2858,6 +2858,29 @@ impl PyQuebec {
         Ok(())
     }
 
+    /// systemd `sd_notify(3)`: send `READY=1` plus an initial status line.
+    ///
+    /// No-op unless launched under a `Type=notify` unit (`NOTIFY_SOCKET` set).
+    /// `status` is built by the caller from in-process state (the supervisor's
+    /// live child set, or a single process's component list). Must be called
+    /// from the process that holds `NOTIFY_SOCKET` — the supervisor in fork
+    /// mode, or the single process running `qc.run()`.
+    fn systemd_ready(&self, status: &str) {
+        crate::systemd::ready(status);
+    }
+
+    /// systemd `sd_notify(3)`: refresh the `STATUS=` line and pet the watchdog.
+    /// Called once per main-loop iteration, so a hung loop stops petting and
+    /// systemd restarts the process.
+    fn systemd_notify(&self, status: &str) {
+        crate::systemd::notify(status);
+    }
+
+    /// systemd `sd_notify(3)`: send `STOPPING=1` from the shutdown path.
+    fn systemd_stop(&self) {
+        crate::systemd::stopping();
+    }
+
     /// Clear finished jobs older than the configured threshold.
     /// Returns the total number of jobs deleted.
     ///

--- a/tests/test_systemd.py
+++ b/tests/test_systemd.py
@@ -1,0 +1,86 @@
+"""systemd sd_notify integration (READY / STATUS / WATCHDOG / STOPPING).
+
+The protocol lives in Rust (src/systemd.rs) and is exposed via the
+``systemd_ready(status)`` / ``systemd_notify(status)`` / ``systemd_stop()``
+methods — the status line is built from in-process state by the caller. Here
+we bind a real ``AF_UNIX`` datagram socket, point ``NOTIFY_SOCKET`` at it, and
+assert on the datagrams Quebec emits — the same wire protocol systemd speaks.
+
+Environment mutations go through ``monkeypatch`` so a stray ``NOTIFY_SOCKET`` /
+``WATCHDOG_*`` from the surrounding shell (e.g. running under a systemd service)
+can't leak into or out of these tests.
+"""
+
+import os
+import shutil
+import socket
+import tempfile
+
+import pytest
+
+
+@pytest.fixture
+def notify_socket(monkeypatch):
+    """A bound AF_UNIX/SOCK_DGRAM socket with NOTIFY_SOCKET pointed at it.
+
+    Uses a short /tmp path to stay under the ~104 char sun_path limit on macOS;
+    monkeypatch restores NOTIFY_SOCKET afterwards.
+    """
+    tmpdir = tempfile.mkdtemp(prefix="qbsd", dir="/tmp")
+    sock_path = os.path.join(tmpdir, "n")
+    srv = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    srv.bind(sock_path)
+    monkeypatch.setenv("NOTIFY_SOCKET", sock_path)
+    try:
+        yield srv
+    finally:
+        srv.close()
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def _drain(srv, timeout=5.0):
+    """Receive one datagram, decoded, raising on timeout."""
+    srv.settimeout(timeout)
+    return srv.recv(8192).decode()
+
+
+def test_noop_without_notify_socket(qc, monkeypatch):
+    """Without NOTIFY_SOCKET the calls are silent no-ops, never raising."""
+    monkeypatch.delenv("NOTIFY_SOCKET", raising=False)
+    qc.systemd_ready("Quebec test: running")
+    qc.systemd_notify("Quebec test: running")
+    qc.systemd_stop()
+
+
+def test_ready_and_status(qc, notify_socket):
+    qc.systemd_ready("Quebec test: workers 2/2; running")
+    msg = _drain(notify_socket)
+    assert "READY=1" in msg
+    assert "STATUS=Quebec test: workers 2/2; running" in msg
+
+
+def test_stopping(qc, notify_socket):
+    qc.systemd_stop()
+    msg = _drain(notify_socket)
+    assert "STOPPING=1" in msg
+
+
+def test_notify_refreshes_status(qc, notify_socket, monkeypatch):
+    """Without a watchdog, notify sends STATUS but not WATCHDOG."""
+    monkeypatch.delenv("WATCHDOG_USEC", raising=False)
+    qc.systemd_notify("Quebec test: workers 1/1; running")
+    msg = _drain(notify_socket)
+    assert "STATUS=Quebec test: workers 1/1; running" in msg
+    assert "WATCHDOG=1" not in msg
+
+
+def test_watchdog_petted_on_notify(qc, notify_socket, monkeypatch):
+    """With WATCHDOG_USEC set, each notify also pets the watchdog."""
+    monkeypatch.setenv("WATCHDOG_USEC", "2000000")
+    # watchdog_enabled() honours WATCHDOG_PID; pin it to this process so an
+    # inherited value pointing elsewhere can't suppress the watchdog.
+    monkeypatch.setenv("WATCHDOG_PID", str(os.getpid()))
+    qc.systemd_notify("Quebec test: workers 1/1; running")
+    msg = _drain(notify_socket)
+    assert "WATCHDOG=1" in msg
+    assert "STATUS=" in msg

--- a/tests/test_systemd.py
+++ b/tests/test_systemd.py
@@ -84,3 +84,17 @@ def test_watchdog_petted_on_notify(qc, notify_socket, monkeypatch):
     msg = _drain(notify_socket)
     assert "WATCHDOG=1" in msg
     assert "STATUS=" in msg
+
+
+def test_single_process_status_reports_worker_idle(qc):
+    """The single-process STATUS line reports live worker thread/idle figures
+    from the worker-owned claim ledger — process-local, no DB query."""
+    from quebec import _systemd_status_line
+
+    assert qc.in_flight_count() == 0  # nothing claimed/running in a fresh instance
+    line = _systemd_status_line(qc, ["worker", "dispatcher", "scheduler"])
+    # Idle = total threads when nothing is running.
+    assert f"worker {qc.worker_threads} threads, {qc.worker_threads} idle" in line
+    assert "dispatcher" in line
+    assert "scheduler" in line
+    assert line.startswith("Quebec ")


### PR DESCRIPTION
## Summary

systemd `sd_notify(3)` integration, auto-enabled when `NOTIFY_SOCKET` is set
(no config switch, the same way Puma detects it).

- `READY=1` — `Type=notify` startup handshake (so `systemctl start` waits for ready)
- `STATUS=` — runtime status line shown in `systemctl status`
- `WATCHDOG=1` — petted from the main loop, so a hung loop stops petting and systemd restarts the process
- `STOPPING=1` — graceful-shutdown notification

## STATUS content

Built from in-process state, never a DB query:

- **supervisor**: live child set + configured plan — e.g. `supervisor; workers 2/2, dispatchers 1/1; running`
- **single process**: worker thread/idle, Puma-style — e.g. `worker 2 threads, 0 idle, dispatcher, scheduler; running`. The idle figure comes from the worker-owned claim ledger (`in_flight_count` = Dispatched + InFlight busy threads), recomputed on each notify.

## Design

- Protocol lives in Rust (`sd-notify` crate); Python supplies the status text from in-process state.
- Watchdog is main-loop-driven (no background timer): one pet per loop iteration, so a stuck loop simply stops petting.
- `sd-notify` is unix-only, so it is a `cfg(unix)` dependency with a non-unix no-op stub — zero impact on the Windows build.

## Verification

- Real machine (Debian 13 + systemd 257): READY / STATUS / WATCHDOG / STOPPING, SIGSTOP-hang triggering an automatic restart, and live worker busy/idle all confirmed in both single-process and supervisor modes.
- Cross-platform: macOS + Linux wheels build; `cargo check --target x86_64-pc-windows-gnu` passes and `cargo tree` confirms `sd-notify` is absent from the Windows dependency graph.
- 6 systemd tests pass.

> Note: for safe supervisor-mode operation this should land alongside
> `fix/supervisor-fork-recursion` (separate PR) — that fix is what keeps the
> forked children from crash-looping.

https://claude.ai/code/session_0128pUbdHbDqpsFLwxS5uhNv
