### PR TITLE
fix(logger): render exception tracebacks in setup_structlog

### DIFF
--- a/python/quebec/logger.py
+++ b/python/quebec/logger.py
@@ -109,6 +109,8 @@ class TracingConsoleRenderer:
         filename = event_dict.pop("filename", "")
         lineno = event_dict.pop("lineno", "")
         target = event_dict.pop("target", filename or "quebec")
+        # `format_exc_info` renders exc_info into this key; print it below the line.
+        exception = event_dict.pop("exception", None)
 
         extra = self._format_kv(event_dict)
         loc_parts = [p for p in [func_name, str(lineno) if lineno else ""] if p]
@@ -119,9 +121,11 @@ class TracingConsoleRenderer:
             ts = f"{s['dim']}{timestamp}{s['reset']}"
             lvl_style = s["levels"].get(method_name, "")
             lvl = f"{lvl_style}{level:>5}{s['reset']}"
-            return f"{ts} {lvl} {origin} {event}{extra}"
+            line = f"{ts} {lvl} {origin} {event}{extra}"
+        else:
+            line = f"{timestamp} {level:>5} {origin} {event}{extra}"
 
-        return f"{timestamp} {level:>5} {origin} {event}{extra}"
+        return f"{line}\n{exception}" if exception else line
 
     @staticmethod
     def _format_kv(event_dict: dict) -> str:
@@ -142,13 +146,22 @@ class TracingConsoleRenderer:
         return " " + " ".join(parts)
 
 
-def setup_structlog(level: int = logging.INFO, *, format: str | None = None) -> None:
+def setup_structlog(
+    level: int = logging.INFO,
+    *,
+    format: str | None = None,
+    show_locals: bool = False,
+) -> None:
     """Configure structlog with job_id context support.
 
     Args:
         level: Logging level (default INFO)
         format: Output format - "console" (colored), "json", or "logfmt".
                 Defaults to QUEBEC_LOG_FORMAT env var, or "console" if not set.
+        show_locals: Include frame-local variables in JSON tracebacks. Off by
+                default since locals often carry secrets (db URLs, tokens,
+                payloads) that would leak into aggregated logs. Only affects
+                the "json" format.
 
     Example:
         from quebec.logger import setup_structlog, get_structlog
@@ -182,6 +195,11 @@ def setup_structlog(level: int = logging.INFO, *, format: str | None = None) -> 
 
     if format == "json":
         processors = shared_processors + [
+            # show_locals defaults off: local variables (secrets, tokens,
+            # payloads) would otherwise leak into aggregated JSON logs.
+            structlog.processors.ExceptionRenderer(
+                structlog.tracebacks.ExceptionDictTransformer(show_locals=show_locals)
+            ),
             structlog.processors.TimeStamper(fmt="iso"),
             structlog.processors.JSONRenderer(),
         ]
@@ -190,6 +208,7 @@ def setup_structlog(level: int = logging.INFO, *, format: str | None = None) -> 
         processors = shared_processors + [
             structlog.processors.TimeStamper(fmt="iso", key="ts"),
             _rename_event_to_message,
+            structlog.processors.format_exc_info,
             structlog.processors.LogfmtRenderer(
                 key_order=["ts", "level", "message"],
                 sort_keys=True,
@@ -198,6 +217,7 @@ def setup_structlog(level: int = logging.INFO, *, format: str | None = None) -> 
     else:  # console
         processors = shared_processors + [
             structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.format_exc_info,
             TracingConsoleRenderer(colors=True),
         ]
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,69 @@
+"""Tests for quebec.logger.
+
+Traceback rendering: setup_structlog must render exception tracebacks in
+every format. Before the fix the processors chain had no exception
+processor, so ``log.exception(...)`` dropped the traceback and only emitted
+a bare ``exc_info`` flag.
+"""
+
+import json
+import logging
+
+from quebec.logger import setup_structlog, get_structlog
+
+
+def _emit_exception(capsys, message="job failed", **kwargs):
+    setup_structlog(level=logging.DEBUG, **kwargs)
+    log = get_structlog("regression")
+    try:
+        raise ValueError("kaboom")
+    except ValueError:
+        log.exception(message)
+    return capsys.readouterr().out
+
+
+def test_console_renders_traceback(capsys):
+    out = _emit_exception(capsys, format="console")
+    assert "Traceback (most recent call last):" in out
+    assert "ValueError: kaboom" in out
+    # No bare flag leaking through as a key-value pair.
+    assert "exc_info" not in out
+
+
+def test_logfmt_renders_traceback(capsys):
+    out = _emit_exception(capsys, format="logfmt")
+    assert "exception=" in out
+    assert "ValueError: kaboom" in out
+
+
+def test_json_renders_structured_traceback(capsys):
+    out = _emit_exception(capsys, format="json").strip().splitlines()[-1]
+    record = json.loads(out)
+    assert record["exception"][0]["exc_type"] == "ValueError"
+    assert record["exception"][0]["exc_value"] == "kaboom"
+
+
+def _json_frames(capsys, **kwargs):
+    setup_structlog(level=logging.DEBUG, format="json", **kwargs)
+    log = get_structlog("regression")
+
+    def boom():
+        secret = "s3cr3t"  # noqa: F841 - intentionally present in the frame
+        raise RuntimeError("nope")
+
+    try:
+        boom()
+    except RuntimeError:
+        log.exception("failed")
+    record = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    return record["exception"][0]["frames"]
+
+
+def test_json_hides_locals_by_default(capsys):
+    frames = _json_frames(capsys)
+    assert all("locals" not in frame for frame in frames)
+
+
+def test_json_show_locals_opt_in(capsys):
+    frames = _json_frames(capsys, show_locals=True)
+    assert any(frame.get("locals", {}).get("secret") == "'s3cr3t'" for frame in frames)


### PR DESCRIPTION
## Problem

`setup_structlog` built its structlog processors chain **without any exception processor**. structlog does not turn `exc_info` into a traceback on its own, so `log.exception(...)` (and `exc_info=True`) dropped the traceback entirely — every format only emitted a bare `exc_info` flag:

```
console:  ... boom while dividing user_id=42 exc_info=True
logfmt:   ... message="boom" exc_info filename=...
json:     {..., "exc_info": true, ...}
```

## Fix

Add the appropriate exception processor per format:

| Format | Processor | Result |
|--------|-----------|--------|
| console | `format_exc_info` + renderer prints it below the line | multi-line traceback |
| logfmt | `format_exc_info` | `exception="..."` field |
| json | `ExceptionRenderer(ExceptionDictTransformer(...))` | structured traceback |

The json format also gains a `show_locals: bool = False` option. `dict_tracebacks` defaults to `show_locals=True`, which would serialize every frame's locals — often secrets, tokens, or payloads in a background-job stack — into aggregated logs. Off by default (secure), opt-in when debugging.

## Tests

`tests/test_logger.py` asserts all three formats render the traceback, plus the `show_locals` default-off / opt-in behavior for json.