### PR TITLE
fix: stop forking when a shutdown signal arrives mid-startup

### DIFF
--- a/python/quebec/supervisor.py
+++ b/python/quebec/supervisor.py
@@ -163,22 +163,36 @@ class Supervisor:
         try:
             for role, count in self.plan.items():
                 for index in range(count):
+                    # A SIGTERM/SIGQUIT arriving mid-startup sets _stopping via
+                    # the signal handler. Stop forking the rest of the plan
+                    # instead of standing up the whole fleet only to tear it
+                    # down immediately in _supervise().
+                    if self._stopping:
+                        break
                     self._fork_child(role, index)
+                if self._stopping:
+                    break
 
-            # Start the control plane only after all children are forked so
-            # the listening socket/runtime task stays parent-only. Children
-            # would otherwise inherit the TcpListener fd.
-            if self.control_plane:
-                try:
-                    self.qc.start_control_plane(self.control_plane)
-                except Exception:
-                    logger.exception("Failed to start control plane")
+            # If shutdown was already requested during the fork loop, skip
+            # standing up the control plane and background threads; go straight
+            # to _supervise() (which returns at once) and let `finally` reap the
+            # children that were already forked.
+            if not self._stopping:
+                # Start the control plane only after all children are forked so
+                # the listening socket/runtime task stays parent-only. Children
+                # would otherwise inherit the TcpListener fd.
+                if self.control_plane:
+                    try:
+                        self.qc.start_control_plane(self.control_plane)
+                    except Exception:
+                        logger.exception("Failed to start control plane")
 
-            self._start_heartbeat()
-            self._start_maintenance()
-            # Children forked and control plane up: tell systemd we're ready.
-            # No-op unless launched under a Type=notify unit.
-            self.qc.systemd_ready(self._status_text())
+                self._start_heartbeat()
+                self._start_maintenance()
+                # Children forked and control plane up: tell systemd we're
+                # ready. No-op unless launched under a Type=notify unit.
+                self.qc.systemd_ready(self._status_text())
+
             self._supervise()
         finally:
             try:

--- a/python/quebec/supervisor.py
+++ b/python/quebec/supervisor.py
@@ -173,22 +173,27 @@ class Supervisor:
                 if self._stopping:
                     break
 
-            # If shutdown was already requested during the fork loop, skip
-            # standing up the control plane and background threads; go straight
-            # to _supervise() (which returns at once) and let `finally` reap the
-            # children that were already forked.
-            if not self._stopping:
-                # Start the control plane only after all children are forked so
-                # the listening socket/runtime task stays parent-only. Children
-                # would otherwise inherit the TcpListener fd.
-                if self.control_plane:
-                    try:
-                        self.qc.start_control_plane(self.control_plane)
-                    except Exception:
-                        logger.exception("Failed to start control plane")
+            # Treat each startup phase as a separate checkpoint. Signal handlers
+            # run on this main thread, including after a blocking startup call
+            # returns, so re-check before every later phase instead of relying on
+            # one guard around the whole block.
+            #
+            # Start the control plane only after all children are forked so the
+            # listening socket/runtime task stays parent-only. Children would
+            # otherwise inherit the TcpListener fd.
+            if not self._stopping and self.control_plane:
+                try:
+                    self.qc.start_control_plane(self.control_plane)
+                except Exception:
+                    logger.exception("Failed to start control plane")
 
+            if not self._stopping:
                 self._start_heartbeat()
+
+            if not self._stopping:
                 self._start_maintenance()
+
+            if not self._stopping:
                 # Children forked and control plane up: tell systemd we're
                 # ready. No-op unless launched under a Type=notify unit.
                 self.qc.systemd_ready(self._status_text())

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -442,11 +442,20 @@ class TestSupervisorStopDuringStartup:
         sup = Supervisor(qc, plan, control_plane=control_plane)
 
         started = {"heartbeat": False, "maintenance": False}
+        sup._install_signal_handlers = lambda: None
         sup._start_heartbeat = lambda: started.__setitem__("heartbeat", True)
         sup._start_maintenance = lambda: started.__setitem__("maintenance", True)
-        sup._supervise = lambda: None
-        sup._terminate_gracefully = lambda: None
+        sup._supervise = MagicMock()
+        sup._terminate_gracefully = MagicMock()
         return sup, qc, started
+
+    @staticmethod
+    def _assert_stopped_cleanly(sup, qc):
+        qc.systemd_ready.assert_not_called()
+        sup._supervise.assert_called_once_with()
+        qc.systemd_stop.assert_called_once_with()
+        sup._terminate_gracefully.assert_called_once_with()
+        qc.deregister_process.assert_called_once_with(1)
 
     def test_stop_mid_fork_halts_remaining_forks(self):
         sup, qc, started = self._stub_supervisor(
@@ -469,6 +478,7 @@ class TestSupervisorStopDuringStartup:
         # Control plane and background threads were never stood up.
         qc.start_control_plane.assert_not_called()
         assert started == {"heartbeat": False, "maintenance": False}
+        self._assert_stopped_cleanly(sup, qc)
 
     def test_stop_before_any_fork_forks_nothing(self):
         sup, qc, started = self._stub_supervisor(
@@ -484,3 +494,26 @@ class TestSupervisorStopDuringStartup:
         assert spawned == []
         qc.start_control_plane.assert_not_called()
         assert started == {"heartbeat": False, "maintenance": False}
+        self._assert_stopped_cleanly(sup, qc)
+
+    def test_stop_during_control_plane_skips_remaining_startup(self):
+        sup, qc, started = self._stub_supervisor(
+            {ROLE_WORKER: 1}, control_plane="dummy"
+        )
+
+        spawned = []
+        sup._fork_child = lambda role, index: spawned.append((role, index))
+
+        def stop_during_control_plane(_address):
+            # Model a signal handled while the blocking startup call is in
+            # progress. Once the call returns, no later startup phase may run.
+            sup._stopping = True
+
+        qc.start_control_plane.side_effect = stop_during_control_plane
+
+        sup.start()
+
+        assert spawned == [(ROLE_WORKER, 0)]
+        qc.start_control_plane.assert_called_once_with("dummy")
+        assert started == {"heartbeat": False, "maintenance": False}
+        self._assert_stopped_cleanly(sup, qc)

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -422,3 +422,65 @@ class TestSupervisorClassValidation:
         Supervisor(qc, {"worker": 2})
         # List-style (length is what matters)
         Supervisor(qc, {"worker": [None, None, None]})
+
+
+class TestSupervisorStopDuringStartup:
+    """A shutdown signal arriving mid-startup must halt forking.
+
+    `start()` installs the signal handlers before forking the plan, so a
+    SIGTERM/SIGQUIT can flip `_stopping` while the fork loop is still running.
+    The loop must stop forking the rest of the plan and skip standing up the
+    control plane / heartbeat / maintenance, rather than build the whole fleet
+    only to tear it down immediately.
+    """
+
+    def _stub_supervisor(self, plan, *, control_plane=None):
+        from unittest.mock import MagicMock
+
+        qc = MagicMock()
+        qc.register_supervisor.return_value = 1
+        sup = Supervisor(qc, plan, control_plane=control_plane)
+
+        started = {"heartbeat": False, "maintenance": False}
+        sup._start_heartbeat = lambda: started.__setitem__("heartbeat", True)
+        sup._start_maintenance = lambda: started.__setitem__("maintenance", True)
+        sup._supervise = lambda: None
+        sup._terminate_gracefully = lambda: None
+        return sup, qc, started
+
+    def test_stop_mid_fork_halts_remaining_forks(self):
+        sup, qc, started = self._stub_supervisor(
+            {ROLE_WORKER: 3}, control_plane="dummy"
+        )
+
+        spawned = []
+
+        def fake_fork(role, index):
+            spawned.append((role, index))
+            # Simulate SIGTERM landing right after the first child is forked.
+            sup._stopping = True
+
+        sup._fork_child = fake_fork
+
+        sup.start()
+
+        # Only the first child was forked; the remaining two were skipped.
+        assert spawned == [(ROLE_WORKER, 0)]
+        # Control plane and background threads were never stood up.
+        qc.start_control_plane.assert_not_called()
+        assert started == {"heartbeat": False, "maintenance": False}
+
+    def test_stop_before_any_fork_forks_nothing(self):
+        sup, qc, started = self._stub_supervisor(
+            {ROLE_WORKER: 3}, control_plane="dummy"
+        )
+        sup._stopping = True  # signal already delivered before the loop runs
+
+        spawned = []
+        sup._fork_child = lambda role, index: spawned.append((role, index))
+
+        sup.start()
+
+        assert spawned == []
+        qc.start_control_plane.assert_not_called()
+        assert started == {"heartbeat": False, "maintenance": False}


### PR DESCRIPTION
## Problem

`Supervisor.start()` installs the signal handlers *before* forking the plan, so
a SIGTERM/SIGQUIT can flip `_stopping` while the fork loop is still running. The
loop never checked `_stopping`, so a signal arriving mid-startup still forked
every remaining child, started the control plane, and started the
heartbeat/maintenance threads — only for `_supervise()` (a `while not
self._stopping` loop) to return immediately and tear the whole fleet back down.

## Fix

Check `_stopping` inside the fork loop and stop forking the rest of the plan,
and skip standing up the control plane / heartbeat / maintenance / systemd-ready
when a shutdown was already requested. `_supervise()` still runs (it returns at
once) and the existing `finally` reaps the children that were already forked.

## Test

`tests/test_supervisor.py::TestSupervisorStopDuringStartup` drives `start()`
with a `MagicMock` qc and a stubbed `_fork_child`:
- signal mid-fork → only the first child is forked, control plane and
  background threads are never started;
- signal before the loop → nothing is forked.

Both fail on the old code (which forks the full plan and starts everything). Full
`test_supervisor.py` (27) passes; `ruff check` / `ruff format --check` clean.
