### PR TITLE
fix: drain threaded runner queue after perform

### DIFF
--- a/python/quebec/__init__.py
+++ b/python/quebec/__init__.py
@@ -330,6 +330,11 @@ class BaseClass(ActiveJob, metaclass=NoNewOverrideMeta):
         return JobBuilder(cls, **options)
 
 
+_STOP_EXCEPTIONS = tuple(
+    e for e in (getattr(queue, "ShutDown", None), KeyboardInterrupt) if e is not None
+)
+
+
 class ThreadedRunner:
     def __init__(self, queue: queue.Queue, event: threading.Event):
         self.queue = queue
@@ -341,10 +346,16 @@ class ThreadedRunner:
         while not self.event.is_set():
             try:
                 self.execution = self.queue.get(timeout=0.1)
-                if self.execution is None:
-                    continue
+            except queue.Empty:
+                continue  # No job available, just continue waiting
+            except _STOP_EXCEPTIONS:
+                break
 
-                self.queue.task_done()
+            # From here on, get() succeeded: task_done() is owed exactly once.
+            try:
+                if self.execution is None:
+                    continue  # finally below still runs task_done()
+
                 self.execution.tid = str(threading.get_ident())
 
                 # Inject jid and queue into context before execution, clean up after
@@ -360,19 +371,19 @@ class ThreadedRunner:
                     logger.debug(self.execution.metric)
                 finally:
                     job_context_var.reset(ctx_token)
-            except queue.Empty:
-                pass  # No job available, just continue waiting
-            except (
-                getattr(queue, "ShutDown", None) or KeyboardInterrupt,
-                KeyboardInterrupt,
-            ):
+            except _STOP_EXCEPTIONS:
                 break
             except Exception as e:
                 logger.error(
                     f"Unexpected exception in ThreadedRunner: {e}", exc_info=True
                 )
             finally:
-                self.cleanup()
+                try:
+                    if self.execution is not None:
+                        self.cleanup()
+                finally:
+                    self.queue.task_done()
+                    self.execution = None
 
         logger.debug("threaded_runner exit")
 

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -23,6 +23,31 @@ class FakeExecution:
         self.cleaned_up.set()
 
 
+class BlockingExecution(FakeExecution):
+    def __init__(self) -> None:
+        super().__init__()
+        self.started = threading.Event()
+        self.release = threading.Event()
+
+    def perform(self) -> None:
+        self.started.set()
+        if not self.release.wait(timeout=5):
+            raise TimeoutError("blocking execution was not released")
+        super().perform()
+
+
+def _join_queue_in_thread(work_queue: queue.Queue) -> tuple[threading.Thread, threading.Event]:
+    joined = threading.Event()
+
+    def join_queue() -> None:
+        work_queue.join()
+        joined.set()
+
+    thread = threading.Thread(target=join_queue)
+    thread.start()
+    return thread, joined
+
+
 def test_threaded_runner_processes_execution_and_sets_job_context():
     work_queue = queue.Queue()
     shutdown_event = threading.Event()
@@ -48,3 +73,68 @@ def test_threaded_runner_processes_execution_and_sets_job_context():
     assert execution.context.jid == "job-1"
     assert execution.context.queue == "default"
     assert execution.context.target == "tests.fake_execution"
+
+
+def test_threaded_runner_marks_queue_done_after_perform_returns():
+    work_queue = queue.Queue()
+    shutdown_event = threading.Event()
+    execution = BlockingExecution()
+    work_queue.put(execution)
+
+    runner = quebec.ThreadedRunner(work_queue, shutdown_event)
+    runner_thread = threading.Thread(target=runner.run)
+    runner_thread.start()
+
+    join_thread, joined = _join_queue_in_thread(work_queue)
+
+    try:
+        wait_until(
+            execution.started.is_set,
+            timeout=2,
+            message="threaded runner did not start the blocking execution",
+        )
+        assert not joined.wait(timeout=0.1)
+
+        execution.release.set()
+        wait_until(
+            joined.is_set,
+            timeout=2,
+            message="queue.join() did not return after perform completed",
+        )
+    finally:
+        execution.release.set()
+        shutdown_event.set()
+        runner_thread.join(timeout=5)
+        join_thread.join(timeout=5)
+
+    assert not runner_thread.is_alive()
+    assert not join_thread.is_alive()
+    assert execution.performed.is_set()
+    assert execution.cleaned_up.is_set()
+
+
+def test_threaded_runner_marks_none_sentinel_done():
+    work_queue = queue.Queue()
+    shutdown_event = threading.Event()
+    work_queue.put(None)
+
+    runner = quebec.ThreadedRunner(work_queue, shutdown_event)
+    runner_thread = threading.Thread(target=runner.run)
+    runner_thread.start()
+
+    join_thread, joined = _join_queue_in_thread(work_queue)
+
+    try:
+        wait_until(
+            joined.is_set,
+            timeout=2,
+            message="None sentinel did not decrement queue unfinished task count",
+        )
+    finally:
+        shutdown_event.set()
+        runner_thread.join(timeout=5)
+        join_thread.join(timeout=5)
+
+    assert not runner_thread.is_alive()
+    assert not join_thread.is_alive()
+    assert runner.execution is None


### PR DESCRIPTION
## Summary
- move ThreadedRunner task_done accounting to after perform/cleanup so queue.join() waits for in-flight Python jobs
- handle None sentinel items without leaking unfinished queue counts
- add regression coverage for join waiting and sentinel accounting

## Verification
- uv run pytest -q tests/test_threading.py
- uv run ruff check tests/test_threading.py
- git diff --check