### PR TITLE
fix: retry DB acquisition in after_executed cleanup instead of bailing

### DIFF
--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1489,7 +1489,6 @@ impl Execution {
         }
         .await;
 
-        let mut db = self.ctx.get_db().await?;
         let failed = result.is_err();
         let err = result.as_ref().err().map(|e| e.to_string());
 
@@ -1536,15 +1535,26 @@ impl Execution {
                     job_id, attempt, max_retries
                 );
                 tokio::time::sleep(backoff).await;
-                // Re-acquire connection from pool for retry
-                db = match self.ctx.get_db().await {
-                    Ok(db) => db,
-                    Err(e) => {
-                        warn!("Failed to re-acquire connection: {}", e);
-                        continue;
-                    }
-                };
+            }
 
+            // Acquire a fresh connection for this attempt. A transient failure
+            // here (momentary pool exhaustion / connection blip) must not bypass
+            // the cleanup and leave the already-executed job's claimed row for
+            // the orphan sweep to mark FAILED — retry it exactly like the
+            // transaction. Only a persistent failure across every attempt falls
+            // through to the emergency path below.
+            let db = match self.ctx.get_db().await {
+                Ok(db) => db,
+                Err(e) => {
+                    warn!(
+                        "Failed to acquire DB connection for cleanup of job {} (attempt {}): {}",
+                        job_id, attempt, e
+                    );
+                    continue;
+                }
+            };
+
+            if attempt > 0 {
                 // Lost-ack guard (mirrors Solid Queue's "the claimed row is the
                 // source of truth"): the cleanup closure is atomic, so a prior
                 // attempt either committed everything — mark_finished/failed,


### PR DESCRIPTION
> Stacked on #112 (`fix/after-executed-lost-ack`). Base retargets to `master`
> automatically once #112 merges. The net diff here is the DB-acquisition change
> only.

## Problem

`after_executed` acquired its DB connection with `let db = self.ctx.get_db().await?`
**before** the cleanup retry loop. That `?` propagated any acquisition failure
straight out of the function, bypassing both the retry loop and the emergency
cleanup that follows it. Since the job has already executed at this point, its
claimed row is left behind with nothing to clean it up — the orphan sweep later
marks the (successful) job as FAILED.

`get_db()` is an `Arc` clone and rarely fails, but momentary pool exhaustion or
a connection blip can trigger it — and a single blip should not cost a
successful job.

## Fix

Acquire the connection at the top of every attempt inside the loop instead of
once before it. A transient acquisition failure now just `continue`s to the next
attempt (with backoff), exactly like the transaction body already does. Only a
persistent failure across all attempts falls through to the emergency path,
which already handles a missing connection gracefully.

## Test

`cargo clippy --all-targets --all-features` clean; execution / retry /
concurrency / failed-jobs pytest passes.
