### PR TITLE
fix: validate queue.yml dispatcher intervals instead of panicking

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -801,6 +801,11 @@ impl PyQuebec {
                     if let Some(polling_interval) = dispatcher.polling_interval {
                         if _ctx.dispatcher_polling_interval == Duration::from_secs(1) {
                             // default value
+                            if !polling_interval.is_finite() || polling_interval < 0.0 {
+                                return Err(pyo3::exceptions::PyValueError::new_err(
+                                    format!("dispatcher_polling_interval must be finite and >= 0 (set via queue.yml dispatchers.polling_interval, got {polling_interval})"),
+                                ));
+                            }
                             _ctx.dispatcher_polling_interval =
                                 Duration::from_secs_f64(polling_interval);
                         }
@@ -816,6 +821,11 @@ impl PyQuebec {
                             == Duration::from_secs(600)
                         {
                             // default value
+                            if !interval.is_finite() || interval < 0.0 {
+                                return Err(pyo3::exceptions::PyValueError::new_err(
+                                    format!("dispatcher_concurrency_maintenance_interval must be finite and >= 0 (set via queue.yml dispatchers.concurrency_maintenance_interval, got {interval})"),
+                                ));
+                            }
                             _ctx.dispatcher_concurrency_maintenance_interval =
                                 Duration::from_secs_f64(interval);
                         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -801,13 +801,12 @@ impl PyQuebec {
                     if let Some(polling_interval) = dispatcher.polling_interval {
                         if _ctx.dispatcher_polling_interval == Duration::from_secs(1) {
                             // default value
-                            if !polling_interval.is_finite() || polling_interval < 0.0 {
-                                return Err(pyo3::exceptions::PyValueError::new_err(
-                                    format!("dispatcher_polling_interval must be finite and >= 0 (set via queue.yml dispatchers.polling_interval, got {polling_interval})"),
-                                ));
-                            }
                             _ctx.dispatcher_polling_interval =
-                                Duration::from_secs_f64(polling_interval);
+                                Duration::try_from_secs_f64(polling_interval).map_err(|_| {
+                                    pyo3::exceptions::PyValueError::new_err(format!(
+                                        "dispatcher_polling_interval must be finite, >= 0, and within Duration range (set via queue.yml dispatchers.polling_interval, got {polling_interval})"
+                                    ))
+                                })?;
                         }
                     }
                     if let Some(batch_size) = dispatcher.batch_size {
@@ -821,13 +820,12 @@ impl PyQuebec {
                             == Duration::from_secs(600)
                         {
                             // default value
-                            if !interval.is_finite() || interval < 0.0 {
-                                return Err(pyo3::exceptions::PyValueError::new_err(
-                                    format!("dispatcher_concurrency_maintenance_interval must be finite and >= 0 (set via queue.yml dispatchers.concurrency_maintenance_interval, got {interval})"),
-                                ));
-                            }
                             _ctx.dispatcher_concurrency_maintenance_interval =
-                                Duration::from_secs_f64(interval);
+                                Duration::try_from_secs_f64(interval).map_err(|_| {
+                                    pyo3::exceptions::PyValueError::new_err(format!(
+                                        "dispatcher_concurrency_maintenance_interval must be finite, >= 0, and within Duration range (set via queue.yml dispatchers.concurrency_maintenance_interval, got {interval})"
+                                    ))
+                                })?;
                         }
                     }
                 }

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,81 @@
+"""Constructor-time validation of queue.yml dispatcher intervals.
+
+An out-of-range interval must surface as a readable ``ValueError`` from the
+Quebec constructor, not a Rust panic (`Duration::from_secs_f64` panics on
+negative / non-finite input). Mirrors the worker-path validation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import quebec
+
+
+def _queue_yml(tmp_path, body: str) -> str:
+    path = tmp_path / "queue.yml"
+    path.write_text(body)
+    return str(path)
+
+
+def test_dispatcher_polling_interval_negative_raises(
+    tmp_path, monkeypatch, db_url, test_prefix
+) -> None:
+    monkeypatch.setenv(
+        "QUEBEC_CONFIG",
+        _queue_yml(
+            tmp_path,
+            """
+development:
+  dispatchers:
+    - polling_interval: -1
+""",
+        ),
+    )
+    monkeypatch.delenv("QUEBEC_ENV", raising=False)
+
+    with pytest.raises(ValueError, match="dispatcher_polling_interval must be finite"):
+        quebec.Quebec(db_url, table_name_prefix=test_prefix)
+
+
+def test_dispatcher_concurrency_maintenance_interval_negative_raises(
+    tmp_path, monkeypatch, db_url, test_prefix
+) -> None:
+    monkeypatch.setenv(
+        "QUEBEC_CONFIG",
+        _queue_yml(
+            tmp_path,
+            """
+development:
+  dispatchers:
+    - concurrency_maintenance_interval: -5
+""",
+        ),
+    )
+    monkeypatch.delenv("QUEBEC_ENV", raising=False)
+
+    with pytest.raises(
+        ValueError, match="concurrency_maintenance_interval must be finite"
+    ):
+        quebec.Quebec(db_url, table_name_prefix=test_prefix)
+
+
+def test_dispatcher_polling_interval_valid_ok(
+    tmp_path, monkeypatch, db_url, test_prefix
+) -> None:
+    """A valid interval still constructs (guards against over-strict checks)."""
+    monkeypatch.setenv(
+        "QUEBEC_CONFIG",
+        _queue_yml(
+            tmp_path,
+            """
+development:
+  dispatchers:
+    - polling_interval: 2.5
+""",
+        ),
+    )
+    monkeypatch.delenv("QUEBEC_ENV", raising=False)
+
+    inst = quebec.Quebec(db_url, table_name_prefix=test_prefix)
+    inst.close()

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -2,7 +2,7 @@
 
 An out-of-range interval must surface as a readable ``ValueError`` from the
 Quebec constructor, not a Rust panic (`Duration::from_secs_f64` panics on
-negative / non-finite input). Mirrors the worker-path validation.
+negative / non-finite / overflowing input). Mirrors the worker-path validation.
 """
 
 from __future__ import annotations
@@ -57,6 +57,27 @@ development:
     with pytest.raises(
         ValueError, match="concurrency_maintenance_interval must be finite"
     ):
+        quebec.Quebec(db_url, table_name_prefix=test_prefix)
+
+
+def test_dispatcher_polling_interval_overflow_raises(
+    tmp_path, monkeypatch, db_url, test_prefix
+) -> None:
+    """A huge finite value overflows Duration and must also raise, not panic."""
+    monkeypatch.setenv(
+        "QUEBEC_CONFIG",
+        _queue_yml(
+            tmp_path,
+            """
+development:
+  dispatchers:
+    - polling_interval: 1.0e30
+""",
+        ),
+    )
+    monkeypatch.delenv("QUEBEC_ENV", raising=False)
+
+    with pytest.raises(ValueError, match="dispatcher_polling_interval must be finite"):
         quebec.Quebec(db_url, table_name_prefix=test_prefix)
 
 


### PR DESCRIPTION
## Problem

When seeding the dispatcher config from `queue.yml`, the constructor fed
`dispatchers.polling_interval` and `dispatchers.concurrency_maintenance_interval`
straight into `Duration::from_secs_f64`, which panics on a negative,
non-finite, or overflowing value. So `dispatchers: [{polling_interval: -1}]`
made `Quebec(...)` raise an opaque `PanicException` instead of a readable
error. The worker path (`workers.polling_interval`) and the runtime
`apply_dispatcher_config` path already validate; only this inline yml path
didn't.

## Fix

Convert both intervals with `Duration::try_from_secs_f64`, raising a
`ValueError` with a clear message on failure. Unlike the `is_finite() && >= 0`
pre-check used elsewhere, this also rejects huge finite values that overflow
`Duration` (e.g. `polling_interval: 1.0e30`), covering every panic case of
`from_secs_f64` in one shot.

## Test

`tests/test_config_validation.py` builds `Quebec` from a `queue.yml` with a
negative `polling_interval` / `concurrency_maintenance_interval` and asserts a
`ValueError` (the old code raised `PanicException`, which is not a `ValueError`,
so these fail pre-fix), plus an overflow case (`1.0e30`) and a valid-value case
that still constructs. `cargo clippy` / `cargo fmt --check` clean; `ruff` clean.
