### PR TITLE
fix: avoid panic in control-plane redirect on invalid header value

### DIFF
--- a/src/control_plane/utils.rs
+++ b/src/control_plane/utils.rs
@@ -268,13 +268,24 @@ impl ControlPlane {
             .expect("static response builder is infallible")
     }
 
-    /// Redirect back to the given URL with 303 See Other
+    /// Redirect back to the given URL with 303 See Other.
+    ///
+    /// `url` is often built from a percent-decoded `:name` path segment, which
+    /// can contain control characters (e.g. `%0D` decodes to a carriage return)
+    /// that are illegal in an HTTP header value. Building the response then
+    /// fails, so fall back to a 400 instead of panicking the handler task (a
+    /// cheap remote-triggerable DoS otherwise).
     pub fn redirect_back(url: &str) -> Response {
         Response::builder()
             .status(StatusCode::SEE_OTHER)
             .header(header::LOCATION, url)
             .body(axum::body::Body::empty())
-            .expect("static response builder is infallible")
+            .unwrap_or_else(|_| {
+                Response::builder()
+                    .status(StatusCode::BAD_REQUEST)
+                    .body(axum::body::Body::empty())
+                    .expect("static 400 response builder is infallible")
+            })
     }
 
     /// Get pagination parameters


### PR DESCRIPTION
## Problem

`redirect_back(url)` built a 303 with `Location: url` and `.expect(...)`-ed the
result as "infallible". But `url` is often assembled from a percent-decoded
`:name` path segment (e.g. `POST /queues/a%0Db/pause` → `a\rb`). A control
character is illegal in a header value, so the response builder returns `Err`,
`.expect()` panics, and the handler task aborts (connection reset; propagated to
the Python caller via the ASGI bridge). A cheap, remote-triggerable DoS.

## Fix

On builder error, fall back to a 400 Bad Request (static status + empty body,
genuinely infallible) instead of panicking.

## Test

No automated test: this crate can't run `cargo test` (cdylib + libpython) and
there's no control-plane HTTP harness in the pytest suite. Verified by `cargo
clippy` (clean) and by construction — the fallback response has a static status
and empty body so it cannot fail.
