### PR TITLE
fix: guard after_executed cleanup retry against lost commit ack

### DIFF
--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1544,6 +1544,35 @@ impl Execution {
                         continue;
                     }
                 };
+
+                // Lost-ack guard (mirrors Solid Queue's "the claimed row is the
+                // source of truth"): the cleanup closure is atomic, so a prior
+                // attempt either committed everything — mark_finished/failed,
+                // semaphore release, retry schedule AND the claimed-row delete —
+                // or rolled back entirely. If the claimed row is already gone,
+                // the previous attempt committed and we merely lost the commit
+                // ack; re-running the closure would double every side effect
+                // (second failed_executions row, second retry job, double
+                // semaphore release). Treat the missing row as success instead.
+                match query_builder::claimed_executions::find_by_id(
+                    db.as_ref(),
+                    &table_config_orig,
+                    claimed_id,
+                )
+                .await
+                {
+                    Ok(None) => {
+                        transaction_result = Ok(failed);
+                        break;
+                    }
+                    Ok(Some(_)) => {} // still present: safe to re-run the closure
+                    Err(e) => {
+                        warn!(
+                            "Could not verify claimed_execution {} before retry {}: {:?}; re-running cleanup transaction",
+                            claimed_id, attempt, e
+                        );
+                    }
+                }
             }
 
             let retry_job_data = retry_job_data.clone();

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import quebec
+from sqlalchemy import text
 
 from .helpers import get_job_by_active_job_id
 
@@ -67,3 +68,52 @@ def test_bool_arguments_round_trip_to_perform_as_bool(qc_with_sqlalchemy) -> Non
     assert dry_run is True
     assert enabled is False
     assert nested is True
+
+
+def test_after_executed_retry_treats_missing_claim_as_committed(
+    qc_with_sqlalchemy, db_assert
+) -> None:
+    """A committed cleanup whose acknowledgement was lost is not run twice.
+
+    The first ``perform`` creates the durable database state left by a cleanup
+    transaction that committed even though its caller observed a commit error:
+    the job is finished and its claimed row is gone. Restoring the worker-local
+    ledger entry and driving cleanup again models the caller entering its retry
+    path without knowing that the first transaction committed.
+
+    Without the lost-ack guard, every retry re-runs the transaction, fails its
+    claimed-row delete, and eventually invokes emergency cleanup, which records
+    an already-finished job as failed. The guard must instead treat the missing
+    claimed row as proof of the earlier commit and skip all duplicate effects.
+    """
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    ExecutingJob.executions = []
+    qc.register_job(ExecutingJob)
+
+    enqueued = ExecutingJob.perform_later(qc, "lost-ack", status="queued")
+    execution = qc.drain_one()
+    claimed_id = session.execute(
+        text(f"SELECT id FROM {prefix}_claimed_executions WHERE job_id = :job_id"),
+        {"job_id": enqueued.id},
+    ).scalar_one()
+
+    execution.perform()
+    session.expire_all()
+
+    assert db_assert.job_is_finished(enqueued.id)
+    assert db_assert.count_claimed_executions() == 0
+    assert db_assert.count_failed_executions() == 0
+
+    # A lost commit acknowledgement leaves the caller's in-memory state on the
+    # retry path even though all transaction effects are already durable.
+    qc._set_ledger_state(claimed_id, 1)
+    execution.post(None, "")
+    session.expire_all()
+
+    assert db_assert.job_is_finished(enqueued.id)
+    assert db_assert.count_claimed_executions() == 0
+    assert db_assert.count_failed_executions() == 0
+    assert qc._ledger_state(claimed_id) is None


### PR DESCRIPTION
## Problem

The `after_executed` cleanup transaction — mark the job finished / insert a
failed_executions row / schedule a retry, then delete the claimed row and
release the concurrency semaphore — is wrapped in a 4-attempt retry loop, and
each retry re-runs the whole closure.

If an earlier attempt commits on the database but the client loses the commit
acknowledgement (the connection drops at commit time), the next retry finds the
claimed row already deleted → `delete_by_id` returns 0 → the closure returns
`Err("Claimed job not found")` → the transaction rolls back. Every remaining
retry fails the same way, and the emergency path then marks an
**already-finished job as FAILED**, leaving a job that is simultaneously
`finished` and `failed`. Re-running the closure on a committed-but-unacked
attempt would also double its side effects (a second failed row, a duplicate
retry job, a double semaphore release).

## Fix

Before re-running the closure on a retry, check whether the claimed row still
exists. If it is already gone, an earlier attempt committed and only the ack was
lost — treat it as success and skip re-running. This mirrors Solid Queue, where
the claimed-row deletion is atomic with the state change and is the single
source of truth for whether cleanup completed.

## Scope

This closes the lost-ack window. The separate case where the cleanup
transaction genuinely fails all retries (persistent DB error, claimed row never
deleted) still routes through the emergency path; aligning that path is tracked
separately.

## Test

`cargo clippy --all-targets --all-features` clean; existing pytest suite
(execution / retry / concurrency / failed-jobs) passes.
