### PR TITLE
fix: escape LIKE metacharacters in wildcard queue matching

### DIFF
--- a/src/query_builder.rs
+++ b/src/query_builder.rs
@@ -1266,17 +1266,25 @@ pub mod ready_executions {
         C: ConnectionTrait,
     {
         let table_name = &table_config.ready_executions;
-        let like_pattern = format!("{pattern}%");
+        // Escape LIKE metacharacters so the pattern is a literal prefix match:
+        // `_` matches any single character in SQL LIKE, so `order_*` would
+        // otherwise also match `orders`. Solid Queue semantics are a plain
+        // string prefix (`starts_with?`).
+        let escaped_prefix = pattern
+            .replace('\\', "\\\\")
+            .replace('%', "\\%")
+            .replace('_', "\\_");
+        let like_pattern = format!("{escaped_prefix}%");
 
         let sql = match db.get_database_backend() {
             DbBackend::Postgres => format!(
-                r#"SELECT DISTINCT "queue_name" FROM "{table_name}" WHERE "queue_name" LIKE $1 ORDER BY "queue_name" ASC"#
+                r#"SELECT DISTINCT "queue_name" FROM "{table_name}" WHERE "queue_name" LIKE $1 ESCAPE '\' ORDER BY "queue_name" ASC"#
             ),
             DbBackend::MySql => format!(
-                r#"SELECT DISTINCT `queue_name` FROM `{table_name}` WHERE `queue_name` LIKE ? ORDER BY `queue_name` ASC"#
+                r#"SELECT DISTINCT `queue_name` FROM `{table_name}` WHERE `queue_name` LIKE ? ESCAPE '\\' ORDER BY `queue_name` ASC"#
             ),
             DbBackend::Sqlite => format!(
-                r#"SELECT DISTINCT "queue_name" FROM "{table_name}" WHERE "queue_name" LIKE ? ORDER BY "queue_name" ASC"#
+                r#"SELECT DISTINCT "queue_name" FROM "{table_name}" WHERE "queue_name" LIKE ? ESCAPE '\' ORDER BY "queue_name" ASC"#
             ),
         };
 

--- a/tests/test_wildcard_queues.py
+++ b/tests/test_wildcard_queues.py
@@ -1,0 +1,55 @@
+"""Wildcard queue pattern matching (`order_*` style prefixes).
+
+Solid Queue treats wildcard patterns as plain string prefixes. The SQL LIKE
+translation must escape `_`/`%` so `order_*` does not also match `orders`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import quebec
+
+
+class WildcardJob(quebec.BaseClass):
+    def perform(self, *args, **kwargs) -> None:
+        pass
+
+
+@pytest.fixture
+def wildcard_qc(tmp_path, monkeypatch, temp_db_path, test_prefix):
+    queue_yml = tmp_path / "queue.yml"
+    queue_yml.write_text(
+        """
+development:
+  workers:
+    - queues: "order_*"
+      threads: 1
+"""
+    )
+    monkeypatch.setenv("QUEBEC_CONFIG", str(queue_yml))
+    monkeypatch.delenv("QUEBEC_ENV", raising=False)
+
+    qc = quebec.Quebec(
+        f"sqlite:///{temp_db_path}?mode=rwc", table_name_prefix=test_prefix
+    )
+    assert qc.create_tables() is True
+    qc.register_job(WildcardJob)
+
+    yield qc
+
+    qc.close()
+
+
+def test_wildcard_prefix_is_literal_not_like_pattern(wildcard_qc) -> None:
+    # `_` is a LIKE metacharacter matching any single character; without
+    # escaping, the `order_*` worker would also claim from `orders`.
+    WildcardJob.set(queue="orders").perform_later(wildcard_qc)
+    WildcardJob.set(queue="order_a").perform_later(wildcard_qc)
+
+    execution = wildcard_qc.drain_one()
+    assert execution.queue == "order_a"
+    execution.perform()
+
+    with pytest.raises(RuntimeError):
+        wildcard_qc.drain_one()


### PR DESCRIPTION
## Problem

Wildcard queue patterns (`order_*`) are translated to `LIKE 'order_%'` without escaping. `_` matches any single character in SQL LIKE, so a worker configured with `order_*` also claims from `orders`, `orderXpayments`, etc. — queues that belong to other workers. Underscores are common in queue names (`active_storage_*`, `mailers_*`).

Solid Queue's implementation has the same quirk (`QueueSelector#prefixed_names` builds an unescaped `LIKE` from `queue.tr("*", "%")`), but its documented semantics are a plain string prefix — the README describes wildcards as "match queues starting with a prefix", and its queue-ordering logic (`delete_in_order`) filters with a literal `start_with?`. This PR follows the documented prefix semantics rather than replicating the unescaped LIKE.

## Fix

Escape `\`, `%`, and `_` in the prefix and add an explicit `ESCAPE` clause for all three backends in `find_matching_queue_names`. The query shape (LIKE-filtered `SELECT DISTINCT`) is unchanged and matches Solid Queue's, so polling performance characteristics are unaffected.

## Tests

New `tests/test_wildcard_queues.py`: a worker configured with `queues: "order_*"` claims from `order_a` but not from `orders`. Fails before the fix, passes after.

## Verification

- uv run pytest tests/test_wildcard_queues.py tests/test_queue_pause.py tests/test_execution.py tests/test_enqueue.py
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features
