### PR TITLE
feat: report quiet mode in systemd STATUS line

### DIFF
--- a/python/quebec/__init__.py
+++ b/python/quebec/__init__.py
@@ -420,7 +420,8 @@ def _systemd_status_line(qc, components):
     if "scheduler" in components:
         segs.append("scheduler")
     body = ", ".join(segs) if segs else "running"
-    return f"Quebec {__version__}: {body}; running"
+    state = "quiet" if qc.is_quiet else "running"
+    return f"Quebec {__version__}: {body}; {state}"
 
 
 def _quebec_start(

--- a/python/quebec/supervisor.py
+++ b/python/quebec/supervisor.py
@@ -139,6 +139,7 @@ class Supervisor:
         self._slots: Dict[Tuple[str, int], _SlotState] = {}
         self._stopping = False
         self._immediate = False
+        self._quiet = False
         self._hostname = socket.gethostname()
         self._wakeup_r, self._wakeup_w = os.pipe()
         os.set_blocking(self._wakeup_r, False)
@@ -244,6 +245,7 @@ class Supervisor:
         # cascade the signal to every worker child. Dispatcher/scheduler are
         # unaffected (they don't own in-flight job execution).
         def quiet(signum, _frame):
+            self._quiet = True
             logger.info(
                 "Supervisor received signal %d, forwarding quiet (SIGUSR1) "
                 "to worker children",
@@ -416,7 +418,12 @@ class Supervisor:
             if expected:
                 segs.append(f"{role}s {counts.get(role, 0)}/{expected}")
         body = ", ".join(segs) if segs else "starting"
-        state = "stopping" if self._stopping else "running"
+        if self._stopping:
+            state = "stopping"
+        elif self._quiet:
+            state = "quiet"
+        else:
+            state = "running"
         return f"Quebec {__version__}: supervisor; {body}; {state}"
 
     def _supervise(self) -> None:

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -504,6 +504,17 @@ class TestSupervisorClassValidation:
         Supervisor(qc, {"worker": [None, None, None]})
 
 
+class TestSupervisorStatusText:
+    def test_status_text_reports_quiet(self, qc):
+        """The systemd STATUS line reflects quiet mode; stopping wins over it."""
+        sup = Supervisor(qc, {ROLE_WORKER: 1})
+        assert sup._status_text().endswith("; running")
+        sup._quiet = True
+        assert sup._status_text().endswith("; quiet")
+        sup._stopping = True
+        assert sup._status_text().endswith("; stopping")
+
+
 class TestSupervisorStopDuringStartup:
     """A shutdown signal arriving mid-startup must halt forking.
 

--- a/tests/test_systemd.py
+++ b/tests/test_systemd.py
@@ -98,3 +98,13 @@ def test_single_process_status_reports_worker_idle(qc):
     assert "dispatcher" in line
     assert "scheduler" in line
     assert line.startswith("Quebec ")
+
+
+def test_single_process_status_reports_quiet(qc):
+    """After entering quiet mode (SIGUSR1/SIGTSTP or qc.quiet()) the STATUS
+    line ends in "; quiet" so `systemctl status` shows the drain state."""
+    from quebec import _systemd_status_line
+
+    assert _systemd_status_line(qc, ["worker"]).endswith("; running")
+    qc.quiet()
+    assert _systemd_status_line(qc, ["worker"]).endswith("; quiet")


### PR DESCRIPTION
## Summary

The systemd `STATUS=` line previously hardcoded `running` and gave no indication that a process had entered quiet mode (SIGUSR1/SIGTSTP), so `systemctl status` could not distinguish an idle worker from one draining for a seamless restart.

- **Single-process**: `_systemd_status_line` now reads the existing `is_quiet` getter, e.g. `Quebec 0.3.11: worker 10 threads, 7 idle; quiet`. Memory-recycle drains share the same quiet token, so they are reported as `quiet` too.
- **Supervisor**: the quiet signal handler records `self._quiet` before forwarding SIGUSR1 to worker children; `_status_text` reports `stopping` > `quiet` > `running`.

Known pre-existing edge case (unchanged): a worker re-forked after quiet does not inherit quiet mode, while the supervisor STATUS keeps showing `quiet`.

## Test plan

- New: `test_single_process_status_reports_quiet`, `TestSupervisorStatusText::test_status_text_reports_quiet` (state precedence)
- Full suite: 293 passed