### PR TITLE
fix: honor dispatcher concurrency_maintenance config flag

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -391,6 +391,9 @@ pub struct AppContext {
     pub dispatcher_polling_interval: Duration,
     pub dispatcher_batch_size: u64,
     pub dispatcher_concurrency_maintenance_interval: Duration,
+    /// Whether the dispatcher runs concurrency maintenance (expiring stale
+    /// semaphores + unblocking blocked jobs) each polling cycle. Default true.
+    pub dispatcher_concurrency_maintenance: bool,
     pub worker_polling_interval: Duration,
     pub worker_threads: u64,
     /// Optional worker RSS soft limit. When set, a worker that stays above the
@@ -1049,6 +1052,7 @@ impl AppContext {
             dispatcher_polling_interval: Duration::from_secs(1), // 1 seconds
             dispatcher_batch_size: 500,
             dispatcher_concurrency_maintenance_interval: Duration::from_secs(600),
+            dispatcher_concurrency_maintenance: true,
             worker_polling_interval: Duration::from_millis(100),
             worker_threads: 3,
             worker_max_rss_bytes: None,
@@ -1231,6 +1235,7 @@ impl AppContext {
             dispatcher_batch_size: self.dispatcher_batch_size,
             dispatcher_concurrency_maintenance_interval: self
                 .dispatcher_concurrency_maintenance_interval,
+            dispatcher_concurrency_maintenance: self.dispatcher_concurrency_maintenance,
             worker_polling_interval: self.worker_polling_interval,
             worker_threads: self.worker_threads,
             worker_max_rss_bytes: self.worker_max_rss_bytes,

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -79,33 +79,39 @@ impl Dispatcher {
                     }) else { continue };
                     let ctx = self.ctx.clone(); // Clone ctx for the async closure
 
-                    // Clean up expired semaphores (matches Solid Queue's
-                    // `expire_semaphores`). Solid Queue runs expire + unblock in a
-                    // single maintenance task, so a failed expire aborts the task
-                    // before unblock runs — mirror that by skipping unblock when
-                    // expire fails. Scheduled dispatch is a separate concern (its
-                    // own task in Solid Queue) and still runs.
-                    let expire_ok =
-                        match query_builder::semaphores::delete_expired(&*polling_db, &ctx.table_config).await {
-                            Ok(n) => {
-                                if n > 0 {
-                                    info!("Cleaned up {} expired semaphores", n);
+                    // Concurrency maintenance: expire stale semaphores + unblock
+                    // blocked jobs. Skipped when the operator sets
+                    // `concurrency_maintenance: false`. Scheduled dispatch below is
+                    // a separate concern (its own task in Solid Queue) and always
+                    // runs regardless of this flag.
+                    if ctx.dispatcher_concurrency_maintenance {
+                        // Clean up expired semaphores (matches Solid Queue's
+                        // `expire_semaphores`). Solid Queue runs expire + unblock in
+                        // a single maintenance task, so a failed expire aborts the
+                        // task before unblock runs — mirror that by skipping unblock
+                        // when expire fails.
+                        let expire_ok =
+                            match query_builder::semaphores::delete_expired(&*polling_db, &ctx.table_config).await {
+                                Ok(n) => {
+                                    if n > 0 {
+                                        info!("Cleaned up {} expired semaphores", n);
+                                    }
+                                    true
                                 }
-                                true
-                            }
-                            Err(e) => {
-                                warn!("Error cleaning up expired semaphores: {:?}", e);
-                                false
-                            }
-                        };
+                                Err(e) => {
+                                    warn!("Error cleaning up expired semaphores: {:?}", e);
+                                    false
+                                }
+                            };
 
-                    // Unblock jobs with expired concurrency keys — one transaction
-                    // per key, matching Solid Queue's `BlockedExecution.unblock`.
-                    if expire_ok {
-                        if let Err(e) =
-                            Self::unblock_blocked_executions(&polling_db, &ctx, batch_size).await
-                        {
-                            warn!("Error unblocking blocked executions: {:?}", e);
+                        // Unblock jobs with expired concurrency keys — one transaction
+                        // per key, matching Solid Queue's `BlockedExecution.unblock`.
+                        if expire_ok {
+                            if let Err(e) =
+                                Self::unblock_blocked_executions(&polling_db, &ctx, batch_size).await
+                            {
+                                warn!("Error unblocking blocked executions: {:?}", e);
+                            }
                         }
                     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -170,6 +170,9 @@ fn apply_dispatcher_cfg_to(
         }
         ctx.dispatcher_concurrency_maintenance_interval = Duration::from_secs_f64(interval);
     }
+    if let Some(enabled) = dispatcher_cfg.concurrency_maintenance {
+        ctx.dispatcher_concurrency_maintenance = enabled;
+    }
     Ok(())
 }
 
@@ -819,6 +822,9 @@ impl PyQuebec {
                             _ctx.dispatcher_concurrency_maintenance_interval =
                                 Duration::from_secs_f64(interval);
                         }
+                    }
+                    if let Some(enabled) = dispatcher.concurrency_maintenance {
+                        _ctx.dispatcher_concurrency_maintenance = enabled;
                     }
                 }
             }
@@ -1769,6 +1775,13 @@ impl PyQuebec {
     #[pyo3(name = "_proc_slot")]
     fn proc_slot(&self) -> Option<(usize, usize)> {
         self.ctx.proc_slot
+    }
+
+    /// Test-only: the resolved dispatcher concurrency-maintenance flag after
+    /// queue.yml is applied. Underscore-prefixed.
+    #[pyo3(name = "_dispatcher_concurrency_maintenance")]
+    fn dispatcher_concurrency_maintenance(&self) -> bool {
+        self.ctx.dispatcher_concurrency_maintenance
     }
 
     /// Read `workers`/`dispatchers` from the loaded queue.yml and return a plan

--- a/tests/test_dispatcher_concurrency_maintenance.py
+++ b/tests/test_dispatcher_concurrency_maintenance.py
@@ -1,0 +1,46 @@
+"""queue.yml `concurrency_maintenance: false` disables the dispatcher's
+concurrency-maintenance sweep (previously parsed but never read)."""
+
+from __future__ import annotations
+
+import quebec
+
+
+def _queue_yml(tmp_path, body: str) -> str:
+    path = tmp_path / "queue.yml"
+    path.write_text(body)
+    return str(path)
+
+
+def test_concurrency_maintenance_defaults_true(
+    tmp_path, monkeypatch, db_url, test_prefix
+) -> None:
+    monkeypatch.delenv("QUEBEC_CONFIG", raising=False)
+    monkeypatch.delenv("QUEBEC_ENV", raising=False)
+    inst = quebec.Quebec(db_url, table_name_prefix=test_prefix)
+    try:
+        assert inst._dispatcher_concurrency_maintenance() is True
+    finally:
+        inst.close()
+
+
+def test_concurrency_maintenance_false_is_honored(
+    tmp_path, monkeypatch, db_url, test_prefix
+) -> None:
+    monkeypatch.setenv(
+        "QUEBEC_CONFIG",
+        _queue_yml(
+            tmp_path,
+            """
+development:
+  dispatchers:
+    - concurrency_maintenance: false
+""",
+        ),
+    )
+    monkeypatch.delenv("QUEBEC_ENV", raising=False)
+    inst = quebec.Quebec(db_url, table_name_prefix=test_prefix)
+    try:
+        assert inst._dispatcher_concurrency_maintenance() is False
+    finally:
+        inst.close()


### PR DESCRIPTION
## Problem

`DispatcherConfig.concurrency_maintenance` (a `queue.yml` boolean) was parsed
and had a getter, but nothing ever read it — the dispatcher and `AppContext`
ignored it entirely. An operator who set `concurrency_maintenance: false` to
disable the dispatcher's concurrency-maintenance sweep got no effect and no
warning.

## Fix

Wire the flag through:
- new `AppContext.dispatcher_concurrency_maintenance` (default `true`, carried
  across fork);
- read the `queue.yml` value in both the constructor path and
  `apply_dispatcher_cfg_to` (supervisor child dispatchers);
- gate the dispatcher's expire-semaphores + unblock-blocked sweep on it.
  Scheduled dispatch is a separate concern and always runs.

Only the `queue.yml` field is wired (no kwarg/env), so there's no code-vs-yaml
precedence ambiguity. Default `true` preserves current behavior.

## Test

`tests/test_dispatcher_concurrency_maintenance.py` (via a test-only
`_dispatcher_concurrency_maintenance()` accessor): default → `true`;
`concurrency_maintenance: false` in `queue.yml` → `false` (fails pre-fix, where
the flag was never read). `cargo clippy` / `ruff` clean; 33 concurrency tests
pass.
