### PR TITLE
fix: unify duration kwarg parsing and dispatcher config precedence

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -581,6 +581,23 @@ pub(crate) fn parse_duration_f64_env(s: &str) -> Option<Duration> {
         .or_else(|| s.parse::<u64>().ok().map(Duration::from_secs))
 }
 
+/// Parse a Python duration option from `datetime.timedelta`, integer seconds,
+/// or floating-point seconds. Invalid, negative, non-finite, and overflowing
+/// values return `None` so the caller can consistently warn and fall back.
+#[cfg(feature = "python")]
+pub(crate) fn parse_py_duration(value: &Bound<'_, PyAny>) -> Option<Duration> {
+    value
+        .extract::<Duration>()
+        .ok()
+        .or_else(|| value.extract::<u64>().ok().map(Duration::from_secs))
+        .or_else(|| {
+            value
+                .extract::<f64>()
+                .ok()
+                .and_then(|seconds| Duration::try_from_secs_f64(seconds).ok())
+        })
+}
+
 /// Build the `<basename>@<sha>` suffix appended to `set_proc_title`. Pure
 /// function (path + revision in, string out) so it can be reasoned about
 /// without spinning up an `AppContext`. Either component is dropped when
@@ -796,21 +813,28 @@ impl AppContext {
                         })
                     })
             };
+            let parse_duration_option = |key: &str, value: &Py<PyAny>| -> Option<Duration> {
+                let value = value.bind(py);
+                parse_py_duration(value).or_else(|| {
+                    if let Ok(seconds) = value.extract::<f64>() {
+                        warn!(
+                            "Config '{}': seconds must be finite, non-negative, and within Duration range, got {:?}",
+                            key, seconds
+                        );
+                    } else {
+                        warn!(
+                            "Config '{}': expected timedelta or numeric seconds, got {:?}",
+                            key,
+                            value.get_type()
+                        );
+                    }
+                    None
+                })
+            };
             let get_duration = |key: &str| -> Option<Duration> {
                 options
                     .get(key)
-                    .and_then(|v| {
-                        v.extract::<Duration>(py)
-                            .or_else(|_| v.extract::<u64>(py).map(Duration::from_secs))
-                            .map_err(|_| {
-                                warn!(
-                                    "Config '{}': expected Duration or u64, got {:?}",
-                                    key,
-                                    v.bind(py).get_type()
-                                );
-                            })
-                            .ok()
-                    })
+                    .and_then(|v| parse_duration_option(key, v))
                     .or_else(|| {
                         let s = env_var(key)?;
                         parse_duration_f64_env(&s).or_else(|| {
@@ -875,36 +899,20 @@ impl AppContext {
             if let Some(v) = get_duration("control_plane_sse_interval") {
                 ctx.control_plane_sse_interval = v;
             }
-            // worker_polling_interval: also accepts f64 for sub-second precision
-            if let Some(val) = options.get("worker_polling_interval") {
-                let result = val
-                    .extract::<Duration>(py)
-                    .or_else(|_| val.extract::<u64>(py).map(Duration::from_secs))
-                    .or_else(|_| {
-                        val.extract::<f64>(py).and_then(|f| {
-                            if f.is_finite() && f >= 0.0 {
-                                Ok(Duration::from_secs_f64(f))
-                            } else {
-                                warn!("Config 'worker_polling_interval': invalid f64 value {}", f);
-                                Err(pyo3::PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                                    "invalid",
-                                ))
-                            }
-                        })
-                    });
-                match result {
-                    Ok(v) => ctx.worker_polling_interval = v,
-                    Err(_) => warn!(
-                        "Config 'worker_polling_interval': expected Duration, u64 or f64, got {:?}",
-                        val.bind(py).get_type()
-                    ),
+            // Preserve the historical worker precedence: an invalid kwarg is
+            // warned about and ignored, but must not expose a lower-priority
+            // environment value. Other Duration options retain their existing
+            // invalid-kwarg -> env fallback behavior through `get_duration`.
+            if let Some(value) = options.get("worker_polling_interval") {
+                if let Some(v) = parse_duration_option("worker_polling_interval", value) {
+                    ctx.worker_polling_interval = v;
                 }
-            } else if let Some(s) = env_var("worker_polling_interval") {
-                match parse_duration_f64_env(&s) {
+            } else if let Some(raw) = env_var("worker_polling_interval") {
+                match parse_duration_f64_env(&raw) {
                     Some(v) => ctx.worker_polling_interval = v,
                     None => warn!(
                         "Env 'QUEBEC_WORKER_POLLING_INTERVAL': failed to parse '{}' as duration",
-                        s
+                        raw
                     ),
                 }
             }

--- a/src/context.rs
+++ b/src/context.rs
@@ -394,6 +394,9 @@ pub struct AppContext {
     pub dispatcher_polling_interval: Duration,
     pub dispatcher_batch_size: u64,
     pub dispatcher_concurrency_maintenance_interval: Duration,
+    pub(crate) has_explicit_dispatcher_polling: bool,
+    pub(crate) has_explicit_dispatcher_batch_size: bool,
+    pub(crate) has_explicit_dispatcher_maintenance: bool,
     /// Whether the dispatcher runs concurrency maintenance (expiring stale
     /// semaphores + unblocking blocked jobs) each polling cycle. Default true.
     pub dispatcher_concurrency_maintenance: bool,
@@ -1075,6 +1078,9 @@ impl AppContext {
             dispatcher_polling_interval: Duration::from_secs(1), // 1 seconds
             dispatcher_batch_size: 500,
             dispatcher_concurrency_maintenance_interval: Duration::from_secs(600),
+            has_explicit_dispatcher_polling: false,
+            has_explicit_dispatcher_batch_size: false,
+            has_explicit_dispatcher_maintenance: false,
             dispatcher_concurrency_maintenance: true,
             worker_polling_interval: Duration::from_millis(100),
             worker_threads: 3,
@@ -1258,6 +1264,9 @@ impl AppContext {
             dispatcher_batch_size: self.dispatcher_batch_size,
             dispatcher_concurrency_maintenance_interval: self
                 .dispatcher_concurrency_maintenance_interval,
+            has_explicit_dispatcher_polling: self.has_explicit_dispatcher_polling,
+            has_explicit_dispatcher_batch_size: self.has_explicit_dispatcher_batch_size,
+            has_explicit_dispatcher_maintenance: self.has_explicit_dispatcher_maintenance,
             dispatcher_concurrency_maintenance: self.dispatcher_concurrency_maintenance,
             worker_polling_interval: self.worker_polling_interval,
             worker_threads: self.worker_threads,

--- a/src/types.rs
+++ b/src/types.rs
@@ -181,23 +181,21 @@ fn apply_dispatcher_cfg_to(
     dispatcher_cfg: &crate::config::DispatcherConfig,
 ) -> PyResult<()> {
     if let Some(polling_interval) = dispatcher_cfg.polling_interval {
-        if !polling_interval.is_finite() || polling_interval < 0.0 {
-            return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                "dispatcher polling_interval must be finite and >= 0, got {polling_interval}"
-            )));
+        if !ctx.has_explicit_dispatcher_polling {
+            ctx.dispatcher_polling_interval =
+                secs_to_duration("dispatcher polling_interval", polling_interval)?;
         }
-        ctx.dispatcher_polling_interval = Duration::from_secs_f64(polling_interval);
     }
     if let Some(batch_size) = dispatcher_cfg.batch_size {
-        ctx.dispatcher_batch_size = batch_size;
+        if !ctx.has_explicit_dispatcher_batch_size {
+            ctx.dispatcher_batch_size = batch_size;
+        }
     }
     if let Some(interval) = dispatcher_cfg.concurrency_maintenance_interval {
-        if !interval.is_finite() || interval < 0.0 {
-            return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                "dispatcher concurrency_maintenance_interval must be finite and >= 0, got {interval}"
-            )));
+        if !ctx.has_explicit_dispatcher_maintenance {
+            ctx.dispatcher_concurrency_maintenance_interval =
+                secs_to_duration("dispatcher concurrency_maintenance_interval", interval)?;
         }
-        ctx.dispatcher_concurrency_maintenance_interval = Duration::from_secs_f64(interval);
     }
     if let Some(enabled) = dispatcher_cfg.concurrency_maintenance {
         ctx.dispatcher_concurrency_maintenance = enabled;
@@ -755,6 +753,9 @@ impl PyQuebec {
             has_explicit_duration(kwargs, "dispatcher_concurrency_maintenance_interval");
 
         let mut _ctx = AppContext::new(dsn.clone(), db_option, opt.clone(), options);
+        _ctx.has_explicit_dispatcher_polling = has_explicit_dispatcher_polling;
+        _ctx.has_explicit_dispatcher_batch_size = has_explicit_dispatcher_batch_size;
+        _ctx.has_explicit_dispatcher_maintenance = has_explicit_dispatcher_maintenance;
 
         if _ctx.worker_threads == 0 {
             return Err(pyo3::exceptions::PyValueError::new_err(
@@ -1941,7 +1942,8 @@ impl PyQuebec {
     }
 
     /// Apply the Nth dispatcher configuration. Same slot semantics as
-    /// apply_worker_config.
+    /// apply_worker_config; constructor/env overrides remain authoritative for
+    /// polling interval, batch size, and concurrency-maintenance interval.
     fn apply_dispatcher_config(&mut self, py: Python<'_>, slot_index: usize) -> PyResult<()> {
         let env = std::env::var("QUEBEC_ENV").ok();
         let dispatchers_opt = crate::config::QueueConfig::find(env.as_deref())

--- a/src/types.rs
+++ b/src/types.rs
@@ -77,6 +77,31 @@ where
     None
 }
 
+fn config_env_key(key: &str) -> String {
+    format!("QUEBEC_{}", key.to_ascii_uppercase())
+}
+
+fn has_explicit_duration(kwargs: Option<&Bound<'_, PyDict>>, key: &str) -> bool {
+    kwargs
+        .and_then(|values| values.get_item(key).ok().flatten())
+        .is_some_and(|value| parse_py_duration(&value).is_some())
+        || std::env::var(config_env_key(key))
+            .ok()
+            .and_then(|value| parse_duration_f64_env(&value))
+            .is_some()
+}
+
+fn has_explicit_u64(kwargs: Option<&Bound<'_, PyDict>>, key: &str) -> bool {
+    kwargs
+        .and_then(|values| values.get_item(key).ok().flatten())
+        .and_then(|value| value.extract::<u64>().ok())
+        .is_some()
+        || std::env::var(config_env_key(key))
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .is_some()
+}
+
 fn secs_to_duration(field: &str, seconds: f64) -> PyResult<Duration> {
     Duration::try_from_secs_f64(seconds).map_err(|_| {
         pyo3::exceptions::PyValueError::new_err(format!(
@@ -716,61 +741,18 @@ impl PyQuebec {
 
         // Check if worker config was explicitly set via code/env before options is moved
         // Verify the value is actually extractable, not just present
-        let has_explicit_threads = kwargs
-            .and_then(|k| k.get_item("worker_threads").ok().flatten())
-            .and_then(|v| v.extract::<u64>().ok())
-            .is_some()
-            || std::env::var("QUEBEC_WORKER_THREADS")
-                .ok()
-                .and_then(|s| s.parse::<u64>().ok())
-                .is_some();
-        let has_explicit_polling = kwargs
-            .and_then(|k| k.get_item("worker_polling_interval").ok().flatten())
-            .filter(|v| {
-                v.extract::<Duration>().is_ok()
-                    || v.extract::<u64>().is_ok()
-                    || v.extract::<f64>()
-                        .map(|f| f.is_finite() && f >= 0.0)
-                        .unwrap_or(false)
-            })
-            .is_some()
-            || std::env::var("QUEBEC_WORKER_POLLING_INTERVAL")
-                .ok()
-                .and_then(|s| parse_duration_f64_env(&s))
-                .is_some();
+        let has_explicit_threads = has_explicit_u64(kwargs, "worker_threads");
+        let has_explicit_polling = has_explicit_duration(kwargs, "worker_polling_interval");
 
         // Same treatment for dispatcher fields: distinguish "user explicitly
         // set this via code/env" from "still at the default value" so a
         // queue.yml value can't silently override an explicit setting that
         // happens to equal the default.
-        let has_explicit_dispatcher_polling = kwargs
-            .and_then(|k| k.get_item("dispatcher_polling_interval").ok().flatten())
-            .filter(|v| v.extract::<Duration>().is_ok() || v.extract::<u64>().is_ok())
-            .is_some()
-            || std::env::var("QUEBEC_DISPATCHER_POLLING_INTERVAL")
-                .ok()
-                .and_then(|s| parse_duration_f64_env(&s))
-                .is_some();
-        let has_explicit_dispatcher_batch_size = kwargs
-            .and_then(|k| k.get_item("dispatcher_batch_size").ok().flatten())
-            .and_then(|v| v.extract::<u64>().ok())
-            .is_some()
-            || std::env::var("QUEBEC_DISPATCHER_BATCH_SIZE")
-                .ok()
-                .and_then(|s| s.parse::<u64>().ok())
-                .is_some();
-        let has_explicit_dispatcher_maintenance = kwargs
-            .and_then(|k| {
-                k.get_item("dispatcher_concurrency_maintenance_interval")
-                    .ok()
-                    .flatten()
-            })
-            .filter(|v| v.extract::<Duration>().is_ok() || v.extract::<u64>().is_ok())
-            .is_some()
-            || std::env::var("QUEBEC_DISPATCHER_CONCURRENCY_MAINTENANCE_INTERVAL")
-                .ok()
-                .and_then(|s| parse_duration_f64_env(&s))
-                .is_some();
+        let has_explicit_dispatcher_polling =
+            has_explicit_duration(kwargs, "dispatcher_polling_interval");
+        let has_explicit_dispatcher_batch_size = has_explicit_u64(kwargs, "dispatcher_batch_size");
+        let has_explicit_dispatcher_maintenance =
+            has_explicit_duration(kwargs, "dispatcher_concurrency_maintenance_interval");
 
         let mut _ctx = AppContext::new(dsn.clone(), db_option, opt.clone(), options);
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -77,6 +77,14 @@ where
     None
 }
 
+fn secs_to_duration(field: &str, seconds: f64) -> PyResult<Duration> {
+    Duration::try_from_secs_f64(seconds).map_err(|_| {
+        pyo3::exceptions::PyValueError::new_err(format!(
+            "{field} must be finite, >= 0, and within Duration range, got {seconds}"
+        ))
+    })
+}
+
 use crate::control_plane::{ControlPlane, ControlPlaneExt};
 
 use crate::context::*;
@@ -131,12 +139,8 @@ fn apply_worker_cfg_to(
         ctx.worker_threads = threads as u64;
     }
     if let Some(polling_interval) = worker_cfg.polling_interval {
-        if !polling_interval.is_finite() || polling_interval < 0.0 {
-            return Err(pyo3::exceptions::PyValueError::new_err(format!(
-                "worker polling_interval must be finite and >= 0, got {polling_interval}"
-            )));
-        }
-        ctx.worker_polling_interval = Duration::from_secs_f64(polling_interval);
+        ctx.worker_polling_interval =
+            secs_to_duration("worker polling_interval", polling_interval)?;
     }
     if worker_cfg.queues.is_some() {
         ctx.worker_queues = worker_cfg.queues.clone();
@@ -808,13 +812,8 @@ impl PyQuebec {
                     }
                     if let Some(polling_interval) = worker.polling_interval {
                         if !has_explicit_polling {
-                            if !polling_interval.is_finite() || polling_interval < 0.0 {
-                                return Err(pyo3::exceptions::PyValueError::new_err(
-                                    format!("worker_polling_interval must be finite and >= 0 (set via queue.yml workers.polling_interval, got {polling_interval})"),
-                                ));
-                            }
                             _ctx.worker_polling_interval =
-                                Duration::from_secs_f64(polling_interval);
+                                secs_to_duration("worker_polling_interval", polling_interval)?;
                         }
                     }
                     // Apply queue configuration (always apply from config if present, as there's no code parameter for this)
@@ -841,11 +840,7 @@ impl PyQuebec {
                     if let Some(polling_interval) = dispatcher.polling_interval {
                         if !has_explicit_dispatcher_polling {
                             _ctx.dispatcher_polling_interval =
-                                Duration::try_from_secs_f64(polling_interval).map_err(|_| {
-                                    pyo3::exceptions::PyValueError::new_err(format!(
-                                        "dispatcher_polling_interval must be finite, >= 0, and within Duration range (set via queue.yml dispatchers.polling_interval, got {polling_interval})"
-                                    ))
-                                })?;
+                                secs_to_duration("dispatcher_polling_interval", polling_interval)?;
                         }
                     }
                     if let Some(batch_size) = dispatcher.batch_size {
@@ -855,12 +850,10 @@ impl PyQuebec {
                     }
                     if let Some(interval) = dispatcher.concurrency_maintenance_interval {
                         if !has_explicit_dispatcher_maintenance {
-                            _ctx.dispatcher_concurrency_maintenance_interval =
-                                Duration::try_from_secs_f64(interval).map_err(|_| {
-                                    pyo3::exceptions::PyValueError::new_err(format!(
-                                        "dispatcher_concurrency_maintenance_interval must be finite, >= 0, and within Duration range (set via queue.yml dispatchers.concurrency_maintenance_interval, got {interval})"
-                                    ))
-                                })?;
+                            _ctx.dispatcher_concurrency_maintenance_interval = secs_to_duration(
+                                "dispatcher_concurrency_maintenance_interval",
+                                interval,
+                            )?;
                         }
                     }
                     if let Some(enabled) = dispatcher.concurrency_maintenance {
@@ -1818,22 +1811,55 @@ impl PyQuebec {
         self.ctx.proc_slot
     }
 
-    /// Test-only: the effective dispatcher config after code/env/queue.yml
-    /// precedence has been resolved at construction. Underscore-prefixed.
-    #[pyo3(name = "_dispatcher_config")]
-    fn dispatcher_config(&self, py: Python<'_>) -> PyResult<Py<PyDict>> {
+    /// Test-only: constructor configuration after code/env/queue.yml precedence.
+    #[pyo3(name = "_config_snapshot")]
+    fn config_snapshot(&self, py: Python<'_>) -> PyResult<Py<PyDict>> {
         let dict = PyDict::new(py);
-        dict.set_item(
-            "polling_interval",
-            self.ctx.dispatcher_polling_interval.as_secs_f64(),
-        )?;
-        dict.set_item("batch_size", self.ctx.dispatcher_batch_size)?;
-        dict.set_item(
-            "concurrency_maintenance_interval",
-            self.ctx
-                .dispatcher_concurrency_maintenance_interval
-                .as_secs_f64(),
-        )?;
+        for (key, value) in [
+            (
+                "notify_throttle_interval",
+                self.ctx.notify_throttle_interval,
+            ),
+            (
+                "process_heartbeat_interval",
+                self.ctx.process_heartbeat_interval,
+            ),
+            ("process_alive_threshold", self.ctx.process_alive_threshold),
+            ("shutdown_timeout", self.ctx.shutdown_timeout),
+            (
+                "clear_finished_jobs_after",
+                self.ctx.clear_finished_jobs_after,
+            ),
+            ("cleanup_interval", self.ctx.cleanup_interval),
+            (
+                "default_concurrency_control_period",
+                self.ctx.default_concurrency_control_period,
+            ),
+            (
+                "dispatcher_polling_interval",
+                self.ctx.dispatcher_polling_interval,
+            ),
+            (
+                "dispatcher_concurrency_maintenance_interval",
+                self.ctx.dispatcher_concurrency_maintenance_interval,
+            ),
+            (
+                "control_plane_sse_interval",
+                self.ctx.control_plane_sse_interval,
+            ),
+            ("worker_polling_interval", self.ctx.worker_polling_interval),
+            (
+                "worker_memory_check_interval",
+                self.ctx.worker_memory_check_interval,
+            ),
+            (
+                "worker_memory_graceful_timeout",
+                self.ctx.worker_memory_graceful_timeout,
+            ),
+        ] {
+            dict.set_item(key, value.as_secs_f64())?;
+        }
+        dict.set_item("dispatcher_batch_size", self.ctx.dispatcher_batch_size)?;
         Ok(dict.into())
     }
 

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -14,6 +14,17 @@ import pytest
 import quebec
 
 
+@pytest.fixture(autouse=True)
+def _clear_interval_overrides(monkeypatch) -> None:
+    for key in (
+        "QUEBEC_WORKER_POLLING_INTERVAL",
+        "QUEBEC_DISPATCHER_POLLING_INTERVAL",
+        "QUEBEC_DISPATCHER_BATCH_SIZE",
+        "QUEBEC_DISPATCHER_CONCURRENCY_MAINTENANCE_INTERVAL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
 def _queue_yml(tmp_path, body: str) -> str:
     path = tmp_path / "queue.yml"
     path.write_text(body)
@@ -83,6 +94,26 @@ development:
         quebec.Quebec(db_url, table_name_prefix=test_prefix)
 
 
+def test_worker_polling_interval_overflow_raises(
+    tmp_path, monkeypatch, db_url, test_prefix
+) -> None:
+    monkeypatch.setenv(
+        "QUEBEC_CONFIG",
+        _queue_yml(
+            tmp_path,
+            """
+development:
+  workers:
+    - polling_interval: 1.0e30
+""",
+        ),
+    )
+    monkeypatch.delenv("QUEBEC_ENV", raising=False)
+
+    with pytest.raises(ValueError, match="worker_polling_interval must be finite"):
+        quebec.Quebec(db_url, table_name_prefix=test_prefix)
+
+
 def test_dispatcher_polling_interval_valid_ok(
     tmp_path, monkeypatch, db_url, test_prefix
 ) -> None:
@@ -135,10 +166,10 @@ development:
         dispatcher_concurrency_maintenance_interval=timedelta(seconds=600),
     )
     try:
-        cfg = inst._dispatcher_config()
-        assert cfg["polling_interval"] == 1.0
-        assert cfg["batch_size"] == 500
-        assert cfg["concurrency_maintenance_interval"] == 600.0
+        cfg = inst._config_snapshot()
+        assert cfg["dispatcher_polling_interval"] == 1.0
+        assert cfg["dispatcher_batch_size"] == 500
+        assert cfg["dispatcher_concurrency_maintenance_interval"] == 600.0
     finally:
         inst.close()
 
@@ -163,8 +194,8 @@ development:
 
     inst = quebec.Quebec(db_url, table_name_prefix=test_prefix)
     try:
-        cfg = inst._dispatcher_config()
-        assert cfg["polling_interval"] == 5.0
-        assert cfg["batch_size"] == 100
+        cfg = inst._config_snapshot()
+        assert cfg["dispatcher_polling_interval"] == 5.0
+        assert cfg["dispatcher_batch_size"] == 100
     finally:
         inst.close()

--- a/tests/test_duration_config.py
+++ b/tests/test_duration_config.py
@@ -1,0 +1,80 @@
+"""Duration constructor options share one safe Python conversion path."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+import quebec
+
+
+FLOAT_DURATION_OPTIONS = {
+    "notify_throttle_interval": 0.125,
+    "process_heartbeat_interval": 1.25,
+    "process_alive_threshold": 2.25,
+    "shutdown_timeout": 3.25,
+    "clear_finished_jobs_after": 4.25,
+    "cleanup_interval": 5.25,
+    "default_concurrency_control_period": 6.25,
+    "dispatcher_polling_interval": 7.25,
+    "dispatcher_concurrency_maintenance_interval": 8.25,
+    "control_plane_sse_interval": 9.25,
+    "worker_polling_interval": 0.05,
+    "worker_memory_check_interval": 10.25,
+    "worker_memory_graceful_timeout": 11.25,
+}
+
+
+def test_all_duration_kwargs_accept_float_seconds(
+    tmp_path, monkeypatch, db_url, test_prefix
+) -> None:
+    monkeypatch.setenv("QUEBEC_CONFIG", str(tmp_path / "missing.yml"))
+
+    inst = quebec.Quebec(
+        db_url,
+        table_name_prefix=test_prefix,
+        **FLOAT_DURATION_OPTIONS,
+    )
+    try:
+        snapshot = inst._config_snapshot()
+        assert {key: snapshot[key] for key in FLOAT_DURATION_OPTIONS} == pytest.approx(
+            FLOAT_DURATION_OPTIONS
+        )
+    finally:
+        inst.close()
+
+
+@pytest.mark.parametrize("invalid", [-1.0, math.nan, math.inf, 1.0e300])
+def test_invalid_float_duration_falls_back_without_panicking(
+    invalid, tmp_path, monkeypatch, db_url, test_prefix
+) -> None:
+    monkeypatch.setenv("QUEBEC_CONFIG", str(tmp_path / "missing.yml"))
+    monkeypatch.delenv("QUEBEC_SHUTDOWN_TIMEOUT", raising=False)
+
+    inst = quebec.Quebec(
+        db_url,
+        table_name_prefix=test_prefix,
+        shutdown_timeout=invalid,
+    )
+    try:
+        assert inst._config_snapshot()["shutdown_timeout"] == 5.0
+    finally:
+        inst.close()
+
+
+def test_invalid_worker_polling_kwarg_does_not_fall_back_to_env(
+    tmp_path, monkeypatch, db_url, test_prefix
+) -> None:
+    monkeypatch.setenv("QUEBEC_CONFIG", str(tmp_path / "missing.yml"))
+    monkeypatch.setenv("QUEBEC_WORKER_POLLING_INTERVAL", "30")
+
+    inst = quebec.Quebec(
+        db_url,
+        table_name_prefix=test_prefix,
+        worker_polling_interval=math.nan,
+    )
+    try:
+        assert inst._config_snapshot()["worker_polling_interval"] == 0.1
+    finally:
+        inst.close()

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -287,6 +287,24 @@ class TestApplyConfig:
         qc.apply_dispatcher_config(1)
         assert qc._proc_slot() == (0, 1)
 
+    def test_apply_worker_config_rejects_duration_overflow(
+        self, qc, monkeypatch, tmp_path
+    ):
+        queue_yml = tmp_path / "queue.yml"
+        queue_yml.write_text(
+            """
+development:
+  workers:
+    - polling_interval: 0.1
+    - polling_interval: 1.0e30
+"""
+        )
+        monkeypatch.setenv("QUEBEC_CONFIG", str(queue_yml))
+        monkeypatch.delenv("QUEBEC_ENV", raising=False)
+
+        with pytest.raises(ValueError, match="within Duration range"):
+            qc.apply_worker_config(1)
+
 
 class TestSupervisorPlanFromConfig:
     def test_returns_dict_or_none(self, qc):

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -17,6 +17,7 @@ import socket
 import pytest
 from sqlalchemy import text
 
+import quebec
 from quebec.supervisor import (
     RECYCLE_EXIT_CODE,
     ROLE_WORKER,
@@ -242,6 +243,17 @@ class TestSupervisorExitStatus:
 
 
 class TestApplyConfig:
+    @pytest.fixture(autouse=True)
+    def _clear_explicit_config_env(self, monkeypatch):
+        for key in (
+            "QUEBEC_WORKER_THREADS",
+            "QUEBEC_WORKER_POLLING_INTERVAL",
+            "QUEBEC_DISPATCHER_POLLING_INTERVAL",
+            "QUEBEC_DISPATCHER_BATCH_SIZE",
+            "QUEBEC_DISPATCHER_CONCURRENCY_MAINTENANCE_INTERVAL",
+        ):
+            monkeypatch.delenv(key, raising=False)
+
     def test_apply_worker_config_out_of_range_raises(self, qc):
         # No queue.yml loaded in this test context; out-of-range should raise
         # IndexError (or be a no-op if config missing). We can't guarantee
@@ -304,6 +316,56 @@ development:
 
         with pytest.raises(ValueError, match="within Duration range"):
             qc.apply_worker_config(1)
+
+    def test_apply_dispatcher_config_rejects_duration_overflow(
+        self, qc, monkeypatch, tmp_path
+    ):
+        queue_yml = tmp_path / "queue.yml"
+        queue_yml.write_text(
+            """
+development:
+  dispatchers:
+    - polling_interval: 1.0
+    - concurrency_maintenance_interval: 1.0e30
+"""
+        )
+        monkeypatch.setenv("QUEBEC_CONFIG", str(queue_yml))
+        monkeypatch.delenv("QUEBEC_ENV", raising=False)
+
+        with pytest.raises(ValueError, match="within Duration range"):
+            qc.apply_dispatcher_config(1)
+
+    def test_apply_dispatcher_config_preserves_explicit_constructor_values(
+        self, monkeypatch, tmp_path, db_url, test_prefix
+    ):
+        queue_yml = tmp_path / "queue.yml"
+        queue_yml.write_text(
+            """
+development:
+  dispatchers:
+    - polling_interval: 5.0
+      batch_size: 100
+      concurrency_maintenance_interval: 50.0
+"""
+        )
+        monkeypatch.setenv("QUEBEC_CONFIG", str(queue_yml))
+        monkeypatch.delenv("QUEBEC_ENV", raising=False)
+
+        inst = quebec.Quebec(
+            db_url,
+            table_name_prefix=test_prefix,
+            dispatcher_polling_interval=2.0,
+            dispatcher_batch_size=200,
+            dispatcher_concurrency_maintenance_interval=20.0,
+        )
+        try:
+            inst.apply_dispatcher_config(0)
+            snapshot = inst._config_snapshot()
+            assert snapshot["dispatcher_polling_interval"] == 2.0
+            assert snapshot["dispatcher_batch_size"] == 200
+            assert snapshot["dispatcher_concurrency_maintenance_interval"] == 20.0
+        finally:
+            inst.close()
 
 
 class TestSupervisorPlanFromConfig:


### PR DESCRIPTION
## Summary

- Accept `datetime.timedelta`, `int`, and `float` seconds uniformly for all duration constructor kwargs via a shared `parse_py_duration` path; invalid values warn with the offending value instead of the Python type. `worker_polling_interval` keeps its historical precedence: an invalid kwarg is ignored without falling back to a lower-priority environment value.
- Replace the six inline `Duration::try_from_secs_f64` validation blocks with a `secs_to_duration` helper (fixes a potential panic in `apply_worker_config`/`apply_dispatcher_config` on overflowing yaml values, which previously bypassed `try_from`).
- Honor explicit dispatcher config (`polling_interval`, `batch_size`, `concurrency_maintenance_interval`) over queue.yml even when the explicit value equals the default, and carry that through to supervisor children: `apply_dispatcher_config` no longer re-applies queue.yml over constructor/env overrides.
- Deduplicate explicit-override detection into `has_explicit_duration`/`has_explicit_u64` with derived env keys; float kwargs now count as explicit, aligning detection with parsing.
- Replace the test-only `_dispatcher_config` accessor with a single `_config_snapshot` covering all duration options.

## Test plan

- `uv run pytest tests/test_config_validation.py tests/test_duration_config.py tests/test_supervisor.py` (new coverage: uniform float/timedelta acceptance, invalid-kwarg fallback, no env fallback for invalid `worker_polling_interval`, yaml overflow rejection, supervisor children preserving explicit dispatcher config)
- `cargo clippy --all-targets --all-features`, `cargo fmt --check`