### PR TITLE
fix: evict stale entries from NOTIFY throttle map

### DIFF
--- a/src/notify.rs
+++ b/src/notify.rs
@@ -8,13 +8,24 @@ use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 use tracing::{error, info, trace, warn};
 
-/// Per-queue last-NOTIFY timestamps, shared across the process. Producers
-/// consult this table before emitting a NOTIFY to coalesce bursts (e.g.
-/// thousands of `perform_later` calls in a loop) into one wake-up per
-/// `notify_throttle_interval`. The window is per process — workers still
-/// catch up via polling / IDLE fallback if a NOTIFY is dropped.
-static LAST_NOTIFY: LazyLock<Mutex<HashMap<String, Instant>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
+/// Per-queue NOTIFY throttle state, shared across the process. `last` records
+/// the last-emitted time per queue so producers coalesce bursts (e.g. thousands
+/// of `perform_later` calls in a loop) into one wake-up per
+/// `notify_throttle_interval`. `last_swept` bounds how often stale entries are
+/// evicted so a churn of dynamic queue names (`customer_<id>`) can't leak the
+/// map unboundedly. The window is per process — workers still catch up via
+/// polling / IDLE fallback if a NOTIFY is dropped.
+struct NotifyThrottle {
+    last: HashMap<String, Instant>,
+    last_swept: Instant,
+}
+
+static LAST_NOTIFY: LazyLock<Mutex<NotifyThrottle>> = LazyLock::new(|| {
+    Mutex::new(NotifyThrottle {
+        last: HashMap::new(),
+        last_swept: Instant::now(),
+    })
+});
 
 /// Should the producer emit a NOTIFY for `queue` given the current context?
 ///
@@ -39,14 +50,30 @@ pub fn should_emit_notify(queue: &str, throttle: Duration) -> bool {
         return true;
     }
     let now = Instant::now();
-    let mut map = LAST_NOTIFY.lock().expect("notify throttle map poisoned");
-    match map.get(queue) {
+    let mut state = LAST_NOTIFY.lock().expect("notify throttle map poisoned");
+
+    let emit = match state.last.get(queue) {
         Some(last) if now.duration_since(*last) < throttle => false,
         _ => {
-            map.insert(queue.to_string(), now);
+            state.last.insert(queue.to_string(), now);
             true
         }
+    };
+
+    // Opportunistically evict entries older than the throttle window. Such an
+    // entry would allow a NOTIFY through anyway, so dropping it never changes
+    // throttling behavior — it only reclaims memory from queue names that will
+    // never recur. The sweep is O(n), so it runs at most once per throttle
+    // window to keep steady-state cost bounded no matter how many distinct
+    // (dynamic) queue names churn through the map.
+    if now.duration_since(state.last_swept) >= throttle {
+        state
+            .last
+            .retain(|_, last| now.duration_since(*last) < throttle);
+        state.last_swept = now;
     }
+
+    emit
 }
 
 /// PostgreSQL LISTEN/NOTIFY manager for reducing queue latency


### PR DESCRIPTION
## Problem

The producer-side NOTIFY throttle keeps a process-global
`HashMap<String, Instant>` of the last-emitted time per queue. Entries were only
ever inserted, never evicted. With dynamic per-tenant / per-entity queue names
(`customer_<id>`, `mailers_<id>`, …) the map grows without bound — a slow
process-level memory leak.

## Fix

Opportunistically evict entries older than the throttle window. An entry that
old would allow a NOTIFY through anyway, so dropping it never changes throttling
behavior — it only reclaims memory from queue names that will never recur. The
sweep is O(n), so it runs at most once per throttle window (tracked via a
`last_swept` timestamp) to keep steady-state cost bounded no matter how many
distinct queue names churn through the map. The map is now bounded to roughly
the set of queues that emitted a NOTIFY within one throttle window.

## Test

No automated test: this crate can't run `cargo test` (cdylib + libpython), and
the throttle only runs on the PostgreSQL producer path (the pytest suite is
SQLite). Verified by `cargo clippy --all-targets --all-features` (clean),
`cargo fmt --check`, and a build + import smoke test. The eviction predicate is
behavior-preserving by construction (it only removes entries that were already
past the throttle window).
