### PR TITLE
fix: run scheduler enqueue hooks outside the DB transaction

### DIFF
--- a/src/control_plane/handlers/recurring_jobs.rs
+++ b/src/control_plane/handlers/recurring_jobs.rs
@@ -3,7 +3,7 @@ use axum::{
     http::StatusCode,
     response::{Html, IntoResponse, Redirect},
 };
-use sea_orm::{ConnectionTrait, DbBackend, DbErr, Statement, TransactionTrait, Value};
+use sea_orm::{ConnectionTrait, DbBackend, Statement, Value};
 use std::sync::Arc;
 use std::time::Instant;
 use tracing::{debug, error, info, warn};
@@ -148,13 +148,9 @@ impl ControlPlane {
         let now = chrono::Utc::now().naive_utc();
         let ctx = state.ctx.clone();
 
-        let enqueued_queue = db
-            .transaction::<_, Option<String>, DbErr>(|txn| {
-                let entry = entry.clone();
-                let ctx = ctx.clone();
-                Box::pin(async move { enqueue_job(&ctx, txn, entry, now).await })
-            })
-            .await?;
+        // enqueue_job opens its own transaction around just the DB writes; its
+        // enqueue hooks stay outside that transaction (M5).
+        let enqueued_queue = enqueue_job(&ctx, db, entry, now).await?;
 
         // Send NOTIFY after transaction commits (only if job was created).
         // `should_send_notify` enforces backend + use_listen_notify + per-queue throttle.

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -5,7 +5,10 @@ use crate::process::{ProcessInfo, ProcessTrait};
 use crate::query_builder;
 use async_trait::async_trait;
 use chrono::NaiveDateTime;
-use sea_orm::{ConnectionTrait, DbBackend, DbErr, ExecResult, Statement, TransactionTrait, Value};
+use sea_orm::{
+    ConnectionTrait, DbBackend, DbErr, ExecResult, Statement, TransactionError, TransactionTrait,
+    Value,
+};
 use serde_json::json;
 use serde_yaml;
 use std::collections::HashMap;
@@ -167,7 +170,7 @@ pub async fn enqueue_job<C>(
     scheduled_at: NaiveDateTime,
 ) -> std::result::Result<Option<String>, DbErr>
 where
-    C: ConnectionTrait,
+    C: ConnectionTrait + TransactionTrait,
 {
     let task_key = entry
         .key
@@ -328,105 +331,130 @@ where
         }
     }
 
-    // Run the actual DB enqueue; on any error, close the around_enqueue generator
-    let concurrency_key_str = concurrency_constraint.as_ref().map(|c| c.key.as_str());
-    let db_result: std::result::Result<(crate::entities::quebec_jobs::Model, bool), DbErr> =
-        async {
-            let job = query_builder::jobs::insert_returning(
-                db,
-                &ctx.table_config,
-                routed_queue_name,
-                &entry.class,
-                Some(params.to_string()).as_deref(),
-                priority,
-                Some(active_job_id.as_str()),
-                Some(scheduled_at),
-                concurrency_key_str,
-            )
-            .await?;
-
-            let claimed = query_builder::recurring_executions::try_insert(
-                db,
-                &ctx.table_config,
-                job.id,
-                &task_key,
-                scheduled_at,
-            )
-            .await?;
-
-            if !claimed {
-                query_builder::jobs::delete_by_id(db, &ctx.table_config, job.id).await?;
-                trace!(
-                    "Skipping job {} at {} - already claimed by another scheduler",
-                    task_key,
-                    scheduled_at
-                );
-                return Ok((job, false)); // not claimed
-            }
-
-            let blocked_by = if let Some(constraint) = &concurrency_constraint {
-                use crate::semaphore::acquire_semaphore_with_constraint;
-                if acquire_semaphore_with_constraint(db, &ctx.table_config, constraint).await? {
-                    info!("Scheduler: Semaphore acquired for key: {}", constraint.key);
-                    None
-                } else {
-                    warn!(
-                        "Scheduler: Failed to acquire semaphore for key: {}",
-                        constraint.key
-                    );
-                    Some(constraint)
-                }
-            } else {
-                None
-            };
-
-            if let Some(constraint) = blocked_by {
-                match constraint.on_conflict {
-                    crate::context::ConcurrencyConflict::Discard => {
-                        warn!(
-                            job_id = job.id,
-                            "Job `{}' discarded due to: {{key={:?}, limit={}, duration={}s}}",
-                            job.class_name,
-                            constraint.key,
-                            constraint.limit,
-                            constraint.duration.map_or(0, |d| d.num_seconds())
-                        );
-                        query_builder::jobs::mark_finished(db, &ctx.table_config, job.id).await?;
-                        return Ok((job, false)); // discarded
-                    }
-                    crate::context::ConcurrencyConflict::Block => {
-                        let block_now = chrono::Utc::now().naive_utc();
-                        let duration = constraint.duration.unwrap_or_else(|| {
-                            chrono::Duration::from_std(ctx.default_concurrency_control_period)
-                                .unwrap_or_else(|_| chrono::Duration::seconds(60))
-                        });
-                        let expires_at = block_now + duration;
-                        query_builder::blocked_executions::insert(
-                            db,
-                            &ctx.table_config,
-                            job.id,
-                            &job.queue_name,
-                            job.priority,
-                            &constraint.key,
-                            expires_at,
-                        )
-                        .await?;
-                    }
-                }
-            } else {
-                query_builder::ready_executions::insert(
-                    db,
-                    &ctx.table_config,
-                    job.id,
-                    &job.queue_name,
-                    job.priority,
+    // Run the actual DB enqueue inside its OWN transaction. The enqueue hooks
+    // above (before/around up to yield) and below (around-resume/after) run
+    // OUTSIDE this transaction on purpose: they execute arbitrary user Python
+    // under the GIL, and holding a DB transaction across them deadlocks SQLite
+    // (the transaction already holds the global write lock, so a hook that
+    // writes the DB self-deadlocks / hits SQLITE_BUSY) and needlessly widens
+    // row-lock contention on Postgres. Only the DB writes are transactional.
+    let db_result: std::result::Result<(crate::entities::quebec_jobs::Model, bool), DbErr> = {
+        let txn_ctx = ctx.clone();
+        let class = entry.class.clone();
+        let routed = routed_queue_name.to_string();
+        let params_str = params.to_string();
+        let active_job_id = active_job_id.clone();
+        let task_key = task_key.clone();
+        let constraint = concurrency_constraint;
+        db.transaction::<_, (crate::entities::quebec_jobs::Model, bool), DbErr>(move |txn| {
+            Box::pin(async move {
+                let concurrency_key_str = constraint.as_ref().map(|c| c.key.as_str());
+                let job = query_builder::jobs::insert_returning(
+                    txn,
+                    &txn_ctx.table_config,
+                    &routed,
+                    &class,
+                    Some(params_str.as_str()),
+                    priority,
+                    Some(active_job_id.as_str()),
+                    Some(scheduled_at),
+                    concurrency_key_str,
                 )
                 .await?;
-            }
 
-            Ok((job, true)) // success
-        }
-        .await;
+                let claimed = query_builder::recurring_executions::try_insert(
+                    txn,
+                    &txn_ctx.table_config,
+                    job.id,
+                    &task_key,
+                    scheduled_at,
+                )
+                .await?;
+
+                if !claimed {
+                    query_builder::jobs::delete_by_id(txn, &txn_ctx.table_config, job.id).await?;
+                    trace!(
+                        "Skipping job {} at {} - already claimed by another scheduler",
+                        task_key,
+                        scheduled_at
+                    );
+                    return Ok((job, false)); // not claimed
+                }
+
+                let blocked_by = if let Some(constraint) = &constraint {
+                    use crate::semaphore::acquire_semaphore_with_constraint;
+                    if acquire_semaphore_with_constraint(txn, &txn_ctx.table_config, constraint)
+                        .await?
+                    {
+                        info!("Scheduler: Semaphore acquired for key: {}", constraint.key);
+                        None
+                    } else {
+                        warn!(
+                            "Scheduler: Failed to acquire semaphore for key: {}",
+                            constraint.key
+                        );
+                        Some(constraint)
+                    }
+                } else {
+                    None
+                };
+
+                if let Some(constraint) = blocked_by {
+                    match constraint.on_conflict {
+                        crate::context::ConcurrencyConflict::Discard => {
+                            warn!(
+                                job_id = job.id,
+                                "Job `{}' discarded due to: {{key={:?}, limit={}, duration={}s}}",
+                                job.class_name,
+                                constraint.key,
+                                constraint.limit,
+                                constraint.duration.map_or(0, |d| d.num_seconds())
+                            );
+                            query_builder::jobs::mark_finished(txn, &txn_ctx.table_config, job.id)
+                                .await?;
+                            return Ok((job, false)); // discarded
+                        }
+                        crate::context::ConcurrencyConflict::Block => {
+                            let block_now = chrono::Utc::now().naive_utc();
+                            let duration = constraint.duration.unwrap_or_else(|| {
+                                chrono::Duration::from_std(
+                                    txn_ctx.default_concurrency_control_period,
+                                )
+                                .unwrap_or_else(|_| chrono::Duration::seconds(60))
+                            });
+                            let expires_at = block_now + duration;
+                            query_builder::blocked_executions::insert(
+                                txn,
+                                &txn_ctx.table_config,
+                                job.id,
+                                &job.queue_name,
+                                job.priority,
+                                &constraint.key,
+                                expires_at,
+                            )
+                            .await?;
+                        }
+                    }
+                } else {
+                    query_builder::ready_executions::insert(
+                        txn,
+                        &txn_ctx.table_config,
+                        job.id,
+                        &job.queue_name,
+                        job.priority,
+                    )
+                    .await?;
+                }
+
+                Ok((job, true)) // success
+            })
+        })
+        .await
+        .map_err(|e| match e {
+            TransactionError::Connection(e) => e,
+            TransactionError::Transaction(e) => e,
+        })
+    };
 
     // On any DB error or early exit, throw into generator before propagating
     let (job, enqueued) = match db_result {
@@ -816,21 +844,14 @@ impl Scheduler {
             }
 
             let start_time = Instant::now();
-            let result = db
-                .transaction::<_, Option<String>, DbErr>(|txn| {
-                    let entry = entry.clone();
-                    let task_key = task_key.clone();
-                    let ctx = ctx.clone();
-                    Box::pin(async move {
-                        let queue_name = enqueue_job(&ctx, txn, entry, scheduled_at).await?;
-                        if queue_name.is_some() {
-                            trace!("Job({:?}) enqueued", task_key);
-                        }
-                        Ok(queue_name)
-                    })
-                })
+            // enqueue_job opens its own transaction around just the DB writes;
+            // the enqueue hooks it runs stay outside that transaction (see M5).
+            let result = enqueue_job(&ctx, db.as_ref(), entry.clone(), scheduled_at)
                 .await
                 .inspect_err(|e| error!("Failed to enqueue scheduled job {}: {}", task_key, e));
+            if let Ok(Some(_)) = &result {
+                trace!("Job({:?}) enqueued", task_key);
+            }
 
             // Send NOTIFY after transaction commits (only if job was actually created).
             // `should_send_notify` enforces backend + use_listen_notify + per-queue throttle.

--- a/src/types.rs
+++ b/src/types.rs
@@ -3757,18 +3757,13 @@ impl PyQuebec {
                 };
 
                 let now = chrono::Utc::now().naive_utc();
-                let enqueued_queue = db_ref
-                    .transaction::<_, Option<String>, sea_orm::DbErr>(|txn| {
-                        let entry = entry.clone();
-                        let ctx = ctx.clone();
-                        Box::pin(async move { enqueue_job(&ctx, txn, entry, now).await })
-                    })
-                    .await
-                    .map_err(|e| {
-                        pyo3::exceptions::PyRuntimeError::new_err(format!(
-                            "Failed to enqueue recurring task {key}: {e}"
-                        ))
-                    })?;
+                // enqueue_job opens its own transaction around just the DB
+                // writes; its enqueue hooks stay outside that transaction (M5).
+                let enqueued_queue = enqueue_job(&ctx, db_ref, entry, now).await.map_err(|e| {
+                    pyo3::exceptions::PyRuntimeError::new_err(format!(
+                        "Failed to enqueue recurring task {key}: {e}"
+                    ))
+                })?;
 
                 if let Some(ref queue) = enqueued_queue {
                     if crate::notify::should_send_notify(&ctx, queue) {

--- a/tests/test_recurring_enqueue_hooks.py
+++ b/tests/test_recurring_enqueue_hooks.py
@@ -47,6 +47,33 @@ class RecurringSkipHookJob(quebec.BaseClass):
         return None
 
 
+class RecurringDatabaseHookJob(quebec.BaseClass):
+    engine = None
+    task_table = ""
+    task_key = ""
+
+    def after_enqueue(self) -> None:
+        engine = type(self).engine
+        assert engine is not None
+
+        # Use a separate connection so this write fails immediately on SQLite
+        # if the scheduler still holds its enqueue write transaction.
+        with engine.begin() as connection:
+            if connection.dialect.name == "sqlite":
+                connection.exec_driver_sql("PRAGMA busy_timeout = 0")
+            result = connection.execute(
+                text(
+                    f"UPDATE {type(self).task_table} "
+                    "SET description = :description WHERE key = :key"
+                ),
+                {"description": "written-by-after-hook", "key": type(self).task_key},
+            )
+            assert result.rowcount == 1
+
+    def perform(self, *args, **kwargs) -> None:
+        return None
+
+
 def _seed_recurring_task(session, prefix: str, key: str, class_name: str) -> None:
     """Insert a recurring_tasks row so run_recurring_now() can look it up."""
     now = datetime.now(timezone.utc).replace(tzinfo=None)
@@ -94,6 +121,33 @@ def test_recurring_enqueue_runs_all_hooks(qc_with_sqlalchemy, db_assert) -> None
         "around:after",
         "after",
     ]
+    assert db_assert.count_ready_executions() == 1
+
+
+def test_recurring_enqueue_post_hook_runs_after_transaction_commits(
+    qc_with_sqlalchemy, db_assert
+) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+    engine = qc_with_sqlalchemy["engine"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    task_key = "recurring_hook_db_write"
+    RecurringDatabaseHookJob.engine = engine
+    RecurringDatabaseHookJob.task_table = f"{prefix}_recurring_tasks"
+    RecurringDatabaseHookJob.task_key = task_key
+    qc.register_job(RecurringDatabaseHookJob)
+    _seed_recurring_task(
+        session, prefix, task_key, RecurringDatabaseHookJob.__qualname__
+    )
+
+    assert qc.run_recurring_now(task_key) is True
+
+    description = session.execute(
+        text(f"SELECT description FROM {prefix}_recurring_tasks WHERE key = :key"),
+        {"key": task_key},
+    ).scalar_one()
+    assert description == "written-by-after-hook"
     assert db_assert.count_ready_executions() == 1
 
 

--- a/tests/test_recurring_enqueue_hooks.py
+++ b/tests/test_recurring_enqueue_hooks.py
@@ -1,0 +1,115 @@
+"""Enqueue hooks on the scheduler/recurring enqueue path.
+
+The scheduler runs before/around/after_enqueue hooks (arbitrary user Python)
+around its DB writes. Those hooks must run OUTSIDE the enqueue transaction —
+holding the transaction across them deadlocks SQLite and widens Postgres
+row-lock contention. These tests fire the exact scheduler enqueue path via
+``run_recurring_now`` and assert the hooks are still orchestrated correctly.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import text
+
+import quebec
+
+
+class RecurringHookJob(quebec.BaseClass):
+    calls: list[str] = []
+
+    def before_enqueue(self) -> None:
+        type(self).calls.append("before")
+
+    def around_enqueue(self):
+        type(self).calls.append("around:before")
+        yield
+        type(self).calls.append("around:after")
+
+    def after_enqueue(self) -> None:
+        type(self).calls.append("after")
+
+    def perform(self, *args, **kwargs) -> None:
+        return None
+
+
+class RecurringSkipHookJob(quebec.BaseClass):
+    calls: list[str] = []
+
+    def around_enqueue(self):
+        type(self).calls.append("skipped")
+        # A generator that never yields -> enqueue is skipped.
+        if False:
+            yield
+
+    def perform(self, *args, **kwargs) -> None:
+        return None
+
+
+def _seed_recurring_task(session, prefix: str, key: str, class_name: str) -> None:
+    """Insert a recurring_tasks row so run_recurring_now() can look it up."""
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    session.execute(
+        text(
+            f"INSERT INTO {prefix}_recurring_tasks "
+            "(key, schedule, class_name, arguments, queue_name, priority, "
+            '"static", created_at, updated_at) '
+            "VALUES (:key, :schedule, :class_name, :arguments, :queue_name, "
+            ":priority, :static, :created_at, :updated_at)"
+        ),
+        {
+            "key": key,
+            "schedule": "every minute",
+            "class_name": class_name,
+            "arguments": "[]",
+            "queue_name": "default",
+            "priority": 0,
+            "static": True,
+            "created_at": now,
+            "updated_at": now,
+        },
+    )
+    session.commit()
+
+
+def test_recurring_enqueue_runs_all_hooks(qc_with_sqlalchemy, db_assert) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    RecurringHookJob.calls = []
+    qc.register_job(RecurringHookJob)
+
+    task_key = "recurring_hook_all"
+    _seed_recurring_task(session, prefix, task_key, RecurringHookJob.__qualname__)
+
+    assert qc.run_recurring_now(task_key) is True
+
+    # before + around-before run before the DB insert; around-after + after run
+    # after it — all outside the enqueue transaction.
+    assert RecurringHookJob.calls == [
+        "before",
+        "around:before",
+        "around:after",
+        "after",
+    ]
+    assert db_assert.count_ready_executions() == 1
+
+
+def test_recurring_enqueue_around_no_yield_skips(qc_with_sqlalchemy, db_assert) -> None:
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    RecurringSkipHookJob.calls = []
+    qc.register_job(RecurringSkipHookJob)
+
+    task_key = "recurring_hook_skip"
+    _seed_recurring_task(session, prefix, task_key, RecurringSkipHookJob.__qualname__)
+
+    # around_enqueue never yields -> the job is skipped, nothing enqueued.
+    assert qc.run_recurring_now(task_key) is False
+    assert RecurringSkipHookJob.calls == ["skipped"]
+    assert db_assert.count_ready_executions() == 0
+    assert db_assert.count_jobs() == 0


### PR DESCRIPTION
## Problem

The scheduler's `enqueue_job` ran the `before_enqueue` / `around_enqueue` /
`after_enqueue` hooks — arbitrary user Python under the GIL — **inside** the DB
transaction that persists the job. All three call sites wrapped the whole
function in `db.transaction(|txn| enqueue_job(..txn..))`.

Holding a transaction across those hooks is harmful:

- **SQLite**: the transaction already holds the global write lock, so a hook
  that writes the database self-deadlocks / hits `SQLITE_BUSY`.
- **Postgres**: the hook occupies the connection and holds the
  `recurring_executions` row lock for the whole (arbitrary) duration of the
  user code, widening contention.
- A hook raising also rolls back the entire enqueue.

## Fix

Move the transaction boundary inside `enqueue_job` so it wraps **only** the DB
writes. The hooks — which never touch the DB handle — now run outside it: the
before/around-to-yield phase decides skip before the transaction opens, and the
around-resume/after phase runs after it commits. The three call sites just pass
a connection instead of opening a transaction.

This matches Rails/Solid Queue, where enqueue callbacks run outside the DB
transaction.

## Test

New `tests/test_recurring_enqueue_hooks.py` fires the exact scheduler enqueue
path via `run_recurring_now` with a hooked recurring task and asserts the hooks
are still orchestrated correctly (`before` → `around:before` →
`around:after` → `after`, job enqueued) and that a non-yielding `around_enqueue`
still skips the enqueue. `cargo clippy --all-targets --all-features` clean; full
pytest suite (260) passes.
