### PR TITLE
fix: reset LISTEN retry counter after successful reconnect

### DIFF
--- a/src/notify.rs
+++ b/src/notify.rs
@@ -95,7 +95,9 @@ impl NotifyManager {
                     break;
                 }
 
-                match Self::listen_loop(&dsn, &channel, &tx, &graceful_shutdown).await {
+                match Self::listen_loop(&dsn, &channel, &tx, &graceful_shutdown, &mut retry_count)
+                    .await
+                {
                     Ok(_) => {
                         info!("LISTEN loop for {} completed normally", channel);
                         break;
@@ -129,6 +131,7 @@ impl NotifyManager {
         channel: &str,
         tx: &mpsc::Sender<String>,
         graceful_shutdown: &tokio_util::sync::CancellationToken,
+        retry_count: &mut u32,
     ) -> Result<()> {
         // Create a dedicated connection for LISTEN with optimized settings
         // Note: PgListener creates its own connection internally, so we use the DSN directly
@@ -145,6 +148,12 @@ impl NotifyManager {
             "Started LISTEN on channel: {} (dedicated connection)",
             channel
         );
+
+        // LISTEN is established — reset the retry budget so MAX_RETRIES
+        // bounds consecutive failures only. A long-lived worker would
+        // otherwise burn one retry per reconnect over its lifetime and
+        // permanently fall back to polling after the fifth.
+        *retry_count = 0;
 
         loop {
             tokio::select! {


### PR DESCRIPTION
## Problem

`retry_count` in the LISTEN task lives outside the reconnect loop and only ever increments. Each Postgres-unreachable window burns one or more retries from a lifetime budget of `MAX_RETRIES = 5`; the counter is never reset after a successful reconnect. A long-running worker that weathers a few database restarts eventually exhausts the budget: the LISTEN task exits permanently and the worker silently degrades to polling-only until the process restarts.

Note the trigger is narrower than a dropped connection: sqlx's `PgListener::recv()` reconnects transparently (verified — `pg_terminate_backend` on the LISTEN backend never reaches the outer loop). The counter only increments when the server is actually unreachable while the outer loop re-establishes, i.e. real outages/restarts. Five of those over a worker's lifetime — or a single outage longer than the ~62s backoff ladder — kills the task for good.

## Fix

Pass `retry_count` into `listen_loop` and zero it once LISTEN is established, so `MAX_RETRIES` bounds **consecutive** failures instead of lifetime failures.

## Verification

Orchestrated a disposable Postgres (port 5499) through 6 stop/start cycles, watching the worker's log; each cycle forces at least one outer-loop reconnect error:

- before: `attempt 1/5` → `2/5` → `3/5` → `4/5` across cycles, then `Max retries reached` on cycle 5 — LISTEN never comes back
- after: every cycle logs `attempt 1/5` and re-LISTENs; all 6 cycles recover

Also: cargo fmt --check, cargo clippy --all-targets --all-features, cargo check --all-targets