### PR TITLE
refactor: pin forced queue into worker_queues at config time

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -655,16 +655,16 @@ pub struct RunnableDefaults {
 }
 
 impl AppContext {
-    /// Queue selector the worker actually claims from. When
-    /// `force_override_queue` is active it wins unconditionally over any
-    /// `worker_queues` config: every enqueue is rewritten to that queue, so
-    /// consuming anything else would break the branch isolation the override
-    /// exists for.
-    pub fn effective_worker_queues(&self) -> Option<crate::config::QueueSelector> {
-        self.force_override_queue
-            .as_ref()
-            .map(|q| crate::config::QueueSelector::Single(q.clone()))
-            .or_else(|| self.worker_queues.clone())
+    /// Resolve the final worker selector after configuration has been applied.
+    ///
+    /// Caching the forced queue in `worker_queues` keeps the claim and NOTIFY
+    /// hot paths identical to the normal configuration path: they do not need
+    /// to check `force_override_queue` on every invocation. Call this whenever
+    /// a worker configuration is applied, including in supervisor children.
+    pub(crate) fn pin_worker_queue_to_override(&mut self) {
+        if let Some(queue) = self.force_override_queue.as_ref() {
+            self.worker_queues = Some(crate::config::QueueSelector::Single(queue.clone()));
+        }
     }
 
     /// Record `id` in the claim ledger with the given state. Poison-recovering;
@@ -1020,7 +1020,8 @@ impl AppContext {
         db: Option<Arc<DatabaseConnection>>,
         connect_options: ConnectOptions,
     ) -> Self {
-        let ctx = Self::new_inner(dsn, db, connect_options);
+        let mut ctx = Self::new_inner(dsn, db, connect_options);
+        ctx.pin_worker_queue_to_override();
         crate::set_silence_polling(ctx.silence_polling);
         ctx
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -141,6 +141,7 @@ fn apply_worker_cfg_to(
     if worker_cfg.queues.is_some() {
         ctx.worker_queues = worker_cfg.queues.clone();
     }
+    ctx.pin_worker_queue_to_override();
     Ok(())
 }
 
@@ -821,15 +822,6 @@ impl PyQuebec {
                     if worker.queues.is_some() {
                         _ctx.worker_queues = worker.queues.clone();
                     }
-                    // Log the effective selector so the override's consumption
-                    // pin is visible — raw worker_queues would claim "all
-                    // queues" while the worker actually only drains the
-                    // forced queue.
-                    if let Some(queues) = _ctx.effective_worker_queues() {
-                        info!("Worker queues configured: {:?}", queues.to_list());
-                    } else {
-                        info!("Worker queues: None (will process all queues)");
-                    }
                 }
             }
 
@@ -870,7 +862,16 @@ impl PyQuebec {
             }
         }
 
-        // All parameters have been processed in AppContext.new
+        // All parameters and queue.yml values have been processed. Resolve the
+        // forced queue once here so claim and NOTIFY hot paths only read the
+        // final worker selector.
+        _ctx.pin_worker_queue_to_override();
+        if let Some(ref queues) = _ctx.worker_queues {
+            info!("Worker queues configured: {:?}", queues.to_list());
+        } else {
+            info!("Worker queues: None (will process all queues)");
+        }
+
         let ctx = Arc::new(_ctx);
         if let Some(override_q) = ctx.force_override_queue.as_deref() {
             warn!(

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -2739,7 +2739,7 @@ impl Worker {
     pub async fn claim_job(&self) -> Result<quebec_claimed_executions::Model> {
         let db = self.ctx.get_db().await?;
         let table_config = self.ctx.table_config.clone();
-        let queue_selector = self.ctx.effective_worker_queues();
+        let queue_selector = self.ctx.worker_queues.clone();
         let use_skip_locked = self.ctx.use_skip_locked;
         let process_id = *self.process_id.lock().await;
         // EXPERIMENTAL: queue-level concurrency overrides — acquired here at
@@ -2913,7 +2913,7 @@ impl Worker {
         let db = self.ctx.get_db().await?;
         let use_skip_locked = self.ctx.use_skip_locked;
         let table_config = self.ctx.table_config.clone();
-        let queue_selector = self.ctx.effective_worker_queues();
+        let queue_selector = self.ctx.worker_queues.clone();
         let process_id = *self.process_id.lock().await;
         // EXPERIMENTAL: shared `ctx` for per-record queue-level acquire below.
         let ctx = self.ctx.clone();
@@ -3289,12 +3289,6 @@ impl Worker {
         };
 
         trace!("Received NOTIFY for queue: {}", queue_name);
-
-        // Hot path (once per NOTIFY): check the override by reference instead
-        // of cloning the effective selector for every message.
-        if let Some(forced) = self.ctx.force_override_queue.as_deref() {
-            return queue_name == forced;
-        }
 
         let Some(ref queues) = self.ctx.worker_queues else {
             return true; // No queue config, process all queues

--- a/tests/test_force_override_queue.py
+++ b/tests/test_force_override_queue.py
@@ -90,3 +90,31 @@ def test_worker_only_consumes_forced_queue(temp_db_path, test_prefix) -> None:
 
     pinned.close()
     plain.close()
+
+
+def test_worker_batch_only_consumes_forced_queue(temp_db_path, test_prefix) -> None:
+    dsn = f"sqlite:///{temp_db_path}?mode=rwc"
+
+    plain = quebec.Quebec(dsn, table_name_prefix=test_prefix)
+    assert plain.create_tables() is True
+    plain.register_job(OverrideJob)
+    OverrideJob.set(queue="other_branch").perform_later(plain)
+
+    pinned = quebec.Quebec(
+        dsn, table_name_prefix=test_prefix, force_override_queue="pinned"
+    )
+    pinned.register_job(OverrideJob)
+    OverrideJob.perform_later(pinned)
+
+    executions = pinned.drain_batch(10)
+    assert [execution.queue for execution in executions] == ["pinned"]
+    executions[0].perform()
+
+    assert pinned.drain_batch(10) == []
+
+    execution = plain.drain_one()
+    assert execution.queue == "other_branch"
+    execution.perform()
+
+    pinned.close()
+    plain.close()


### PR DESCRIPTION
## Summary

Replaces the per-call `effective_worker_queues()` helper with `pin_worker_queue_to_override()`, which resolves `force_override_queue` into `worker_queues` once when configuration is applied. The claim (`claim_job` / `claim_jobs`) and NOTIFY-filter hot paths now read the final selector directly instead of recomputing or special-casing the override on every invocation.

Pin call sites cover all `worker_queues` write paths:
- `AppContext::new` (after `new_inner` defaults)
- `apply_worker_config` (supervisor children)
- queue.yml processing in the `PyQuebec` constructor (after all config is applied)
- `fork_clone` inherits the already-pinned value

## Testing

- `cargo clippy --all-targets --all-features` clean
- `uv run pytest tests/test_force_override_queue.py -v` — 4 passed, including the new `test_worker_batch_only_consumes_forced_queue` covering the batch claim path