### PR TITLE
fix: honor explicit dispatcher config equal to defaults over queue.yml

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -732,6 +732,51 @@ impl PyQuebec {
                 .and_then(|s| parse_duration_f64_env(&s))
                 .is_some();
 
+        // Same treatment for dispatcher fields: distinguish "user explicitly
+        // set this via code/env" from "still at the default value" so a
+        // queue.yml value can't silently override an explicit setting that
+        // happens to equal the default (e.g. dispatcher_polling_interval=1.0).
+        let has_explicit_dispatcher_polling = kwargs
+            .and_then(|k| k.get_item("dispatcher_polling_interval").ok().flatten())
+            .filter(|v| {
+                v.extract::<Duration>().is_ok()
+                    || v.extract::<u64>().is_ok()
+                    || v.extract::<f64>()
+                        .map(|f| f.is_finite() && f >= 0.0)
+                        .unwrap_or(false)
+            })
+            .is_some()
+            || std::env::var("QUEBEC_DISPATCHER_POLLING_INTERVAL")
+                .ok()
+                .and_then(|s| parse_duration_f64_env(&s))
+                .is_some();
+        let has_explicit_dispatcher_batch_size = kwargs
+            .and_then(|k| k.get_item("dispatcher_batch_size").ok().flatten())
+            .and_then(|v| v.extract::<u64>().ok())
+            .is_some()
+            || std::env::var("QUEBEC_DISPATCHER_BATCH_SIZE")
+                .ok()
+                .and_then(|s| s.parse::<u64>().ok())
+                .is_some();
+        let has_explicit_dispatcher_maintenance = kwargs
+            .and_then(|k| {
+                k.get_item("dispatcher_concurrency_maintenance_interval")
+                    .ok()
+                    .flatten()
+            })
+            .filter(|v| {
+                v.extract::<Duration>().is_ok()
+                    || v.extract::<u64>().is_ok()
+                    || v.extract::<f64>()
+                        .map(|f| f.is_finite() && f >= 0.0)
+                        .unwrap_or(false)
+            })
+            .is_some()
+            || std::env::var("QUEBEC_DISPATCHER_CONCURRENCY_MAINTENANCE_INTERVAL")
+                .ok()
+                .and_then(|s| parse_duration_f64_env(&s))
+                .is_some();
+
         let mut _ctx = AppContext::new(dsn.clone(), db_option, opt.clone(), options);
 
         if _ctx.worker_threads == 0 {
@@ -799,8 +844,7 @@ impl PyQuebec {
             if let Some(dispatchers) = config.dispatchers {
                 if let Some(dispatcher) = dispatchers.first() {
                     if let Some(polling_interval) = dispatcher.polling_interval {
-                        if _ctx.dispatcher_polling_interval == Duration::from_secs(1) {
-                            // default value
+                        if !has_explicit_dispatcher_polling {
                             if !polling_interval.is_finite() || polling_interval < 0.0 {
                                 return Err(pyo3::exceptions::PyValueError::new_err(
                                     format!("dispatcher_polling_interval must be finite and >= 0 (set via queue.yml dispatchers.polling_interval, got {polling_interval})"),
@@ -811,16 +855,12 @@ impl PyQuebec {
                         }
                     }
                     if let Some(batch_size) = dispatcher.batch_size {
-                        if _ctx.dispatcher_batch_size == 500 {
-                            // default value
+                        if !has_explicit_dispatcher_batch_size {
                             _ctx.dispatcher_batch_size = batch_size;
                         }
                     }
                     if let Some(interval) = dispatcher.concurrency_maintenance_interval {
-                        if _ctx.dispatcher_concurrency_maintenance_interval
-                            == Duration::from_secs(600)
-                        {
-                            // default value
+                        if !has_explicit_dispatcher_maintenance {
                             if !interval.is_finite() || interval < 0.0 {
                                 return Err(pyo3::exceptions::PyValueError::new_err(
                                     format!("dispatcher_concurrency_maintenance_interval must be finite and >= 0 (set via queue.yml dispatchers.concurrency_maintenance_interval, got {interval})"),
@@ -1779,6 +1819,25 @@ impl PyQuebec {
     #[pyo3(name = "_proc_slot")]
     fn proc_slot(&self) -> Option<(usize, usize)> {
         self.ctx.proc_slot
+    }
+
+    /// Test-only: the effective dispatcher config after code/env/queue.yml
+    /// precedence has been resolved at construction. Underscore-prefixed.
+    #[pyo3(name = "_dispatcher_config")]
+    fn dispatcher_config(&self, py: Python<'_>) -> PyResult<Py<PyDict>> {
+        let dict = PyDict::new(py);
+        dict.set_item(
+            "polling_interval",
+            self.ctx.dispatcher_polling_interval.as_secs_f64(),
+        )?;
+        dict.set_item("batch_size", self.ctx.dispatcher_batch_size)?;
+        dict.set_item(
+            "concurrency_maintenance_interval",
+            self.ctx
+                .dispatcher_concurrency_maintenance_interval
+                .as_secs_f64(),
+        )?;
+        Ok(dict.into())
     }
 
     /// Read `workers`/`dispatchers` from the loaded queue.yml and return a plan

--- a/src/types.rs
+++ b/src/types.rs
@@ -738,16 +738,10 @@ impl PyQuebec {
         // Same treatment for dispatcher fields: distinguish "user explicitly
         // set this via code/env" from "still at the default value" so a
         // queue.yml value can't silently override an explicit setting that
-        // happens to equal the default (e.g. dispatcher_polling_interval=1.0).
+        // happens to equal the default.
         let has_explicit_dispatcher_polling = kwargs
             .and_then(|k| k.get_item("dispatcher_polling_interval").ok().flatten())
-            .filter(|v| {
-                v.extract::<Duration>().is_ok()
-                    || v.extract::<u64>().is_ok()
-                    || v.extract::<f64>()
-                        .map(|f| f.is_finite() && f >= 0.0)
-                        .unwrap_or(false)
-            })
+            .filter(|v| v.extract::<Duration>().is_ok() || v.extract::<u64>().is_ok())
             .is_some()
             || std::env::var("QUEBEC_DISPATCHER_POLLING_INTERVAL")
                 .ok()
@@ -767,13 +761,7 @@ impl PyQuebec {
                     .ok()
                     .flatten()
             })
-            .filter(|v| {
-                v.extract::<Duration>().is_ok()
-                    || v.extract::<u64>().is_ok()
-                    || v.extract::<f64>()
-                        .map(|f| f.is_finite() && f >= 0.0)
-                        .unwrap_or(false)
-            })
+            .filter(|v| v.extract::<Duration>().is_ok() || v.extract::<u64>().is_ok())
             .is_some()
             || std::env::var("QUEBEC_DISPATCHER_CONCURRENCY_MAINTENANCE_INTERVAL")
                 .ok()

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -7,6 +7,8 @@ negative / non-finite / overflowing input). Mirrors the worker-path validation.
 
 from __future__ import annotations
 
+from datetime import timedelta
+
 import pytest
 
 import quebec
@@ -117,22 +119,26 @@ development:
   dispatchers:
     - polling_interval: 5.0
       batch_size: 100
+      concurrency_maintenance_interval: 30.0
 """,
         ),
     )
     monkeypatch.delenv("QUEBEC_ENV", raising=False)
 
-    # 1.0 / 500 are the defaults, passed explicitly. queue.yml sets 5.0 / 100.
+    # 1 second / 500 / 600 seconds are the defaults, passed explicitly using
+    # supported constructor types. queue.yml sets different values for all three.
     inst = quebec.Quebec(
         db_url,
         table_name_prefix=test_prefix,
-        dispatcher_polling_interval=1.0,
+        dispatcher_polling_interval=timedelta(seconds=1),
         dispatcher_batch_size=500,
+        dispatcher_concurrency_maintenance_interval=timedelta(seconds=600),
     )
     try:
         cfg = inst._dispatcher_config()
         assert cfg["polling_interval"] == 1.0
         assert cfg["batch_size"] == 500
+        assert cfg["concurrency_maintenance_interval"] == 600.0
     finally:
         inst.close()
 

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -79,3 +79,65 @@ development:
 
     inst = quebec.Quebec(db_url, table_name_prefix=test_prefix)
     inst.close()
+
+
+def test_dispatcher_explicit_default_not_overridden_by_yaml(
+    tmp_path, monkeypatch, db_url, test_prefix
+) -> None:
+    """An explicit code value equal to the default must not be overridden by
+    a different queue.yml value (the value-equality check couldn't tell an
+    explicit setting from an untouched default)."""
+    monkeypatch.setenv(
+        "QUEBEC_CONFIG",
+        _queue_yml(
+            tmp_path,
+            """
+development:
+  dispatchers:
+    - polling_interval: 5.0
+      batch_size: 100
+""",
+        ),
+    )
+    monkeypatch.delenv("QUEBEC_ENV", raising=False)
+
+    # 1.0 / 500 are the defaults, passed explicitly. queue.yml sets 5.0 / 100.
+    inst = quebec.Quebec(
+        db_url,
+        table_name_prefix=test_prefix,
+        dispatcher_polling_interval=1.0,
+        dispatcher_batch_size=500,
+    )
+    try:
+        cfg = inst._dispatcher_config()
+        assert cfg["polling_interval"] == 1.0
+        assert cfg["batch_size"] == 500
+    finally:
+        inst.close()
+
+
+def test_dispatcher_yaml_applies_when_not_explicit(
+    tmp_path, monkeypatch, db_url, test_prefix
+) -> None:
+    """With no code/env override, the queue.yml value takes effect."""
+    monkeypatch.setenv(
+        "QUEBEC_CONFIG",
+        _queue_yml(
+            tmp_path,
+            """
+development:
+  dispatchers:
+    - polling_interval: 5.0
+      batch_size: 100
+""",
+        ),
+    )
+    monkeypatch.delenv("QUEBEC_ENV", raising=False)
+
+    inst = quebec.Quebec(db_url, table_name_prefix=test_prefix)
+    try:
+        cfg = inst._dispatcher_config()
+        assert cfg["polling_interval"] == 5.0
+        assert cfg["batch_size"] == 100
+    finally:
+        inst.close()


### PR DESCRIPTION
## Problem

When applying dispatcher settings from `queue.yml`, the constructor decided
whether a value was "still the default" by comparing it to the literal default
(`dispatcher_polling_interval == 1s`, `batch_size == 500`, and
`concurrency_maintenance_interval == 600s`). That cannot distinguish "the user
explicitly set this to the default" from "untouched", so `queue.yml` could
silently override an explicit constructor or `QUEBEC_*` environment setting.

The worker constructor path already tracks whether its settings were supplied
explicitly; the dispatcher constructor path had not been migrated.

## Scope

This PR fixes constructor-time precedence using the input types currently
supported by the Python API: `datetime.timedelta` or integer seconds for
duration kwargs, integer batch sizes, and integer or decimal duration strings
from environment variables.

It intentionally does not add Python `float` support to Duration kwargs and
does not change the supervisor's per-process `apply_dispatcher_config()`
semantics. Duration parsing will be unified across all constructor options in a
follow-up PR; supervisor precedence can be addressed separately once its
per-entry override semantics are defined.

## Fix

- Compute `has_explicit_dispatcher_polling`,
  `has_explicit_dispatcher_batch_size`, and
  `has_explicit_dispatcher_maintenance` before `AppContext::new`.
- Validate kwargs with the same types that `AppContext` currently parses, while
  retaining decimal-second support for environment variables.
- Apply the first `queue.yml` dispatcher entry only when the corresponding
  value was not supplied explicitly.
- Add a test-only `_dispatcher_config()` accessor to observe the resolved
  constructor configuration.

## Test

`tests/test_config_validation.py` covers both directions:

- explicit default values supplied as `timedelta` / integer kwargs for polling
  interval, batch size, and concurrency-maintenance interval win over different
  `queue.yml` values;
- without a code or environment override, the `queue.yml` values apply.

Verification:

- `uv run pytest -q tests/test_config_validation.py` (6 passed)
- `uv run ruff check tests/test_config_validation.py`
- `cargo fmt --check`
- `git diff --check`
