### PR TITLE
fix: only strip reserved JobBuilder kwargs, pass through user _-kwargs

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -317,6 +317,18 @@ pub struct PyQuebec {
     control_plane_router: Arc<tokio::sync::Mutex<Option<axum::Router>>>,
 }
 
+/// Kwargs injected by `JobBuilder.set()` (queue / priority / scheduled_at
+/// overrides). They are consumed by the enqueue path and must be stripped from
+/// the job's serialized arguments and from any user `queue` callable. Only
+/// these exact keys are reserved — a user kwarg that merely starts with `_`
+/// (e.g. `_id`, `_type`, `_meta`) is a real argument and must pass through to
+/// `perform()`.
+const JOB_BUILDER_INTERNAL_KWARGS: [&str; 3] = ["_queue", "_priority", "_scheduled_at"];
+
+fn is_job_builder_internal_kwarg(key: &str) -> bool {
+    JOB_BUILDER_INTERNAL_KWARGS.contains(&key)
+}
+
 /// Resolve `wait` / `wait_until` options from a Python dict into an optional
 /// `NaiveDateTime`.  Returns `None` when neither key is present.
 fn resolve_scheduled_at(
@@ -2023,7 +2035,7 @@ impl PyQuebec {
                 if let Some(k) = kwargs {
                     for (key, value) in k.iter() {
                         if let Ok(key_str) = key.extract::<String>() {
-                            if !key_str.starts_with('_') {
+                            if !is_job_builder_internal_kwarg(&key_str) {
                                 filtered.set_item(key, value)?;
                             }
                         }
@@ -2103,7 +2115,7 @@ impl PyQuebec {
         if let Some(Value::Object(kwargs_map)) = &kwargs_json {
             let mut real_kwargs: serde_json::Map<String, Value> = kwargs_map
                 .iter()
-                .filter(|(key, _)| !key.starts_with('_'))
+                .filter(|(key, _)| !is_job_builder_internal_kwarg(key.as_str()))
                 .map(|(k, v)| (k.clone(), v.clone()))
                 .collect();
 
@@ -2344,7 +2356,7 @@ impl PyQuebec {
                     let filtered = PyDict::new(py);
                     for (key, value) in kwargs_bound.iter() {
                         if let Ok(key_str) = key.extract::<String>() {
-                            if !key_str.starts_with('_') {
+                            if !is_job_builder_internal_kwarg(&key_str) {
                                 filtered.set_item(key, value)?;
                             }
                         }
@@ -2402,7 +2414,7 @@ impl PyQuebec {
             if let Some(Value::Object(kwargs_map)) = &kwargs_json {
                 let mut real_kwargs: serde_json::Map<String, Value> = kwargs_map
                     .iter()
-                    .filter(|(key, _)| !key.starts_with('_'))
+                    .filter(|(key, _)| !is_job_builder_internal_kwarg(key.as_str()))
                     .map(|(k, v)| (k.clone(), v.clone()))
                     .collect();
                 if !real_kwargs.is_empty() {

--- a/tests/test_enqueue.py
+++ b/tests/test_enqueue.py
@@ -371,3 +371,49 @@ def test_register_job_raises_for_non_str_queue(qc_with_sqlalchemy) -> None:
 
     with pytest.raises(TypeError, match=r"NonStrQueueJob\.queue must be str, got int"):
         qc.register_job(NonStrQueueJob)
+
+
+def test_perform_later_passes_through_user_underscore_kwargs(
+    qc_with_sqlalchemy, db_assert
+) -> None:
+    """User kwargs that merely start with `_` (e.g. `_meta`, `_id`) are real
+    arguments and must reach perform() — only JobBuilder's reserved
+    `_queue`/`_priority`/`_scheduled_at` are stripped."""
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    qc.register_job(DefaultQueueJob)
+
+    enqueued = DefaultQueueJob.perform_later(qc, "alice", _meta="m", _id=7, normal="n")
+    persisted = get_job_by_active_job_id(session, prefix, enqueued.active_job_id)
+    payload = json.loads(persisted["arguments"])
+
+    kwargs_dict = payload["arguments"]["arguments"][1]
+    assert kwargs_dict["_meta"] == "m"
+    assert kwargs_dict["_id"] == 7
+    assert kwargs_dict["normal"] == "n"
+    assert kwargs_dict["_quebec_kwargs"] is True
+
+
+def test_perform_later_reserved_underscore_kwargs_still_stripped(
+    qc_with_sqlalchemy, db_assert
+) -> None:
+    """The reserved `_queue` override is still consumed and stripped from the
+    serialized kwargs (the fix narrows the filter, it doesn't remove it)."""
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    qc.register_job(DefaultQueueJob)
+
+    enqueued = DefaultQueueJob.perform_later(qc, "alice", _queue="override-q", keep="y")
+    persisted = get_job_by_active_job_id(session, prefix, enqueued.active_job_id)
+    payload = json.loads(persisted["arguments"])
+
+    # _queue was consumed as the queue override...
+    assert persisted["queue_name"] == "override-q"
+    kwargs_dict = payload["arguments"]["arguments"][1]
+    # ...and stripped from the arguments, while the real kwarg passes through.
+    assert "_queue" not in kwargs_dict
+    assert kwargs_dict["keep"] == "y"


### PR DESCRIPTION
## Problem

To strip the internal kwargs `JobBuilder.set()` injects (`_queue`,
`_priority`, `_scheduled_at`), the enqueue path filtered out **every** kwarg
whose key starts with `_`. So a user's legitimate `_id`, `_type`, `_meta`, etc.
were silently dropped — never serialized into the job arguments, never reaching
`perform()`, with no warning. This applied to both the single (`perform_later`)
and bulk (`perform_all_later`) paths, in the serialized-args filter and the
user `queue` callable filter.

## Fix

Strip only the three reserved keys (`JOB_BUILDER_INTERNAL_KWARGS`) via a small
`is_job_builder_internal_kwarg` helper, replacing the four blanket
`starts_with('_')` filters. Any other `_`-prefixed kwarg is a real argument and
passes through. A user kwarg that literally collides with a reserved name is
still consumed as the override — unchanged behavior.

## Test

`tests/test_enqueue.py`:
- `_meta` / `_id` alongside a normal kwarg → all present in the serialized
  arguments (fails pre-fix, where they were dropped);
- `_queue="override-q"` → still consumed as the queue override and stripped
  from the serialized kwargs (guards the narrowed filter still strips reserved
  keys).

`cargo clippy` / `cargo fmt --check` clean; `ruff` clean; full
`test_enqueue.py` + `test_bulk_enqueue_hooks.py` (17) pass.
