### PR TITLE
feat(control-plane): confirm bulk retry/unblock/pause actions

### DIFF
--- a/src/control_plane/templates/blocked-jobs.html
+++ b/src/control_plane/templates/blocked-jobs.html
@@ -47,7 +47,7 @@
   {% set filter_qs = "" %}
   {% if filter_args %}{% set filter_qs = "?" ~ filter_args %}{% endif %}
 
-  <form action="{{ base_path }}/blocked-jobs/all/unblock{{ filter_qs }}" method="post" data-turbo-frame="_top">
+  <form action="{{ base_path }}/blocked-jobs/all/unblock{{ filter_qs }}" method="post" data-turbo-frame="_top" data-turbo-confirm="{% if filter_class_name or filter_queue_name %}Unblock all filtered blocked jobs?{% else %}Unblock all blocked jobs?{% endif %}">
     <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-gray-900 text-gray-50 hover:bg-gray-900/90 h-8 px-4 py-1.5">
       <svg class="h-4 w-4 mr-1.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" aria-hidden="true">
         <rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>

--- a/src/control_plane/templates/failed-jobs.html
+++ b/src/control_plane/templates/failed-jobs.html
@@ -47,7 +47,7 @@
     {% set filter_qs = "" %}
     {% if filter_args %}{% set filter_qs = "?" ~ filter_args %}{% endif %}
 
-    <form action="{{ base_path }}/failed-jobs/all/retry{{ filter_qs }}" method="post" data-turbo-frame="_top">
+    <form action="{{ base_path }}/failed-jobs/all/retry{{ filter_qs }}" method="post" data-turbo-frame="_top" data-turbo-confirm="{% if filter_class_name or filter_queue_name %}Retry all filtered failed jobs?{% else %}Retry all failed jobs?{% endif %}">
       <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-gray-900 text-gray-50 hover:bg-gray-900/90 h-8 px-4 py-1.5 mr-2">
         <svg class="h-4 w-4 mr-1.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" aria-hidden="true">
           <polyline points="23 4 23 10 17 10"></polyline>

--- a/src/control_plane/templates/queues.html
+++ b/src/control_plane/templates/queues.html
@@ -26,7 +26,7 @@
 
   <div class="flex-grow basis-full sm:basis-auto"></div>
 
-  <form action="{{ base_path }}/queues/all/pause" method="post">
+  <form action="{{ base_path }}/queues/all/pause" method="post" data-turbo-confirm="Pause all queues?">
     <button type="submit" class="inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-gray-900 text-gray-50 hover:bg-gray-900/90 h-8 px-4 py-1.5 mr-2">
       <svg class="h-4 w-4 mr-1.5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24" aria-hidden="true">
         <rect x="6" y="4" width="4" height="16"></rect>


### PR DESCRIPTION
## Summary

Bulk actions in the control plane that mutate or trigger work at scale previously fired immediately on click. Only `Discard all` (failed jobs) had a confirmation prompt. This adds `data-turbo-confirm` to the remaining high-impact bulk actions so a misclick can't take effect instantly.

## Changes

- **Retry all** (failed jobs) — confirm before re-running every failed job
- **Unblock all** (blocked jobs) — confirm before forcing all jobs past the concurrency semaphore
- **Pause all** (queues) — confirm before halting job processing across every queue

Confirmation copy switches with the active filter (e.g. `Retry all filtered failed jobs?` vs `Retry all failed jobs?`).

## Not changed

- Single-row actions (per-job retry/delete/cancel/unblock, per-queue pause/resume) stay confirmation-free, consistent with the existing single-row Discard.
- `Resume all` (queues) — non-destructive restore to normal operation; no confirm needed.