### PR TITLE
fix: preserve bool job arguments

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 #[cfg(feature = "python")]
-use pyo3::types::{PyDict, PyFloat, PyInt, PyList, PyString, PyTuple};
+use pyo3::types::{PyBool, PyDict, PyFloat, PyInt, PyList, PyString, PyTuple};
 use serde_json::Value;
 #[cfg(feature = "python")]
 use serde_yaml;
@@ -148,7 +148,9 @@ pub fn yaml_value_to_python(py: Python<'_>, value: &serde_yaml::Value) -> PyResu
 /// Convert Python object to JSON value
 #[cfg(feature = "python")]
 pub fn python_to_json_value(obj: &Bound<'_, PyAny>) -> PyResult<Value> {
-    if obj.is_instance_of::<PyInt>() {
+    if obj.is_instance_of::<PyBool>() {
+        Ok(Value::Bool(obj.extract::<bool>()?))
+    } else if obj.is_instance_of::<PyInt>() {
         Ok(Value::Number(obj.extract::<i64>()?.into()))
     } else if obj.is_instance_of::<PyFloat>() {
         let f = obj.extract::<f64>()?;

--- a/tests/test_enqueue.py
+++ b/tests/test_enqueue.py
@@ -87,6 +87,7 @@ def test_perform_later_persists_job_and_ready_execution(
         "alice",
         {"flag": True, "_quebec_kwargs": True},
     ]
+    assert payload["arguments"]["arguments"][1]["flag"] is True
     assert db_assert.count_jobs() == 1
     assert db_assert.count_ready_executions() == 1
 

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -12,6 +12,15 @@ class ExecutingJob(quebec.BaseClass):
         type(self).executions.append((subject, kwargs["status"]))
 
 
+class BooleanExecutingJob(quebec.BaseClass):
+    observed: list[tuple[bool, bool, bool]] = []
+
+    def perform(self, dry_run: bool, **kwargs) -> None:
+        type(self).observed.append(
+            (dry_run, kwargs["enabled"], kwargs["options"]["nested"])
+        )
+
+
 def test_pick_job_and_perform_finishes_job(qc_with_sqlalchemy, db_assert) -> None:
     qc = qc_with_sqlalchemy["qc"]
     session = qc_with_sqlalchemy["session"]
@@ -37,3 +46,24 @@ def test_pick_job_and_perform_finishes_job(qc_with_sqlalchemy, db_assert) -> Non
     assert db_assert.count_ready_executions() == 0
     assert db_assert.count_claimed_executions() == 0
     assert db_assert.count_failed_executions() == 0
+
+
+def test_bool_arguments_round_trip_to_perform_as_bool(qc_with_sqlalchemy) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+
+    BooleanExecutingJob.observed = []
+    qc.register_job(BooleanExecutingJob)
+
+    BooleanExecutingJob.perform_later(
+        qc,
+        True,
+        enabled=False,
+        options={"nested": True},
+    )
+    execution = qc.drain_one()
+    execution.perform()
+
+    dry_run, enabled, nested = BooleanExecutingJob.observed[0]
+    assert dry_run is True
+    assert enabled is False
+    assert nested is True


### PR DESCRIPTION
## Summary
- serialize Python bool values as JSON booleans before checking PyInt
- tighten enqueue persistence coverage so True is not accepted as 1
- add execution round-trip coverage for positional, keyword, and nested bool arguments

## Verification
- uv run pytest -q tests/test_enqueue.py tests/test_execution.py
- uv run pytest -q tests/test_enqueue.py::test_perform_later_persists_job_and_ready_execution tests/test_execution.py::test_bool_arguments_round_trip_to_perform_as_bool
- uv run ruff check tests/test_enqueue.py tests/test_execution.py
- cargo fmt --check
- git diff --check