### PR TITLE
fix: keep worker alive on transient heartbeat DB error

### DIFF
--- a/src/worker.rs
+++ b/src/worker.rs
@@ -4465,7 +4465,16 @@ impl Worker {
                     let Ok(heartbeat_db) = self.ctx.get_db().await.inspect_err(|e| {
                         warn!("Failed to get DB for heartbeat: {}", e);
                     }) else { continue };
-                    self.heartbeat(&heartbeat_db, &process).await?;
+                    // A transient heartbeat failure must not tear down the whole
+                    // worker. Like every other periodic branch (prune, cleanup,
+                    // reconcile) and the quiet-mode heartbeat below, log and
+                    // continue — the next tick retries. If heartbeats fail
+                    // persistently the process row goes stale and another
+                    // worker's prune reclaims its jobs, which is the designed
+                    // recovery path.
+                    if let Err(e) = self.heartbeat(&heartbeat_db, &process).await {
+                        warn!("Failed to flush heartbeat: {}", e);
+                    }
                 }
                 // Quiet mode entered: immediately push a heartbeat so the
                 // metadata column reflects the new state without waiting


### PR DESCRIPTION
## Problem

In the worker main loop, the periodic heartbeat branch was the only periodic
branch that propagated errors with `?`. Every sibling branch — prune, cleanup,
reconcile, and the quiet-mode heartbeat right below it — logs and continues. So
a single transient database error during a heartbeat (a lock timeout or a
connection blip) returned from `run_main_loop` and tore down the entire worker.

## Fix

Log and continue on heartbeat error, matching the sibling branches; the next
tick retries. If heartbeats fail persistently the process row goes stale and
another worker's prune reclaims its jobs — the designed recovery path, and the
same tolerance Solid Queue's heartbeat has.

## Test

`cargo clippy --all-targets --all-features` clean; execution / supervisor /
integration pytest passes.
