### PR TITLE
fix: run concurrency maintenance on its own interval instead of every poll

### DIFF
--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -44,6 +44,16 @@ impl Dispatcher {
             != 0;
         let mut parent_check_interval = tokio::time::interval(std::time::Duration::from_secs(1));
         let batch_size = self.ctx.dispatcher_batch_size;
+        // Concurrency maintenance runs on its own cadence (Solid Queue's
+        // ConcurrencyMaintenance timer, default 600s), separate from polling.
+        // Clamp to >= 1s: a zero period would panic tokio's interval (same
+        // guard as the worker's cleanup_interval).
+        let maintenance_enabled = self.ctx.dispatcher_concurrency_maintenance;
+        let mut maintenance_interval = tokio::time::interval(
+            self.ctx
+                .dispatcher_concurrency_maintenance_interval
+                .max(std::time::Duration::from_secs(1)),
+        );
 
         let init_db = self.ctx.get_db().await?;
         let process = self.on_start(&init_db).await?;
@@ -73,47 +83,54 @@ impl Dispatcher {
                     self.on_stop(&stop_db, &process).await?;
                     return Ok(());
                 }
+                // Concurrency maintenance: expire stale semaphores + unblock
+                // blocked jobs. Runs every `concurrency_maintenance_interval`
+                // (Solid Queue parity — its ConcurrencyMaintenance TimerTask,
+                // `run_now: true`, which tokio's immediate first tick matches),
+                // not every polling tick. The completion path releases the
+                // semaphore and unblocks the next job directly (after_executed),
+                // so this sweep only reclaims semaphores whose holder crashed.
+                // Skipped entirely when `concurrency_maintenance: false`.
+                _ = maintenance_interval.tick(), if maintenance_enabled => {
+                    let Ok(maintenance_db) = self.ctx.get_db().await.inspect_err(|e| {
+                        warn!("Failed to get DB for concurrency maintenance: {}", e);
+                    }) else { continue };
+                    let ctx = self.ctx.clone();
+
+                    // Clean up expired semaphores (matches Solid Queue's
+                    // `expire_semaphores`). Solid Queue runs expire + unblock in
+                    // a single maintenance task, so a failed expire aborts the
+                    // task before unblock runs — mirror that by skipping unblock
+                    // when expire fails.
+                    let expire_ok =
+                        match query_builder::semaphores::delete_expired(&*maintenance_db, &ctx.table_config).await {
+                            Ok(n) => {
+                                if n > 0 {
+                                    info!("Cleaned up {} expired semaphores", n);
+                                }
+                                true
+                            }
+                            Err(e) => {
+                                warn!("Error cleaning up expired semaphores: {:?}", e);
+                                false
+                            }
+                        };
+
+                    // Unblock jobs with expired concurrency keys — one transaction
+                    // per key, matching Solid Queue's `BlockedExecution.unblock`.
+                    if expire_ok {
+                        if let Err(e) =
+                            Self::unblock_blocked_executions(&maintenance_db, &ctx, batch_size).await
+                        {
+                            warn!("Error unblocking blocked executions: {:?}", e);
+                        }
+                    }
+                }
                 _ = polling_interval.tick() => {
                     let Ok(polling_db) = self.ctx.get_db().await.inspect_err(|e| {
                         warn!("Failed to get DB for polling: {}", e);
                     }) else { continue };
                     let ctx = self.ctx.clone(); // Clone ctx for the async closure
-
-                    // Concurrency maintenance: expire stale semaphores + unblock
-                    // blocked jobs. Skipped when the operator sets
-                    // `concurrency_maintenance: false`. Scheduled dispatch below is
-                    // a separate concern (its own task in Solid Queue) and always
-                    // runs regardless of this flag.
-                    if ctx.dispatcher_concurrency_maintenance {
-                        // Clean up expired semaphores (matches Solid Queue's
-                        // `expire_semaphores`). Solid Queue runs expire + unblock in
-                        // a single maintenance task, so a failed expire aborts the
-                        // task before unblock runs — mirror that by skipping unblock
-                        // when expire fails.
-                        let expire_ok =
-                            match query_builder::semaphores::delete_expired(&*polling_db, &ctx.table_config).await {
-                                Ok(n) => {
-                                    if n > 0 {
-                                        info!("Cleaned up {} expired semaphores", n);
-                                    }
-                                    true
-                                }
-                                Err(e) => {
-                                    warn!("Error cleaning up expired semaphores: {:?}", e);
-                                    false
-                                }
-                            };
-
-                        // Unblock jobs with expired concurrency keys — one transaction
-                        // per key, matching Solid Queue's `BlockedExecution.unblock`.
-                        if expire_ok {
-                            if let Err(e) =
-                                Self::unblock_blocked_executions(&polling_db, &ctx, batch_size).await
-                            {
-                                warn!("Error unblocking blocked executions: {:?}", e);
-                            }
-                        }
-                    }
 
                     // Dispatch scheduled jobs in their own transaction.
                     let transaction_result = polling_db.transaction::<_, std::collections::HashSet<String>, DbErr>(|txn| {

--- a/tests/test_dispatcher_concurrency_maintenance.py
+++ b/tests/test_dispatcher_concurrency_maintenance.py
@@ -1,9 +1,26 @@
 """queue.yml `concurrency_maintenance: false` disables the dispatcher's
-concurrency-maintenance sweep (previously parsed but never read)."""
+concurrency-maintenance sweep (previously parsed but never read), and the
+sweep itself runs on `concurrency_maintenance_interval`, not every poll."""
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+
 import quebec
+from sqlalchemy import text
+
+from .helpers import wait_until
+
+
+class SweepConcurrentJob(quebec.BaseClass):
+    concurrency_limit = 1
+
+    @staticmethod
+    def concurrency_key(*args, **kwargs) -> str:
+        return "sweep-resource"
+
+    def perform(self) -> None:
+        pass
 
 
 def _queue_yml(tmp_path, body: str) -> str:
@@ -44,3 +61,46 @@ development:
         assert inst._dispatcher_concurrency_maintenance() is False
     finally:
         inst.close()
+
+
+def test_maintenance_sweep_reclaims_crashed_holder(
+    qc_with_sqlalchemy, db_assert
+) -> None:
+    """The maintenance sweep deletes expired semaphores and promotes expired
+    blocked executions — the crash-recovery fallback (the normal completion
+    path unblocks directly in ``after_executed``). The sweep's first tick
+    fires immediately on dispatcher start (Solid Queue ``run_now: true``
+    parity), so this must succeed well before the 600s default interval."""
+    qc = qc_with_sqlalchemy["qc"]
+    session = qc_with_sqlalchemy["session"]
+    prefix = qc_with_sqlalchemy["prefix"]
+
+    qc.register_job(SweepConcurrentJob)
+
+    # A holds the semaphore (ready), B is blocked on the same key.
+    SweepConcurrentJob.perform_later(qc)
+    SweepConcurrentJob.perform_later(qc)
+    assert db_assert.count_ready_executions() == 1
+    assert db_assert.count_blocked_executions() == 1
+
+    # Simulate a crashed holder: A's ready row is gone and both the semaphore
+    # and B's blocked row have passed their TTL.
+    past = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(seconds=60)
+    session.execute(text(f"DELETE FROM {prefix}_ready_executions"))
+    session.execute(
+        text(f"UPDATE {prefix}_semaphores SET expires_at = :past"), {"past": past}
+    )
+    session.execute(
+        text(f"UPDATE {prefix}_blocked_executions SET expires_at = :past"),
+        {"past": past},
+    )
+    session.commit()
+
+    qc.spawn_dispatcher()
+    wait_until(
+        lambda: (session.expire_all() or True)
+        and db_assert.count_blocked_executions() == 0
+        and db_assert.count_ready_executions() == 1,
+        timeout=5,
+        message="maintenance sweep did not reclaim the crashed holder",
+    )


### PR DESCRIPTION
## Problem

Follow-up to #124. `dispatchers.concurrency_maintenance_interval` (default 600s)
was parsed, stored in `AppContext`, and carried across fork — but nothing ever
read it. The dispatcher ran the expire-semaphores + unblock-blocked sweep on
every polling tick (default 1s) instead. Same class of dead config as the
boolean fixed in #124, plus a cadence divergence from Solid Queue, whose
`ConcurrencyMaintenance` runs as a separate timer at
`concurrency_maintenance_interval`.

## Fix

Move the sweep out of the polling branch into its own `tokio::select!` branch
driven by `concurrency_maintenance_interval`:

- first tick fires immediately, matching Solid Queue's `run_now: true`;
- the `concurrency_maintenance` flag from #124 becomes the branch guard;
- interval clamped to >= 1s (a zero period panics tokio's `interval`; same
  guard as the worker's `cleanup_interval`);
- expire-fails-skips-unblock semantics unchanged; scheduled dispatch stays on
  `polling_interval`.

## Why the cadence change is safe

The completion path (`after_executed`) releases the semaphore and promotes the
next blocked job directly in the same transaction — mirroring Solid Queue's
`unblock_next_blocked_job` ensure block. The dispatcher sweep is only the
crash-recovery fallback for semaphores whose holder died, which is exactly the
role (and cadence) it has in Solid Queue. Normal unblock latency is unaffected.
No test relied on the per-poll sweep: the two dispatcher-spawning tests exercise
scheduled dispatch, which is untouched.

## Test

New `test_maintenance_sweep_reclaims_crashed_holder`: a crashed holder
(deleted ready row, expired semaphore + blocked row) is reclaimed by the sweep
right after dispatcher start via the immediate first tick. Full concurrency
suites (45 tests) pass; `cargo clippy` / `cargo fmt --check` / `ruff` clean.
