### PR TITLE
fix: pin worker consumption to QUEBEC_FORCE_OVERRIDE_QUEUE

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Set `QUEBEC_FORCE_OVERRIDE_QUEUE` to pin every enqueue and consumption to one qu
 QUEBEC_FORCE_OVERRIDE_QUEUE=branch_x python -m quebec your.jobs
 ```
 
-Every enqueue path rewrites `queue_name` to this value (ignoring whatever the class, call site, or scheduler specified), and the worker only consumes that queue — so jobs enqueued by one branch are never picked up by another. URL-hostile characters in the name are sanitized to `-`.
+Every enqueue path rewrites `queue_name` to this value (ignoring whatever the class, call site, or scheduler specified), and the worker only consumes that queue — so jobs enqueued by one branch are never picked up by another. URL-hostile characters and `*` in the name are sanitized to `-` (a literal `*` would otherwise be reinterpreted as a wildcard by the consuming worker).
 
 ### Transactional Enqueue
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -335,7 +335,10 @@ pub(crate) fn sanitize_queue_name(raw: &str) -> (String, bool) {
     let cleaned: String = raw
         .chars()
         .map(|c| match c {
-            '/' | '\\' | '?' | '#' | '%' => '-',
+            // '*' would be enqueued literally but reinterpreted as a
+            // wildcard prefix by the worker's queue selector, silently
+            // widening the pinned worker to other queues.
+            '/' | '\\' | '?' | '#' | '%' | '*' => '-',
             c if c.is_whitespace() || c.is_control() => '-',
             c => c,
         })

--- a/src/context.rs
+++ b/src/context.rs
@@ -652,6 +652,18 @@ pub struct RunnableDefaults {
 }
 
 impl AppContext {
+    /// Queue selector the worker actually claims from. When
+    /// `force_override_queue` is active it wins unconditionally over any
+    /// `worker_queues` config: every enqueue is rewritten to that queue, so
+    /// consuming anything else would break the branch isolation the override
+    /// exists for.
+    pub fn effective_worker_queues(&self) -> Option<crate::config::QueueSelector> {
+        self.force_override_queue
+            .as_ref()
+            .map(|q| crate::config::QueueSelector::Single(q.clone()))
+            .or_else(|| self.worker_queues.clone())
+    }
+
     /// Record `id` in the claim ledger with the given state. Poison-recovering;
     /// never held across an await.
     pub fn ledger_set(&self, id: i64, state: ClaimState) {

--- a/src/types.rs
+++ b/src/types.rs
@@ -788,7 +788,11 @@ impl PyQuebec {
                     if worker.queues.is_some() {
                         _ctx.worker_queues = worker.queues.clone();
                     }
-                    if let Some(ref queues) = _ctx.worker_queues {
+                    // Log the effective selector so the override's consumption
+                    // pin is visible — raw worker_queues would claim "all
+                    // queues" while the worker actually only drains the
+                    // forced queue.
+                    if let Some(queues) = _ctx.effective_worker_queues() {
                         info!("Worker queues configured: {:?}", queues.to_list());
                     } else {
                         info!("Worker queues: None (will process all queues)");
@@ -844,8 +848,9 @@ impl PyQuebec {
             warn!(
                 "QUEBEC_FORCE_OVERRIDE_QUEUE is active: every enqueue will be \
                  rewritten to queue '{}', ignoring class queue config and any \
-                 `.set(queue=...)` call. Intended for dev isolation; do not \
-                 leave this set in production.",
+                 `.set(queue=...)` call, and the worker will only consume that \
+                 queue. Intended for dev isolation; do not leave this set in \
+                 production.",
                 override_q
             );
         }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -2739,7 +2739,7 @@ impl Worker {
     pub async fn claim_job(&self) -> Result<quebec_claimed_executions::Model> {
         let db = self.ctx.get_db().await?;
         let table_config = self.ctx.table_config.clone();
-        let queue_selector = self.ctx.worker_queues.clone();
+        let queue_selector = self.ctx.effective_worker_queues();
         let use_skip_locked = self.ctx.use_skip_locked;
         let process_id = *self.process_id.lock().await;
         // EXPERIMENTAL: queue-level concurrency overrides — acquired here at
@@ -2913,7 +2913,7 @@ impl Worker {
         let db = self.ctx.get_db().await?;
         let use_skip_locked = self.ctx.use_skip_locked;
         let table_config = self.ctx.table_config.clone();
-        let queue_selector = self.ctx.worker_queues.clone();
+        let queue_selector = self.ctx.effective_worker_queues();
         let process_id = *self.process_id.lock().await;
         // EXPERIMENTAL: shared `ctx` for per-record queue-level acquire below.
         let ctx = self.ctx.clone();
@@ -3289,6 +3289,12 @@ impl Worker {
         };
 
         trace!("Received NOTIFY for queue: {}", queue_name);
+
+        // Hot path (once per NOTIFY): check the override by reference instead
+        // of cloning the effective selector for every message.
+        if let Some(forced) = self.ctx.force_override_queue.as_deref() {
+            return queue_name == forced;
+        }
 
         let Some(ref queues) = self.ctx.worker_queues else {
             return true; // No queue config, process all queues

--- a/tests/test_force_override_queue.py
+++ b/tests/test_force_override_queue.py
@@ -1,0 +1,72 @@
+"""QUEBEC_FORCE_OVERRIDE_QUEUE pins both enqueue and consumption.
+
+README promises the override rewrites every enqueue to the forced queue AND
+that the worker only consumes that queue, so branches sharing one database
+never pick up each other's jobs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import quebec
+
+
+class OverrideJob(quebec.BaseClass):
+    def perform(self, *args, **kwargs) -> None:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _no_env_override(monkeypatch):
+    # A developer using the feature may have the env var exported; these
+    # tests control the override via kwargs only.
+    monkeypatch.delenv("QUEBEC_FORCE_OVERRIDE_QUEUE", raising=False)
+
+
+def test_enqueue_is_rewritten_to_forced_queue(temp_db_path, test_prefix) -> None:
+    qc = quebec.Quebec(
+        f"sqlite:///{temp_db_path}?mode=rwc",
+        table_name_prefix=test_prefix,
+        force_override_queue="pinned",
+    )
+    assert qc.create_tables() is True
+    qc.register_job(OverrideJob)
+
+    job = OverrideJob.set(queue="elsewhere").perform_later(qc)
+    assert job.queue_name == "pinned"
+
+    qc.close()
+
+
+def test_worker_only_consumes_forced_queue(temp_db_path, test_prefix) -> None:
+    dsn = f"sqlite:///{temp_db_path}?mode=rwc"
+
+    # Another branch (no override) enqueues into its own queue.
+    plain = quebec.Quebec(dsn, table_name_prefix=test_prefix)
+    assert plain.create_tables() is True
+    plain.register_job(OverrideJob)
+    OverrideJob.set(queue="other_branch").perform_later(plain)
+
+    # This branch runs with the override active.
+    pinned = quebec.Quebec(
+        dsn, table_name_prefix=test_prefix, force_override_queue="pinned"
+    )
+    pinned.register_job(OverrideJob)
+    OverrideJob.perform_later(pinned)
+
+    execution = pinned.drain_one()
+    assert execution.queue == "pinned"
+    execution.perform()
+
+    # The other branch's job must not be claimable by the pinned worker.
+    with pytest.raises(RuntimeError):
+        pinned.drain_one()
+
+    # The plain worker still sees it.
+    execution = plain.drain_one()
+    assert execution.queue == "other_branch"
+    execution.perform()
+
+    pinned.close()
+    plain.close()

--- a/tests/test_force_override_queue.py
+++ b/tests/test_force_override_queue.py
@@ -39,6 +39,26 @@ def test_enqueue_is_rewritten_to_forced_queue(temp_db_path, test_prefix) -> None
     qc.close()
 
 
+def test_wildcard_chars_are_sanitized_from_forced_queue(
+    temp_db_path, test_prefix
+) -> None:
+    # A '*' in the forced name would be enqueued literally but reinterpreted
+    # as a wildcard prefix on the consumption side, silently widening the
+    # pinned worker to other branches' queues.
+    qc = quebec.Quebec(
+        f"sqlite:///{temp_db_path}?mode=rwc",
+        table_name_prefix=test_prefix,
+        force_override_queue="branch*",
+    )
+    assert qc.create_tables() is True
+    qc.register_job(OverrideJob)
+
+    job = OverrideJob.perform_later(qc)
+    assert job.queue_name == "branch-"
+
+    qc.close()
+
+
 def test_worker_only_consumes_forced_queue(temp_db_path, test_prefix) -> None:
     dsn = f"sqlite:///{temp_db_path}?mode=rwc"
 


### PR DESCRIPTION
## Problem

README promises `QUEBEC_FORCE_OVERRIDE_QUEUE` pins **both** enqueue and consumption to the forced queue, but only the enqueue rewrite was implemented. `worker_queues` was never pinned, so with the default config (all queues) an override worker still claimed jobs from every queue — observed in practice as a branch worker executing another branch's jobs.

## Fix

- `AppContext::effective_worker_queues()`: when the override is active it unconditionally returns `QueueSelector::Single(forced)`, otherwise falls back to the `worker_queues` config. Used by `claim_job`, `claim_jobs`, and the NOTIFY filter (the latter checks the override by reference to avoid cloning per message).
- Sanitize `*` out of the forced queue name: a literal `*` was enqueued as-is but reinterpreted as a wildcard prefix by the consuming selector, which would silently widen the pinned worker to other queues.
- Startup log now reports the effective selector instead of claiming "will process all queues" while the override is active.

## Tests

New `tests/test_force_override_queue.py`: enqueue rewrite, `*` sanitization, and a two-instance shared-DB test proving the pinned worker cannot claim another branch's job (failed before the fix). Full suite: 268 passed; clippy/fmt clean.