### PR TITLE
fix: use safe JobInterrupted type lookup

### DIFF
--- a/src/continuation.rs
+++ b/src/continuation.rs
@@ -595,7 +595,7 @@ impl Continuable {
                 }
                 Err(e) => {
                     // Check if it's JobInterrupted
-                    let job_interrupted = py.get_type::<JobInterrupted>();
+                    let job_interrupted = <JobInterrupted as pyo3::PyTypeInfo>::type_object(py);
                     if e.is_instance(py, &job_interrupted) {
                         // Propagate interruption
                         return Err(e);
@@ -730,7 +730,7 @@ impl StepContextManager {
 
         // Check if JobInterrupted was raised
         if let Some(exc_type) = exc_type {
-            let job_interrupted = py.get_type::<JobInterrupted>();
+            let job_interrupted = <JobInterrupted as pyo3::PyTypeInfo>::type_object(py);
             if exc_type.is(&job_interrupted) {
                 // JobInterrupted: save current state and propagate
                 debug!(

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -904,7 +904,8 @@ impl Runnable {
         error: &PyErr,
     ) -> Result<quebec_jobs::Model> {
         // Check for JobInterrupted first (continuation checkpoint)
-        let job_interrupted = py.get_type::<crate::continuation::JobInterrupted>();
+        let job_interrupted =
+            <crate::continuation::JobInterrupted as pyo3::PyTypeInfo>::type_object(py);
         if error.is_instance(py, &job_interrupted) {
             info!(
                 "Job `{}' interrupted for continuation, will be re-enqueued",


### PR DESCRIPTION
## Summary
- replace remaining py.get_type::<JobInterrupted>() calls with PyTypeInfo::type_object(py)
- align worker and continuation error handling with the module initialization path
- avoid Python 3.14 GIL-release crashes when matching JobInterrupted

## Verification
- uv run pytest -q tests/test_failure.py tests/test_continuation.py tests/test_continuation_resume.py tests/test_error_strategies.py
- cargo fmt --check
- git diff --check